### PR TITLE
Classify Email Workflow Retry Errors

### DIFF
--- a/apps/api/src/dao/ProcessedMessageDAO.ts
+++ b/apps/api/src/dao/ProcessedMessageDAO.ts
@@ -21,6 +21,7 @@ class ProcessedMessageDAO {
     providerId: ProviderId,
     providerMessageId: string,
     providerThreadId?: string | null,
+    options: TryStartProcessedMessageOptions = {},
   ): Promise<boolean> {
     const now: number = TimestampUtil.getCurrentUnixTimestampInSeconds();
     const processedMessageId: string = UUIDUtil.getRandomUUID();
@@ -46,7 +47,12 @@ class ProcessedMessageDAO {
     if (!result.success) {
       throw new DatabaseError(`Failed to create processed message row: ${result.error}`);
     }
-    return ((result.meta as { changes?: number } | undefined)?.changes ?? 0) > 0;
+    const inserted: boolean = ((result.meta as { changes?: number } | undefined)?.changes ?? 0) > 0;
+    if (inserted || !options.allowExistingForRetry) {
+      return inserted;
+    }
+    const status: ProcessedMessageStatus | undefined = await this.getStatus(applicationId, providerMessageId);
+    return status === PROCESSED_MESSAGE_STATUS_PROCESSING || status === PROCESSED_MESSAGE_STATUS_ERROR;
   }
 
   public async markSummarized(applicationId: string, providerMessageId: string): Promise<void> {
@@ -100,6 +106,21 @@ class ProcessedMessageDAO {
     }
   }
 
+  private async getStatus(applicationId: string, providerMessageId: string): Promise<ProcessedMessageStatus | undefined> {
+    const row: { status: ProcessedMessageStatus } | null = await this.database
+      .prepare(
+        `
+          SELECT status
+          FROM processed_messages
+          WHERE application_id = ? AND provider_message_id = ?
+          LIMIT 1
+        `,
+      )
+      .bind(applicationId, providerMessageId)
+      .first<{ status: ProcessedMessageStatus }>();
+    return row?.status;
+  }
+
   private toProcessedMessage(row: ProcessedMessageInternal): ProcessedMessage {
     return {
       processedMessageId: row.processed_message_id,
@@ -114,6 +135,10 @@ class ProcessedMessageDAO {
       updatedAt: row.updated_at,
     };
   }
+}
+
+interface TryStartProcessedMessageOptions {
+  allowExistingForRetry?: boolean | undefined;
 }
 
 export { ProcessedMessageDAO };

--- a/apps/api/src/error/EmailProcessingError.ts
+++ b/apps/api/src/error/EmailProcessingError.ts
@@ -1,0 +1,20 @@
+import { NonRetryableError } from './NonRetryableError';
+import { RetryableError } from './RetryableError';
+
+class AiSummaryRetryableError extends RetryableError {}
+
+class ProviderApiRetryableError extends RetryableError {}
+
+class ProviderApiNonRetryableError extends NonRetryableError {}
+
+class OAuth2TokenRetryableError extends RetryableError {}
+
+class OAuth2TokenNonRetryableError extends NonRetryableError {}
+
+export {
+  AiSummaryRetryableError,
+  OAuth2TokenNonRetryableError,
+  OAuth2TokenRetryableError,
+  ProviderApiNonRetryableError,
+  ProviderApiRetryableError,
+};

--- a/apps/api/src/error/NonRetryableError.ts
+++ b/apps/api/src/error/NonRetryableError.ts
@@ -1,0 +1,10 @@
+class NonRetryableError extends Error {
+  public readonly retryable = false;
+
+  constructor(message: string) {
+    super(message);
+    this.name = new.target.name;
+  }
+}
+
+export { NonRetryableError };

--- a/apps/api/src/error/RetryableError.ts
+++ b/apps/api/src/error/RetryableError.ts
@@ -1,0 +1,10 @@
+class RetryableError extends Error {
+  public readonly retryable = true;
+
+  constructor(message: string) {
+    super(message);
+    this.name = new.target.name;
+  }
+}
+
+export { RetryableError };

--- a/apps/api/src/error/index.ts
+++ b/apps/api/src/error/index.ts
@@ -1,8 +1,17 @@
 export { IServiceError } from './IServiceError';
 export { BadRequestError } from './BadRequestError';
 export { DatabaseError } from './DatabaseError';
+export {
+  AiSummaryRetryableError,
+  OAuth2TokenNonRetryableError,
+  OAuth2TokenRetryableError,
+  ProviderApiNonRetryableError,
+  ProviderApiRetryableError,
+} from './EmailProcessingError';
 export { ForbiddenError } from './ForbiddenError';
 export { InternalServerError, DefaultInternalServerError } from './InternalServerError';
 export { MethodNotAllowedError } from './MethodNotAllowedError';
+export { NonRetryableError } from './NonRetryableError';
+export { RetryableError } from './RetryableError';
 export { UnauthorizedError } from './UnauthorizedError';
 export type { ErrorResponse } from './model/ErrorResponse';

--- a/apps/api/src/utils/EmailProcessingUtil.ts
+++ b/apps/api/src/utils/EmailProcessingUtil.ts
@@ -1,7 +1,7 @@
 import { PROVIDER_SUBSCRIPTION_STATUS_ACTIVE } from '@mail-otter/shared/constants';
 import { ConnectedApplicationDAO, ProcessedMessageDAO, ProviderSubscriptionDAO } from '@/dao';
 import type { ConnectedApplication, EmailQueueMessage, ProviderSubscription } from '@mail-otter/shared/model';
-import { BadRequestError } from '@/error';
+import { BadRequestError, NonRetryableError, RetryableError } from '@/error';
 import {
   ConfigurationManager,
   EmailContentUtil,
@@ -15,15 +15,19 @@ import type { GmailMessage } from './GmailProviderUtil';
 import type { OutlookMessage } from './OutlookProviderUtil';
 
 class EmailProcessingUtil {
-  public static async processQueueMessage(message: EmailQueueMessage, env: EmailProcessingEnv): Promise<void> {
+  public static async processQueueMessage(
+    message: EmailQueueMessage,
+    env: EmailProcessingEnv,
+    options: EmailProcessingOptions = {},
+  ): Promise<void> {
     const masterKey: string = await env.AES_ENCRYPTION_KEY_SECRET.get();
     const applicationDAO = new ConnectedApplicationDAO(env.DB, masterKey);
     const application: ConnectedApplication | undefined = await applicationDAO.getById(message.applicationId);
     if (!application) {
-      throw new BadRequestError('Connected application was not found for queued email event.');
+      throw new NonRetryableError('Connected application was not found for queued email event.');
     }
     if (!application.providerEmail) {
-      throw new BadRequestError('Connected application does not have a provider mailbox address.');
+      throw new NonRetryableError('Connected application does not have a provider mailbox address.');
     }
 
     const accessToken: string = await OAuth2AccessTokenService.getAccessToken(application.applicationId, env);
@@ -35,10 +39,11 @@ class EmailProcessingUtil {
         message.notificationHistoryId,
         env,
         enabledApplicationIds,
+        options,
       );
       return;
     }
-    await EmailProcessingUtil.processOutlookMessage(application, accessToken, message.messageId, env, enabledApplicationIds);
+    await EmailProcessingUtil.processOutlookMessage(application, accessToken, message.messageId, env, enabledApplicationIds, options);
   }
 
   private static async processGmailNotification(
@@ -47,6 +52,7 @@ class EmailProcessingUtil {
     notificationHistoryId: string,
     env: EmailProcessingEnv,
     enabledApplicationIds: string[],
+    options: EmailProcessingOptions,
   ): Promise<void> {
     const subscriptionDAO = new ProviderSubscriptionDAO(env.DB);
     const subscription: ProviderSubscription | undefined = await subscriptionDAO.getByApplication(application.applicationId);
@@ -54,7 +60,7 @@ class EmailProcessingUtil {
     const startHistoryId: string | undefined = subscription.gmailHistoryId || notificationHistoryId;
     const history = await GmailProviderUtil.listMessageIdsSince(accessToken, startHistoryId);
     for (const messageId of history.messageIds) {
-      await EmailProcessingUtil.processGmailMessage(application, accessToken, messageId, env, enabledApplicationIds);
+      await EmailProcessingUtil.processGmailMessage(application, accessToken, messageId, env, enabledApplicationIds, options);
     }
     await subscriptionDAO.updateGmailHistory(subscription.subscriptionId, history.historyId || notificationHistoryId);
   }
@@ -65,6 +71,7 @@ class EmailProcessingUtil {
     messageId: string,
     env: EmailProcessingEnv,
     enabledApplicationIds: string[],
+    options: EmailProcessingOptions,
   ): Promise<void> {
     const message: GmailMessage = await GmailProviderUtil.getMessage(accessToken, messageId);
     const headers = message.payload?.headers;
@@ -72,7 +79,9 @@ class EmailProcessingUtil {
     const from: string = EmailContentUtil.getHeader(headers, 'From') || '';
     const isSummary: boolean = EmailContentUtil.getHeader(headers, 'X-Mail-Otter-Summary')?.toLowerCase() === 'true';
     const processedDAO = new ProcessedMessageDAO(env.DB);
-    const started: boolean = await processedDAO.tryStart(application.applicationId, application.providerId, message.id, message.threadId);
+    const started: boolean = await processedDAO.tryStart(application.applicationId, application.providerId, message.id, message.threadId, {
+      allowExistingForRetry: EmailProcessingUtil.isRetryAttempt(options),
+    });
     if (!started) return;
     try {
       if (isSummary || EmailContentUtil.isFromMailbox(from, application.providerEmail)) {
@@ -94,8 +103,9 @@ class EmailProcessingUtil {
       await GmailProviderUtil.sendSummaryReply(accessToken, application.providerEmail!, message, summary);
       await processedDAO.markSummarized(application.applicationId, message.id);
     } catch (error: unknown) {
-      await processedDAO.markError(application.applicationId, message.id, EmailProcessingUtil.formatError(error));
-      throw error;
+      const processingError: Error = EmailProcessingUtil.classifyError(error);
+      await processedDAO.markError(application.applicationId, message.id, EmailProcessingUtil.formatError(processingError));
+      throw processingError;
     }
   }
 
@@ -105,9 +115,12 @@ class EmailProcessingUtil {
     messageId: string,
     env: EmailProcessingEnv,
     enabledApplicationIds: string[],
+    options: EmailProcessingOptions,
   ): Promise<void> {
     const processedDAO = new ProcessedMessageDAO(env.DB);
-    const started: boolean = await processedDAO.tryStart(application.applicationId, application.providerId, messageId, null);
+    const started: boolean = await processedDAO.tryStart(application.applicationId, application.providerId, messageId, null, {
+      allowExistingForRetry: EmailProcessingUtil.isRetryAttempt(options),
+    });
     if (!started) return;
 
     let message: OutlookMessage;
@@ -122,8 +135,9 @@ class EmailProcessingUtil {
         );
         return;
       }
-      await processedDAO.markError(application.applicationId, messageId, EmailProcessingUtil.formatError(error));
-      throw error;
+      const processingError: Error = EmailProcessingUtil.classifyError(error);
+      await processedDAO.markError(application.applicationId, messageId, EmailProcessingUtil.formatError(processingError));
+      throw processingError;
     }
 
     const from: string = message.from?.emailAddress?.address || message.sender?.emailAddress?.address || '';
@@ -154,8 +168,9 @@ class EmailProcessingUtil {
       await OutlookProviderUtil.sendSelfSummaryReply(accessToken, message, application.providerEmail!, summary);
       await processedDAO.markSummarized(application.applicationId, message.id);
     } catch (error: unknown) {
-      await processedDAO.markError(application.applicationId, message.id, EmailProcessingUtil.formatError(error));
-      throw error;
+      const processingError: Error = EmailProcessingUtil.classifyError(error);
+      await processedDAO.markError(application.applicationId, message.id, EmailProcessingUtil.formatError(processingError));
+      throw processingError;
     }
   }
 
@@ -173,6 +188,23 @@ class EmailProcessingUtil {
 
   private static formatError(error: unknown): string {
     return error instanceof Error ? error.message : String(error);
+  }
+
+  private static isRetryAttempt(options: EmailProcessingOptions): boolean {
+    return typeof options.retryAttempt === 'number' && options.retryAttempt > 1;
+  }
+
+  private static classifyError(error: unknown): Error {
+    if (error instanceof RetryableError || error instanceof NonRetryableError) {
+      return error;
+    }
+    if (error instanceof BadRequestError) {
+      return new NonRetryableError(error.message);
+    }
+    if (error instanceof Error) {
+      return new RetryableError(error.message);
+    }
+    return new RetryableError(String(error));
   }
 }
 
@@ -193,5 +225,9 @@ interface EmailProcessingEnv {
   RAG_VECTOR_QUERY_TOP_K?: string | undefined;
 }
 
+interface EmailProcessingOptions {
+  retryAttempt?: number | undefined;
+}
+
 export { EmailProcessingUtil };
-export type { EmailProcessingEnv };
+export type { EmailProcessingEnv, EmailProcessingOptions };

--- a/apps/api/src/utils/EmailSummaryUtil.ts
+++ b/apps/api/src/utils/EmailSummaryUtil.ts
@@ -1,4 +1,4 @@
-import { InternalServerError } from '@/error';
+import { AiSummaryRetryableError } from '@/error';
 
 const SUMMARY_JSON_SCHEMA = {
   type: 'object',
@@ -81,12 +81,12 @@ class EmailSummaryUtil {
 
     const summaryText = EmailSummaryUtil.extractResponseText(result);
     if (!summaryText) {
-      throw new InternalServerError('Workers AI did not return a summary.');
+      throw new AiSummaryRetryableError('Workers AI did not return a summary.');
     }
 
     const summary = EmailSummaryUtil.parseAiSummaryResult(summaryText);
     if (!summary) {
-      throw new InternalServerError('Workers AI did not return a valid summary.');
+      throw new AiSummaryRetryableError('Workers AI did not return a valid summary.');
     }
     return EmailSummaryUtil.renderSummary(summary);
   }

--- a/apps/api/src/utils/GmailProviderUtil.ts
+++ b/apps/api/src/utils/GmailProviderUtil.ts
@@ -1,4 +1,4 @@
-import { InternalServerError } from '@/error';
+import { ProviderApiNonRetryableError, ProviderApiRetryableError } from '@/error';
 import { EmailContentUtil } from './EmailContentUtil';
 import { WebhookSecurityUtil } from './WebhookSecurityUtil';
 import type { GmailMessagePart, MailHeader } from './EmailContentUtil';
@@ -44,7 +44,7 @@ class GmailProviderUtil {
     });
     const data = (await response.json()) as { historyId?: string; expiration?: string; error?: { message?: string } };
     if (!response.ok || !data.historyId || !data.expiration) {
-      throw new InternalServerError(`Gmail watch failed: ${data.error?.message || response.statusText}`);
+      throw GmailProviderUtil.createApiError('watch', response, data.error?.message || response.statusText);
     }
     return {
       historyId: data.historyId,
@@ -58,7 +58,7 @@ class GmailProviderUtil {
       headers: { Authorization: `Bearer ${accessToken}` },
     });
     if (!response.ok) {
-      throw new InternalServerError(`Gmail stop failed: ${await response.text()}`);
+      throw GmailProviderUtil.createApiError('stop', response, await response.text());
     }
   }
 
@@ -122,7 +122,7 @@ class GmailProviderUtil {
       }),
     });
     if (!response.ok) {
-      throw new InternalServerError(`Gmail send summary failed: ${await response.text()}`);
+      throw GmailProviderUtil.createApiError('send summary', response, await response.text());
     }
     const sentMessage = (await response.json()) as { id: string };
     await GmailProviderUtil.trashGmailMessage(sentMessage.id, accessToken);
@@ -147,9 +147,21 @@ class GmailProviderUtil {
     const text: string = await response.text();
     const data = text ? (JSON.parse(text) as T & { error?: { message?: string } }) : ({} as T & { error?: { message?: string } });
     if (!response.ok) {
-      throw new InternalServerError(`Gmail API error: ${data.error?.message || text || response.statusText}`);
+      throw GmailProviderUtil.createApiError('request', response, data.error?.message || text || response.statusText);
     }
     return data as T;
+  }
+
+  private static createApiError(operation: string, response: Response, detail: string): Error {
+    const message: string = `Gmail ${operation} failed (${response.status}): ${detail || response.statusText}`;
+    if (GmailProviderUtil.isRetryableStatus(response.status)) {
+      return new ProviderApiRetryableError(message);
+    }
+    return new ProviderApiNonRetryableError(message);
+  }
+
+  private static isRetryableStatus(status: number): boolean {
+    return status === 408 || status === 409 || status === 425 || status === 429 || status >= 500;
   }
 }
 

--- a/apps/api/src/utils/OAuth2AccessTokenService.ts
+++ b/apps/api/src/utils/OAuth2AccessTokenService.ts
@@ -1,6 +1,6 @@
 import { DURABLE_OBJECT_OAUTH2_TOKEN_REFRESHERS_EXCHANGE_URL, DURABLE_OBJECT_OAUTH2_TOKEN_REFRESHERS_REFRESH_URL } from '@/constants';
 import { OAuth2AccessTokenCacheDAO } from '@/dao';
-import { InternalServerError } from '@/error';
+import { OAuth2TokenNonRetryableError, OAuth2TokenRetryableError } from '@/error';
 import { ConfigurationManager } from './ConfigurationManager';
 
 interface OAuth2AccessTokenServiceEnv {
@@ -86,7 +86,11 @@ class OAuth2AccessTokenService {
     const text: string = await response.text();
     const data = text ? (JSON.parse(text) as Partial<OAuth2AccessTokenResult> & { error?: string | undefined }) : {};
     if (!response.ok || !data.accessToken || !data.expiresAt) {
-      throw new InternalServerError(`OAuth2 token worker failed: ${data.error || text || response.statusText}`);
+      const message: string = `OAuth2 token worker failed: ${data.error || text || response.statusText}`;
+      if (response.status >= 400 && response.status < 500) {
+        throw new OAuth2TokenNonRetryableError(message);
+      }
+      throw new OAuth2TokenRetryableError(message);
     }
     return {
       accessToken: data.accessToken,

--- a/apps/api/src/utils/OAuth2ProviderUtil.ts
+++ b/apps/api/src/utils/OAuth2ProviderUtil.ts
@@ -123,7 +123,11 @@ class OAuth2ProviderUtil {
     });
     const data = (await response.json()) as OAuth2TokenResponse;
     if (!response.ok || !data.access_token) {
-      throw new InternalServerError(`OAuth2 token request failed: ${data.error_description || data.error || response.statusText}`);
+      const message: string = `OAuth2 token request failed: ${data.error_description || data.error || response.statusText}`;
+      if (response.status >= 400 && response.status < 500) {
+        throw new BadRequestError(message);
+      }
+      throw new InternalServerError(message);
     }
     return data;
   }

--- a/apps/api/src/utils/OutlookProviderUtil.ts
+++ b/apps/api/src/utils/OutlookProviderUtil.ts
@@ -1,4 +1,4 @@
-import { InternalServerError } from '@/error';
+import { ProviderApiNonRetryableError, ProviderApiRetryableError } from '@/error';
 import { EmailContentUtil } from './EmailContentUtil';
 
 interface OutlookMailboxProfile {
@@ -34,7 +34,7 @@ class OutlookProviderUtil {
       userPrincipalName?: string | null | undefined;
     }>('https://graph.microsoft.com/v1.0/me?$select=mail,userPrincipalName', accessToken);
     const emailAddress: string | undefined = data.mail || data.userPrincipalName || undefined;
-    if (!emailAddress) throw new InternalServerError('Microsoft Graph profile did not include a mailbox address.');
+    if (!emailAddress) throw new ProviderApiNonRetryableError('Microsoft Graph profile did not include a mailbox address.');
     return { emailAddress };
   }
 
@@ -64,7 +64,7 @@ class OutlookProviderUtil {
       }),
     });
     if (!data.id || !data.expirationDateTime) {
-      throw new InternalServerError(`Microsoft Graph subscription response was incomplete: ${data.error?.message || 'missing id'}`);
+      throw new ProviderApiRetryableError(`Microsoft Graph subscription response was incomplete: ${data.error?.message || 'missing id'}`);
     }
     return {
       id: data.id,
@@ -88,7 +88,7 @@ class OutlookProviderUtil {
       body: JSON.stringify({ expirationDateTime: new Date(expiresAt * 1000).toISOString() }),
     });
     if (!data.id || !data.expirationDateTime) {
-      throw new InternalServerError('Microsoft Graph subscription renewal response was incomplete.');
+      throw new ProviderApiRetryableError('Microsoft Graph subscription renewal response was incomplete.');
     }
     return {
       id: data.id,
@@ -103,7 +103,7 @@ class OutlookProviderUtil {
       headers: { Authorization: `Bearer ${accessToken}` },
     });
     if (!response.ok && response.status !== 404) {
-      throw new InternalServerError(`Microsoft Graph delete subscription failed: ${await response.text()}`);
+      throw OutlookProviderUtil.createApiError('delete subscription', response, await response.text());
     }
   }
 
