### PR TITLE
Keep Subscription Active On Transient Renewal Error

### DIFF
--- a/packages/backend-data/src/dao/ProviderSubscriptionDAO.ts
+++ b/packages/backend-data/src/dao/ProviderSubscriptionDAO.ts
@@ -185,6 +185,17 @@ class ProviderSubscriptionDAO {
     }
   }
 
+  public async recordTransientError(subscriptionId: string, errorMessage: string): Promise<void> {
+    const now: number = TimestampUtil.getCurrentUnixTimestampInSeconds();
+    const result: D1Result = await this.database
+      .prepare('UPDATE provider_subscriptions SET last_error = ?, updated_at = ? WHERE subscription_id = ?')
+      .bind(errorMessage.slice(0, 1024), now, subscriptionId)
+      .run();
+    if (!result.success) {
+      throw new DatabaseError(`Failed to record transient error on provider subscription: ${result.error}`);
+    }
+  }
+
   private async getById(subscriptionId: string): Promise<ProviderSubscription | undefined> {
     const row: ProviderSubscriptionInternal | null = await this.database
       .prepare(

--- a/packages/backend-services/src/subscription/SubscriptionRenewalUtil.ts
+++ b/packages/backend-services/src/subscription/SubscriptionRenewalUtil.ts
@@ -6,6 +6,7 @@ import { WebhookSecurityUtil } from '@mail-otter/provider-clients/webhook';
 import type { ConnectedApplication, ProviderSubscription } from '@mail-otter/shared/model';
 import { TimestampUtil } from '@mail-otter/shared/utils';
 import { ConfigurationManager } from '@mail-otter/backend-runtime/config';
+import { RetryableError } from '@mail-otter/backend-errors';
 import { OAuth2AccessTokenService } from '../oauth2/OAuth2AccessTokenService';
 
 class SubscriptionRenewalUtil {
@@ -27,7 +28,12 @@ class SubscriptionRenewalUtil {
           await SubscriptionRenewalUtil.renewOutlook(subscription, applicationDAO, subscriptionDAO, env);
         }
       } catch (error: unknown) {
-        await subscriptionDAO.markError(subscription.subscriptionId, error instanceof Error ? error.message : String(error));
+        const message = error instanceof Error ? error.message : String(error);
+        if (error instanceof RetryableError) {
+          await subscriptionDAO.recordTransientError(subscription.subscriptionId, message);
+        } else {
+          await subscriptionDAO.markError(subscription.subscriptionId, message);
+        }
       }
     }
   }


### PR DESCRIPTION
When Microsoft Graph returns a 503 ServiceUnavailable (e.g. mailbox database on unknown backend during a migration), the renewal catch block was unconditionally calling `markError()`, which sets `status = 'error'`. `listActiveRenewalCandidates` only selects `status = 'active'`, so the subscription was silently dropped from future cron retries and expired without renewal.

Fix: check whether the caught error is a `RetryableError`. If so, call the new `recordTransientError()` DAO method, which updates only `last_error` without touching `status`. The subscription stays `active` and is picked up on the next scheduled cron run. Non-retryable errors (auth revoked, resource gone, etc.) continue to call `markError()` as before.