### PR TITLE
Add ESLint Import Guardrails

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -81,6 +81,21 @@ Run `volta run pnpm run cf-typegen` after changing bindings in Wrangler config.
 - `functions/[[path]].ts` proxies Cloudflare Pages requests to the API Worker through a service binding.
 - `test/` contains Vitest suites for workers, schemas, and utilities.
 
+## Import Direction
+
+Packages are organized in layers. Higher layers may import from lower layers; lower layers must not import upward.
+
+```
+Layer 0: shared, backend-errors          — zero @mail-otter/* deps
+Layer 1: backend-runtime                 → layer 0 only
+Layer 2: backend-data, provider-clients  → layer 0 only
+Layer 3: backend-services                → layers 0–2 (not apps)
+Layer 5: apps/background                 → layers 0–3 (including provider-clients directly)
+         apps/api                        → layers 0–3 + background (NOT provider-clients directly)
+```
+
+Enforced by ESLint `no-restricted-imports` rules in `eslint.config.mjs`.
+
 ## Build And Runtime Notes
 
 - The root package is `@mail-otter/monorepo` and uses pnpm workspaces.

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -18,4 +18,96 @@ export default defineConfig([
       ],
     },
   },
+
+  // --- Import direction guardrails ---
+  // Layer 0: shared — zero @mail-otter/* deps
+  {
+    files: ['packages/shared/**/*.{ts,js}'],
+    rules: {
+      'no-restricted-imports': ['error', {
+        patterns: [
+          { group: ['@mail-otter/*'], message: 'shared must not import from other @mail-otter packages — it is a zero-dependency base layer' },
+        ],
+      }],
+    },
+  },
+  // Layer 0: backend-errors — zero @mail-otter/* deps
+  {
+    files: ['packages/backend-errors/**/*.{ts,js}'],
+    rules: {
+      'no-restricted-imports': ['error', {
+        patterns: [
+          { group: ['@mail-otter/*'], message: 'backend-errors must not import from other @mail-otter packages — it is a zero-dependency base layer' },
+        ],
+      }],
+    },
+  },
+  // Layer 1: backend-runtime — only shared and backend-errors
+  {
+    files: ['packages/backend-runtime/**/*.{ts,js}'],
+    rules: {
+      'no-restricted-imports': ['error', {
+        patterns: [
+          { group: ['@mail-otter/backend-data', '@mail-otter/backend-data/*'], message: 'backend-runtime must not import from backend-data (higher layer)' },
+          { group: ['@mail-otter/provider-clients', '@mail-otter/provider-clients/*'], message: 'backend-runtime must not import from provider-clients (higher layer)' },
+          { group: ['@mail-otter/backend-services', '@mail-otter/backend-services/*'], message: 'backend-runtime must not import from backend-services (higher layer)' },
+          { group: ['@mail-otter/api', '@mail-otter/api/*'], message: 'backend-runtime must not import from apps/api' },
+          { group: ['@mail-otter/background', '@mail-otter/background/*'], message: 'backend-runtime must not import from apps/background' },
+        ],
+      }],
+    },
+  },
+  // Layer 2: backend-data — only shared and backend-errors
+  {
+    files: ['packages/backend-data/**/*.{ts,js}'],
+    rules: {
+      'no-restricted-imports': ['error', {
+        patterns: [
+          { group: ['@mail-otter/backend-runtime', '@mail-otter/backend-runtime/*'], message: 'backend-data must not import from backend-runtime' },
+          { group: ['@mail-otter/provider-clients', '@mail-otter/provider-clients/*'], message: 'backend-data must not import from provider-clients' },
+          { group: ['@mail-otter/backend-services', '@mail-otter/backend-services/*'], message: 'backend-data must not import services (higher layer)' },
+          { group: ['@mail-otter/api', '@mail-otter/api/*'], message: 'backend-data must not import from apps/api' },
+          { group: ['@mail-otter/background', '@mail-otter/background/*'], message: 'backend-data must not import from apps/background' },
+        ],
+      }],
+    },
+  },
+  // Layer 2: provider-clients — only shared and backend-errors
+  {
+    files: ['packages/provider-clients/**/*.{ts,js}'],
+    rules: {
+      'no-restricted-imports': ['error', {
+        patterns: [
+          { group: ['@mail-otter/backend-data', '@mail-otter/backend-data/*'], message: 'provider-clients must not import DAOs from backend-data' },
+          { group: ['@mail-otter/backend-runtime', '@mail-otter/backend-runtime/*'], message: 'provider-clients must not import from backend-runtime' },
+          { group: ['@mail-otter/backend-services', '@mail-otter/backend-services/*'], message: 'provider-clients must not import from backend-services (higher layer)' },
+          { group: ['@mail-otter/api', '@mail-otter/api/*'], message: 'provider-clients must not import from apps/api' },
+          { group: ['@mail-otter/background', '@mail-otter/background/*'], message: 'provider-clients must not import from apps/background' },
+        ],
+      }],
+    },
+  },
+  // Layer 3: backend-services — cannot import apps
+  {
+    files: ['packages/backend-services/**/*.{ts,js}'],
+    rules: {
+      'no-restricted-imports': ['error', {
+        patterns: [
+          { group: ['@mail-otter/api', '@mail-otter/api/*'], message: 'backend-services must not import from apps/api' },
+          { group: ['@mail-otter/background', '@mail-otter/background/*'], message: 'backend-services must not import from apps/background' },
+        ],
+      }],
+    },
+  },
+  // Layer 5: apps/api — route through backend-services, not directly to provider-clients
+  {
+    files: ['apps/api/**/*.{ts,js}'],
+    rules: {
+      'no-restricted-imports': ['error', {
+        patterns: [
+          { group: ['@mail-otter/provider-clients', '@mail-otter/provider-clients/*'], message: 'apps/api must not import provider-clients directly; use @mail-otter/backend-services instead' },
+        ],
+      }],
+    },
+  },
 ]);


### PR DESCRIPTION
Add `no-restricted-imports` rules to `eslint.config.mjs` enforcing the layered dependency direction established by Phases 1–8. Each package gets a targeted config block listing which higher-layer packages it must not import.

Enforced boundaries:
- `shared` and `backend-errors`: no `@mail-otter/*` deps (base layers)
- `backend-runtime`: cannot import `backend-data`, `provider-clients`, `backend-services`, or apps
- `backend-data`: cannot import `backend-runtime`, `provider-clients`, `backend-services`, or apps
- `provider-clients`: cannot import `backend-data`, `backend-runtime`, `backend-services`, or apps
- `backend-services`: cannot import `apps/api` or `apps/background`
- `apps/api`: cannot import `provider-clients` directly (use `backend-services`)

`apps/background` is intentionally unrestricted from `provider-clients` — `OAuth2TokenRefreshWorker` legitimately calls provider clients directly.

Also documents the import direction layer model in `AGENTS.md`.

All existing code already complies; lint, typecheck, and tests pass clean.