@@ -139,7 +139,7 @@ class OutlookProviderUtil {
       },
     );
     if (!draft.id) {
-      throw new InternalServerError('Microsoft Graph createReply did not return a draft id.');
+      throw new ProviderApiRetryableError('Microsoft Graph createReply did not return a draft id.');
     }
     await OutlookProviderUtil.fetchJson<unknown>(
       `https://graph.microsoft.com/v1.0/me/messages/${encodeURIComponent(draft.id)}`,
@@ -166,7 +166,7 @@ class OutlookProviderUtil {
       },
     });
     if (!response.ok) {
-      throw new InternalServerError(`Microsoft Graph send summary failed: ${await response.text()}`);
+      throw OutlookProviderUtil.createApiError('send summary', response, await response.text());
     }
     await OutlookProviderUtil.deleteSentCopy(accessToken, draft.id);
   }
@@ -183,9 +183,21 @@ class OutlookProviderUtil {
     const text: string = await response.text();
     const data = text ? (JSON.parse(text) as T & { error?: { message?: string } }) : ({} as T & { error?: { message?: string } });
     if (!response.ok) {
-      throw new InternalServerError(`Microsoft Graph API error: ${data.error?.message || text || response.statusText}`);
+      throw OutlookProviderUtil.createApiError('request', response, data.error?.message || text || response.statusText);
     }
     return data as T;
+  }
+
+  private static createApiError(operation: string, response: Response, detail: string): Error {
+    const message: string = `Microsoft Graph ${operation} failed (${response.status}): ${detail || response.statusText}`;
+    if (OutlookProviderUtil.isRetryableStatus(response.status)) {
+      return new ProviderApiRetryableError(message);
+    }
+    return new ProviderApiNonRetryableError(message);
+  }
+
+  private static isRetryableStatus(status: number): boolean {
+    return status === 408 || status === 409 || status === 425 || status === 429 || status >= 500;
   }
 
   private static async deleteSentCopy(accessToken: string, messageId: string): Promise<void> {

--- a/apps/api/src/workers/EmailProcessingWorkflow.ts
+++ b/apps/api/src/workers/EmailProcessingWorkflow.ts
@@ -1,7 +1,9 @@
 import { AbstractWorkflowWorker } from '@/base/AbstractWorkflowWorker';
+import { NonRetryableError, RetryableError } from '@/error';
 import { EmailProcessingUtil } from '@/utils';
 import type { EmailQueueMessage } from '@mail-otter/shared/model';
-import type { WorkflowEvent, WorkflowStep } from 'cloudflare:workers';
+import type { WorkflowEvent, WorkflowStep, WorkflowStepContext } from 'cloudflare:workers';
+import { NonRetryableError as WorkflowNonRetryableError } from 'cloudflare:workflows';
 
 class EmailProcessingWorkflow extends AbstractWorkflowWorker<EmailQueueMessage, EmailProcessingWorkflowResult> {
   protected async onWorkflow(
@@ -18,14 +20,31 @@ class EmailProcessingWorkflow extends AbstractWorkflowWorker<EmailQueueMessage, 
         },
         timeout: '10 minutes',
       },
-      async (): Promise<void> => {
-        await EmailProcessingUtil.processQueueMessage(event.payload, this.env);
+      async (context: WorkflowStepContext): Promise<void> => {
+        try {
+          await EmailProcessingUtil.processQueueMessage(event.payload, this.env, { retryAttempt: context.attempt });
+        } catch (error: unknown) {
+          throw EmailProcessingWorkflow.toWorkflowError(error);
+        }
       },
     );
     return {
       processed: true,
       applicationId: event.payload.applicationId,
     };
+  }
+
+  private static toWorkflowError(error: unknown): Error {
+    if (error instanceof NonRetryableError) {
+      return new WorkflowNonRetryableError(error.message, error.name);
+    }
+    if (error instanceof RetryableError) {
+      return error;
+    }
+    if (error instanceof Error) {
+      return new RetryableError(error.message);
+    }
+    return new RetryableError(String(error));
   }
 }
 

