### PR TITLE
Drop Legacy Plaintext Audit Columns

### DIFF
--- a/apps/api/src/dao/ApplicationContextDAO.ts
+++ b/apps/api/src/dao/ApplicationContextDAO.ts
@@ -47,8 +47,7 @@ class ApplicationContextDAO {
             UPDATE application_context_documents
             SET user_email = ?, source_provider_id = ?, source_thread_id = ?, vector_namespace = ?,
                 source_document_fingerprint = ?, source_thread_fingerprint = ?, title_fingerprint = ?, sender_fingerprint = ?,
-                content_fingerprint = ?, indexed_text_chars = ?, title = NULL, sender = NULL, indexed_text = NULL,
-                status = ?, deleted_at = NULL, last_error = NULL, updated_at = ?
+                content_fingerprint = ?, indexed_text_chars = ?, status = ?, deleted_at = NULL, last_error = NULL, updated_at = ?
             WHERE context_document_id = ?
           `,
         )
@@ -84,8 +83,8 @@ class ApplicationContextDAO {
           INSERT INTO application_context_documents
             (context_document_id, application_id, user_email, source_type, source_provider_id, source_document_id, source_thread_id,
              vector_namespace, vector_id, source_document_fingerprint, source_thread_fingerprint, title_fingerprint, sender_fingerprint,
-             content_fingerprint, indexed_text_chars, title, sender, indexed_text, status, indexed_at, deleted_at, last_error, created_at, updated_at)
-          VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, NULL, NULL, NULL, ?, NULL, NULL, NULL, ?, ?)
+             content_fingerprint, indexed_text_chars, status, indexed_at, deleted_at, last_error, created_at, updated_at)
+          VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, NULL, NULL, NULL, ?, ?)
         `,
       )
       .bind(
@@ -376,7 +375,7 @@ class ApplicationContextDAO {
         .prepare(
           `
             UPDATE application_context_documents
-            SET status = ?, title = NULL, sender = NULL, indexed_text = NULL, deleted_at = ?, updated_at = ?
+            SET status = ?, deleted_at = ?, updated_at = ?
             WHERE application_id = ? AND user_email = ? AND vector_id IN (${placeholders})
           `,
         )

--- a/apps/api/src/dao/ProcessedMessageDAO.ts
+++ b/apps/api/src/dao/ProcessedMessageDAO.ts
@@ -28,8 +28,8 @@ class ProcessedMessageDAO {
       .prepare(
         `
           INSERT OR IGNORE INTO processed_messages
-            (processed_message_id, application_id, provider_id, provider_message_id, provider_thread_id, subject, status, summary_sent_at, error_message, created_at, updated_at)
-          VALUES (?, ?, ?, ?, ?, NULL, ?, NULL, NULL, ?, ?)
+            (processed_message_id, application_id, provider_id, provider_message_id, provider_thread_id, status, summary_sent_at, error_message, created_at, updated_at)
+          VALUES (?, ?, ?, ?, ?, ?, NULL, NULL, ?, ?)
         `,
       )
       .bind(

--- a/migrations/0004_drop_plaintext_audit_columns.sql
+++ b/migrations/0004_drop_plaintext_audit_columns.sql
@@ -1,0 +1,11 @@
+ALTER TABLE application_context_documents
+DROP COLUMN title;
+
+ALTER TABLE application_context_documents
+DROP COLUMN sender;
+
+ALTER TABLE application_context_documents
+DROP COLUMN indexed_text;
+
+ALTER TABLE processed_messages
+DROP COLUMN subject;


### PR DESCRIPTION
## Summary

- Add migration 0004 to remove the legacy D1 plaintext columns after the completed scrub migration.
- Stop referencing the removed columns from context-document and processed-message DAO writes.

## Implementation

- Drop application_context_documents.title, application_context_documents.sender, application_context_documents.indexed_text, and processed_messages.subject.
- Keep the audit-safe fingerprint and indexed-text-length columns introduced by migration 0003.
- Leave historical migrations intact so already-applied environments keep a linear migration history.

## Verification

- source ~/.customrc && volta run pnpm run typecheck
- source ~/.customrc && volta run pnpm run test
- source ~/.customrc && volta run pnpm run lint
- source ~/.customrc && volta run pnpm run build
- git diff --check