### PR TITLE
Potential fix for code scanning alert no. 1: Double escaping or unescaping

### DIFF
--- a/apps/api/src/utils/EmailContentUtil.ts
+++ b/apps/api/src/utils/EmailContentUtil.ts
@@ -37,11 +37,11 @@ class EmailContentUtil {
       .replace(/<\/p>/gi, '\n')
       .replace(/<[^>]+>/g, ' ')
       .replace(/&nbsp;/g, ' ')
-      .replace(/&amp;/g, '&')
       .replace(/&lt;/g, '<')
       .replace(/&gt;/g, '>')
       .replace(/&quot;/g, '"')
-      .replace(/&#39;/g, "'");
+      .replace(/&#39;/g, "'")
+      .replace(/&amp;/g, '&');
   }
 
   public static normalizeText(value: string): string {


### PR DESCRIPTION
Potential fix for [https://github.com/Rexezuge-CloudflareWorkers/Mail-Otter/security/code-scanning/1](https://github.com/Rexezuge-CloudflareWorkers/Mail-Otter/security/code-scanning/1)

General fix: when manually decoding HTML entities, decode `&amp;` **last**, after other entities. This prevents newly-created `&...;` sequences from being decoded again in the same pass.

Best targeted fix here (without changing intended functionality): reorder the replacements inside `stripHtml` in `apps/api/src/utils/EmailContentUtil.ts` so that:
- `&nbsp;`, `&lt;`, `&gt;`, `&quot;`, `&#39;` are decoded first
- `&amp;` is decoded last

Only the replacement order in that method needs to change; no new imports, methods, or dependencies are required.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