--- a/test/mocks/cloudflare-workflows.ts
+++ b/test/mocks/cloudflare-workflows.ts
@@ -1,0 +1,8 @@
+class NonRetryableError extends Error {
+  constructor(message: string, name?: string | undefined) {
+    super(message);
+    this.name = name || 'NonRetryableError';
+  }
+}
+
+export { NonRetryableError };

--- a/test/utils/EmailProcessingUtil.test.ts
+++ b/test/utils/EmailProcessingUtil.test.ts
@@ -1,8 +1,10 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { EmailProcessingUtil } from '@/utils/EmailProcessingUtil';
+import type { EmailProcessingEnv } from '@/utils/EmailProcessingUtil';
 import { ConnectedApplicationDAO, ProcessedMessageDAO } from '@/dao';
 import { OAuth2AccessTokenService } from '@/utils/OAuth2AccessTokenService';
 import { OutlookProviderUtil } from '@/utils/OutlookProviderUtil';
+import { NonRetryableError, RetryableError } from '@/error';
 
 describe('EmailProcessingUtil', () => {
   beforeEach(() => {
@@ -28,28 +30,80 @@ describe('EmailProcessingUtil', () => {
       ),
     );
 
-    await expect(
-      EmailProcessingUtil.processQueueMessage(
-        {
-          type: 'outlook-notification',
-          applicationId: 'app-1',
-          subscriptionId: 'subscription-1',
-          messageId: 'message-1',
-        } as never,
-        {
-          DB: {} as D1Database,
-          AES_ENCRYPTION_KEY_SECRET: {
-            get: vi.fn().mockResolvedValue('master-key'),
-          } as never,
-          OAUTH2_TOKEN_CACHE: {} as KVNamespace,
-          OAUTH2_TOKEN_REFRESHERS: {} as DurableObjectNamespace,
-          AI: {} as Ai,
-        },
-      ),
-    ).resolves.toBeUndefined();
+    await expect(EmailProcessingUtil.processQueueMessage(createOutlookQueueMessage(), createEnv())).resolves.toBeUndefined();
 
-    expect(tryStart).toHaveBeenCalledWith('app-1', 'microsoft-outlook', 'message-1', null);
+    expect(tryStart).toHaveBeenCalledWith('app-1', 'microsoft-outlook', 'message-1', null, { allowExistingForRetry: false });
     expect(markSkipped).toHaveBeenCalledWith('app-1', 'message-1', 'Outlook message was deleted before Mail-Otter could process it.');
     expect(markError).not.toHaveBeenCalled();
   });
+
+  it('allows workflow retry attempts to resume existing processed-message rows', async () => {
+    vi.spyOn(ConnectedApplicationDAO.prototype, 'getById').mockResolvedValue({
+      applicationId: 'app-1',
+      userEmail: 'owner@example.com',
+      providerId: 'microsoft-outlook',
+      providerEmail: 'owner@example.com',
+      credentials: { refreshToken: 'refresh-token' },
+    } as never);
+    vi.spyOn(ConnectedApplicationDAO.prototype, 'listContextEnabledApplicationIdsByUserEmail').mockResolvedValue([]);
+    vi.spyOn(OAuth2AccessTokenService, 'getAccessToken').mockResolvedValue('access-token');
+    const tryStart = vi.spyOn(ProcessedMessageDAO.prototype, 'tryStart').mockResolvedValue(true);
+    vi.spyOn(ProcessedMessageDAO.prototype, 'markSkipped').mockResolvedValue();
+    vi.spyOn(OutlookProviderUtil, 'getMessage').mockRejectedValue(
+      new Error(
+        'Microsoft Graph API error: The specified object was not found in the store., The process failed to get the correct properties.',
+      ),
+    );
+
+    await expect(EmailProcessingUtil.processQueueMessage(createOutlookQueueMessage(), createEnv(), { retryAttempt: 2 })).resolves
+      .toBeUndefined();
+
+    expect(tryStart).toHaveBeenCalledWith('app-1', 'microsoft-outlook', 'message-1', null, { allowExistingForRetry: true });
+  });
+
+  it('classifies missing applications as non-retryable', async () => {
+    vi.spyOn(ConnectedApplicationDAO.prototype, 'getById').mockResolvedValue(undefined);
+
+    await expect(EmailProcessingUtil.processQueueMessage(createOutlookQueueMessage(), createEnv())).rejects.toThrow(NonRetryableError);
+  });
+
+  it('classifies unexpected processing failures as retryable and records the error', async () => {
+    vi.spyOn(ConnectedApplicationDAO.prototype, 'getById').mockResolvedValue({
+      applicationId: 'app-1',
+      userEmail: 'owner@example.com',
+      providerId: 'microsoft-outlook',
+      providerEmail: 'owner@example.com',
+      credentials: { refreshToken: 'refresh-token' },
+    } as never);
+    vi.spyOn(ConnectedApplicationDAO.prototype, 'listContextEnabledApplicationIdsByUserEmail').mockResolvedValue([]);
+    vi.spyOn(OAuth2AccessTokenService, 'getAccessToken').mockResolvedValue('access-token');
+    vi.spyOn(ProcessedMessageDAO.prototype, 'tryStart').mockResolvedValue(true);
+    const markError = vi.spyOn(ProcessedMessageDAO.prototype, 'markError').mockResolvedValue();
+    vi.spyOn(OutlookProviderUtil, 'getMessage').mockRejectedValue(new Error('Temporary Graph failure.'));
+
+    await expect(EmailProcessingUtil.processQueueMessage(createOutlookQueueMessage(), createEnv())).rejects.toThrow(RetryableError);
+
+    expect(markError).toHaveBeenCalledWith('app-1', 'message-1', 'Temporary Graph failure.');
+  });
 });
+
+function createOutlookQueueMessage() {
+  return {
+    type: 'outlook-notification',
+    applicationId: 'app-1',
+    subscriptionId: 'subscription-1',
+    messageId: 'message-1',
+  } as never;
+}
+
+function createEnv(): EmailProcessingEnv {
+  return {
+    DB: {} as D1Database,
+    AES_ENCRYPTION_KEY_SECRET: {
+      get: vi.fn().mockResolvedValue('master-key'),
+    } as never,
+    OAUTH2_TOKEN_CACHE: {} as KVNamespace,
+    OAUTH2_TOKEN_REFRESHERS: {} as DurableObjectNamespace,
+    AI: {} as Ai,
+  };
+}

--- a/test/utils/EmailSummaryUtil.test.ts
+++ b/test/utils/EmailSummaryUtil.test.ts
@@ -1,5 +1,5 @@
 import { EmailSummaryUtil } from '@/utils';
-import { InternalServerError } from '@/error';
+import { AiSummaryRetryableError } from '@/error';
 
 describe('EmailSummaryUtil', () => {
   it('renders a consistent summary format from structured AI output', async () => {
@@ -65,7 +65,7 @@ Action items:
     } as unknown as Ai;
 
     await expect(EmailSummaryUtil.summarizeEmail(ai, 'model', 'Status', 'sam@example.com', 'body')).rejects.toThrow(
-      new InternalServerError('Workers AI did not return a valid summary.'),
+      new AiSummaryRetryableError('Workers AI did not return a valid summary.'),
     );
   });
 

--- a/test/utils/GmailProviderUtil.test.ts
+++ b/test/utils/GmailProviderUtil.test.ts
@@ -72,7 +72,7 @@ describe('GmailProviderUtil', () => {
 
       await expect(
         GmailProviderUtil.sendSummaryReply('test-access-token', 'sender@example.com', originalMessage as never, 'Summary text'),
-      ).rejects.toThrow('Gmail send summary failed: Send failed');
+      ).rejects.toThrow('Gmail send summary failed (500): Send failed');
 
       expect(vi.mocked(fetch)).toHaveBeenCalledTimes(1);
     });

--- a/test/utils/OAuth2AccessTokenService.test.ts
+++ b/test/utils/OAuth2AccessTokenService.test.ts
@@ -1,6 +1,7 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { OAuth2AccessTokenCacheDAO } from '@/dao';
 import { OAuth2AccessTokenService } from '@/utils/OAuth2AccessTokenService';
+import { OAuth2TokenNonRetryableError, OAuth2TokenRetryableError } from '@/error';
 
 describe('OAuth2AccessTokenService', () => {
   beforeEach(() => {
@@ -50,5 +51,35 @@ describe('OAuth2AccessTokenService', () => {
     expect(env.OAUTH2_TOKEN_REFRESHERS.get).toHaveBeenCalledWith(id);
     const request: Request = fetch.mock.calls[0][0];
     expect(new URL(request.url).pathname).toBe('/refresh');
+  });
+
+  it('classifies token worker client failures as non-retryable', async () => {
+    vi.spyOn(OAuth2AccessTokenCacheDAO.prototype, 'getCachedAccessToken').mockResolvedValue(undefined);
+    const fetch = vi.fn().mockResolvedValue(Response.json({ error: 'Connected application is not authorized.' }, { status: 400 }));
+    const env = {
+      AES_ENCRYPTION_KEY_SECRET: { get: vi.fn().mockResolvedValue('master-key') },
+      OAUTH2_TOKEN_CACHE: {} as KVNamespace,
+      OAUTH2_TOKEN_REFRESHERS: {
+        idFromName: vi.fn(() => ({} as DurableObjectId)),
+        get: vi.fn(() => ({ fetch })),
+      },
+    } as unknown as Env;
+
+    await expect(OAuth2AccessTokenService.getAccessToken('app-1', env)).rejects.toThrow(OAuth2TokenNonRetryableError);
+  });
+
+  it('classifies token worker server failures as retryable', async () => {
+    vi.spyOn(OAuth2AccessTokenCacheDAO.prototype, 'getCachedAccessToken').mockResolvedValue(undefined);
+    const fetch = vi.fn().mockResolvedValue(Response.json({ error: 'Temporary failure.' }, { status: 500 }));
+    const env = {
+      AES_ENCRYPTION_KEY_SECRET: { get: vi.fn().mockResolvedValue('master-key') },
+      OAUTH2_TOKEN_CACHE: {} as KVNamespace,
+      OAUTH2_TOKEN_REFRESHERS: {
+        idFromName: vi.fn(() => ({} as DurableObjectId)),
+        get: vi.fn(() => ({ fetch })),
+      },
+    } as unknown as Env;
+
+    await expect(OAuth2AccessTokenService.getAccessToken('app-1', env)).rejects.toThrow(OAuth2TokenRetryableError);
   });
 });

--- a/test/utils/OutlookProviderUtil.test.ts
+++ b/test/utils/OutlookProviderUtil.test.ts
@@ -77,7 +77,7 @@ describe('OutlookProviderUtil', () => {
 
       await expect(
         OutlookProviderUtil.sendSelfSummaryReply('test-access-token', { id: 'original-msg-id' }, 'sender@example.com', 'Summary text'),
-      ).rejects.toThrow('Microsoft Graph send summary failed: Send failed');
+      ).rejects.toThrow('Microsoft Graph send summary failed (500): Send failed');
     });
 
     it('throws when createReply fails', async () => {
@@ -87,7 +87,7 @@ describe('OutlookProviderUtil', () => {
 
       await expect(
         OutlookProviderUtil.sendSelfSummaryReply('test-access-token', { id: 'original-msg-id' }, 'sender@example.com', 'Summary text'),
-      ).rejects.toThrow('Microsoft Graph API error: createReply failed');
+      ).rejects.toThrow('Microsoft Graph request failed (400): createReply failed');
     });
 
     it('throws when draft has no id', async () => {

--- a/test/workers/EmailProcessingWorkflow.test.ts
+++ b/test/workers/EmailProcessingWorkflow.test.ts
@@ -1,0 +1,81 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { NonRetryableError, RetryableError } from '@/error';
+import type { EmailQueueMessage } from '@mail-otter/shared/model';
+import type { WorkflowEvent, WorkflowStep, WorkflowStepConfig, WorkflowStepContext } from 'cloudflare:workers';
+import { NonRetryableError as WorkflowNonRetryableError } from 'cloudflare:workflows';
+
+vi.mock('@/utils', () => ({
+  EmailProcessingUtil: {
+    processQueueMessage: vi.fn(),
+  },
+}));
+
+import { EmailProcessingWorkflow } from '@/workers/EmailProcessingWorkflow';
+import { EmailProcessingUtil } from '@/utils';
+
+describe('EmailProcessingWorkflow', () => {
+  beforeEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('passes the workflow retry attempt into email processing', async () => {
+    vi.mocked(EmailProcessingUtil.processQueueMessage).mockResolvedValue();
+    const workflow = new EmailProcessingWorkflow({} as ExecutionContext, {} as Env);
+    const step = createStep(3);
+    const event = createEvent();
+
+    await workflow.run(event, step);
+
+    expect(EmailProcessingUtil.processQueueMessage).toHaveBeenCalledWith(event.payload, {}, { retryAttempt: 3 });
+  });
+
+  it('leaves retryable errors retryable for the workflow step policy', async () => {
+    const error = new RetryableError('Temporary provider failure.');
+    vi.mocked(EmailProcessingUtil.processQueueMessage).mockRejectedValue(error);
+    const workflow = new EmailProcessingWorkflow({} as ExecutionContext, {} as Env);
+
+    await expect(workflow.run(createEvent(), createStep(1))).rejects.toBe(error);
+  });
+
+  it('converts non-retryable errors into Cloudflare workflow fatal errors', async () => {
+    vi.mocked(EmailProcessingUtil.processQueueMessage).mockRejectedValue(new NonRetryableError('Application is not connected.'));
+    const workflow = new EmailProcessingWorkflow({} as ExecutionContext, {} as Env);
+
+    await expect(workflow.run(createEvent(), createStep(1))).rejects.toThrow(WorkflowNonRetryableError);
+  });
+});
+
+function createEvent(): Readonly<WorkflowEvent<EmailQueueMessage>> {
+  return {
+    payload: {
+      type: 'outlook-notification',
+      applicationId: 'app-1',
+      subscriptionId: 'subscription-1',
+      messageId: 'message-1',
+    } as EmailQueueMessage,
+    timestamp: new Date(),
+    instanceId: 'workflow-instance-1',
+  };
+}
+
+function createStep(attempt: number): WorkflowStep {
+  return {
+    do: vi.fn(
+      async <T>(
+        _name: string,
+        configOrCallback: WorkflowStepConfig | ((context: WorkflowStepContext) => Promise<T>),
+        callback?: (context: WorkflowStepContext) => Promise<T>,
+      ): Promise<T> => {
+        const stepCallback = typeof configOrCallback === 'function' ? configOrCallback : callback!;
+        return stepCallback({
+          attempt,
+          config: typeof configOrCallback === 'function' ? {} : configOrCallback,
+          step: {
+            name: 'process email event',
+            count: attempt,
+          },
+        });
+      },
+    ),
+  } as unknown as WorkflowStep;
+}

--- a/vitest.config.mts
+++ b/vitest.config.mts
@@ -4,6 +4,7 @@ import { fileURLToPath } from 'node:url';
 const apiSrcPath = fileURLToPath(new URL('./apps/api/src', import.meta.url));
 const sharedSrcPath = fileURLToPath(new URL('./packages/shared/src', import.meta.url));
 const cloudflareWorkersMockPath = fileURLToPath(new URL('./test/mocks/cloudflare-workers.ts', import.meta.url));
+const cloudflareWorkflowsMockPath = fileURLToPath(new URL('./test/mocks/cloudflare-workflows.ts', import.meta.url));
 
 export default defineConfig({
   test: {
@@ -19,6 +20,7 @@ export default defineConfig({
       { find: '@/utils', replacement: `${apiSrcPath}/utils` },
       { find: '@mail-otter/shared', replacement: sharedSrcPath },
       { find: 'cloudflare:workers', replacement: cloudflareWorkersMockPath },
+      { find: 'cloudflare:workflows', replacement: cloudflareWorkflowsMockPath },
       { find: /^@\//, replacement: `${apiSrcPath}/` },
     ],
   },


### PR DESCRIPTION
Add app-level RetryableError and NonRetryableError types plus email-processing subclasses for AI summary, provider API, and OAuth2 token failures.

Map NonRetryableError to Cloudflare Workflows NonRetryableError so permanent failures stop the step retry policy, while retryable failures continue to use the configured exponential retries.

Pass the workflow attempt count into email processing and allow retry attempts to resume existing processing/error processed-message rows so retries do not silently no-op after the first failed attempt.

Verification: source ~/.customrc && volta run pnpm run checks