### PR TITLE
Break Email Processing Into Multiple Checkpointed Steps

### DIFF
--- a/apps/background/src/EmailProcessingWorkflow.ts
+++ b/apps/background/src/EmailProcessingWorkflow.ts
@@ -1,6 +1,7 @@
 import { AbstractWorkflowWorker } from '@mail-otter/backend-runtime/base';
 import { NonRetryableError, RetryableError } from '@mail-otter/backend-errors';
 import { EmailProcessingUtil } from '@mail-otter/backend-services/email';
+import type { GmailMessageList, ResolvedApplication } from '@mail-otter/backend-services/email';
 import type { EmailQueueMessage } from '@mail-otter/shared/model';
 import type { WorkflowEvent, WorkflowStep, WorkflowStepContext } from 'cloudflare:workers';
 import { NonRetryableError as WorkflowNonRetryableError } from 'cloudflare:workflows';
@@ -10,24 +11,93 @@ class EmailProcessingWorkflow extends AbstractWorkflowWorker<EmailQueueMessage, 
     event: Readonly<WorkflowEvent<EmailQueueMessage>>,
     step: WorkflowStep,
   ): Promise<EmailProcessingWorkflowResult> {
-    await step.do(
-      'process email event',
-      {
-        retries: {
-          limit: 5,
-          delay: '30 seconds',
-          backoff: 'exponential',
-        },
-        timeout: '10 minutes',
-      },
-      async (context: WorkflowStepContext): Promise<void> => {
+    const resolved = await step.do(
+      'Resolve Application',
+      { retries: { limit: 3, delay: '10 seconds', backoff: 'exponential' }, timeout: '2 minutes' },
+      async (): Promise<ResolvedApplication> => {
         try {
-          await EmailProcessingUtil.processQueueMessage(event.payload, this.env, { retryAttempt: context.attempt });
+          return await EmailProcessingUtil.resolveApplication(event.payload, this.env);
         } catch (error: unknown) {
           throw EmailProcessingWorkflow.toWorkflowError(error);
         }
       },
     );
+
+    if (event.payload.type === 'gmail-notification') {
+      const gmailPayload = event.payload;
+      const messageList = await step.do(
+        'List Gmail Messages',
+        { retries: { limit: 3, delay: '10 seconds', backoff: 'exponential' }, timeout: '2 minutes' },
+        async (): Promise<GmailMessageList | null> => {
+          try {
+            return await EmailProcessingUtil.listGmailMessages(
+              resolved.application,
+              resolved.accessToken,
+              gmailPayload.notificationHistoryId,
+              this.env,
+            );
+          } catch (error: unknown) {
+            throw EmailProcessingWorkflow.toWorkflowError(error);
+          }
+        },
+      );
+
+      if (messageList) {
+        for (const messageId of messageList.messageIds) {
+          await step.do(
+            `Summarize Gmail Message ${messageId}`,
+            { retries: { limit: 5, delay: '30 seconds', backoff: 'exponential' }, timeout: '5 minutes' },
+            async (context: WorkflowStepContext): Promise<void> => {
+              try {
+                await EmailProcessingUtil.processGmailMessage(
+                  resolved.application,
+                  resolved.accessToken,
+                  messageId,
+                  this.env,
+                  resolved.enabledApplicationIds,
+                  { retryAttempt: context.attempt },
+                );
+              } catch (error: unknown) {
+                throw EmailProcessingWorkflow.toWorkflowError(error);
+              }
+            },
+          );
+        }
+
+        await step.do(
+          'Update Gmail History',
+          { retries: { limit: 3, delay: '10 seconds', backoff: 'exponential' }, timeout: '2 minutes' },
+          async (): Promise<void> => {
+            try {
+              await EmailProcessingUtil.updateGmailHistory(messageList.subscriptionId, messageList.historyId, this.env);
+            } catch (error: unknown) {
+              throw EmailProcessingWorkflow.toWorkflowError(error);
+            }
+          },
+        );
+      }
+    } else if (event.payload.type === 'outlook-notification') {
+      const outlookPayload = event.payload;
+      await step.do(
+        'Summarize Outlook Message',
+        { retries: { limit: 5, delay: '30 seconds', backoff: 'exponential' }, timeout: '5 minutes' },
+        async (context: WorkflowStepContext): Promise<void> => {
+          try {
+            await EmailProcessingUtil.processOutlookMessage(
+              resolved.application,
+              resolved.accessToken,
+              outlookPayload.messageId,
+              this.env,
+              resolved.enabledApplicationIds,
+              { retryAttempt: context.attempt },
+            );
+          } catch (error: unknown) {
+            throw EmailProcessingWorkflow.toWorkflowError(error);
+          }
+        },
+      );
+    }
+
     return {
       processed: true,
       applicationId: event.payload.applicationId,

--- a/packages/backend-services/src/email/EmailProcessingUtil.ts
+++ b/packages/backend-services/src/email/EmailProcessingUtil.ts
@@ -13,11 +13,7 @@ import { EmailSummaryUtil } from './EmailSummaryUtil';
 import { OAuth2AccessTokenService } from '../oauth2/OAuth2AccessTokenService';
 
 class EmailProcessingUtil {
-  public static async processQueueMessage(
-    message: EmailQueueMessage,
-    env: EmailProcessingEnv,
-    options: EmailProcessingOptions = {},
-  ): Promise<void> {
+  public static async resolveApplication(message: EmailQueueMessage, env: EmailProcessingEnv): Promise<ResolvedApplication> {
     const masterKey: string = await env.AES_ENCRYPTION_KEY_SECRET.get();
     const applicationDAO = new ConnectedApplicationDAO(env.DB, masterKey);
     const application: ConnectedApplication | undefined = await applicationDAO.getById(message.applicationId);
@@ -27,49 +23,37 @@ class EmailProcessingUtil {
     if (!application.providerEmail) {
       throw new NonRetryableError('Connected application does not have a provider mailbox address.');
     }
-
     const accessToken: string = await OAuth2AccessTokenService.getAccessToken(application.applicationId, env);
     const enabledApplicationIds: string[] = await applicationDAO.listContextEnabledApplicationIdsByUserEmail(application.userEmail);
-    if (message.type === 'gmail-notification') {
-      await EmailProcessingUtil.processGmailNotification(
-        application,
-        accessToken,
-        message.notificationHistoryId,
-        env,
-        enabledApplicationIds,
-        options,
-      );
-      return;
-    }
-    await EmailProcessingUtil.processOutlookMessage(application, accessToken, message.messageId, env, enabledApplicationIds, options);
+    return { application, accessToken, enabledApplicationIds };
   }
 
-  private static async processGmailNotification(
+  public static async listGmailMessages(
     application: ConnectedApplication,
     accessToken: string,
     notificationHistoryId: string,
     env: EmailProcessingEnv,
-    enabledApplicationIds: string[],
-    options: EmailProcessingOptions,
-  ): Promise<void> {
+  ): Promise<GmailMessageList | null> {
     const subscriptionDAO = new ProviderSubscriptionDAO(env.DB);
     const subscription: ProviderSubscription | undefined = await subscriptionDAO.getByApplication(application.applicationId);
-    if (!subscription || subscription.status !== PROVIDER_SUBSCRIPTION_STATUS_ACTIVE) return;
+    if (!subscription || subscription.status !== PROVIDER_SUBSCRIPTION_STATUS_ACTIVE) return null;
     const startHistoryId: string | undefined = subscription.gmailHistoryId || notificationHistoryId;
     const history = await GmailProviderUtil.listMessageIdsSince(accessToken, startHistoryId);
-    for (const messageId of history.messageIds) {
-      await EmailProcessingUtil.processGmailMessage(application, accessToken, messageId, env, enabledApplicationIds, options);
-    }
-    await subscriptionDAO.updateGmailHistory(subscription.subscriptionId, history.historyId || notificationHistoryId);
+    return { messageIds: history.messageIds, historyId: history.historyId || notificationHistoryId, subscriptionId: subscription.subscriptionId };
   }
 
-  private static async processGmailMessage(
+  public static async updateGmailHistory(subscriptionId: string, historyId: string, env: EmailProcessingEnv): Promise<void> {
+    const subscriptionDAO = new ProviderSubscriptionDAO(env.DB);
+    await subscriptionDAO.updateGmailHistory(subscriptionId, historyId);
+  }
+
+  public static async processGmailMessage(
     application: ConnectedApplication,
     accessToken: string,
     messageId: string,
     env: EmailProcessingEnv,
     enabledApplicationIds: string[],
-    options: EmailProcessingOptions,
+    options: EmailProcessingOptions = {},
   ): Promise<void> {
     const message: GmailMessage = await GmailProviderUtil.getMessage(accessToken, messageId);
     const headers = message.payload?.headers;
@@ -107,13 +91,13 @@ class EmailProcessingUtil {
     }
   }
 
-  private static async processOutlookMessage(
+  public static async processOutlookMessage(
     application: ConnectedApplication,
     accessToken: string,
     messageId: string,
     env: EmailProcessingEnv,
     enabledApplicationIds: string[],
-    options: EmailProcessingOptions,
+    options: EmailProcessingOptions = {},
   ): Promise<void> {
     const processedDAO = new ProcessedMessageDAO(env.DB);
     const started: boolean = await processedDAO.tryStart(application.applicationId, application.providerId, messageId, null, {
@@ -206,6 +190,18 @@ class EmailProcessingUtil {
   }
 }
 
+interface ResolvedApplication {
+  application: ConnectedApplication;
+  accessToken: string;
+  enabledApplicationIds: string[];
+}
+
+interface GmailMessageList {
+  messageIds: string[];
+  historyId: string;
+  subscriptionId: string;
+}
+
 interface EmailProcessingEnv {
   DB: D1Database;
   AES_ENCRYPTION_KEY_SECRET: SecretsStoreSecret;
@@ -228,4 +224,4 @@ interface EmailProcessingOptions {
 }
 
 export { EmailProcessingUtil };
-export type { EmailProcessingEnv, EmailProcessingOptions };
+export type { EmailProcessingEnv, EmailProcessingOptions, ResolvedApplication, GmailMessageList };

--- a/test/utils/EmailProcessingUtil.test.ts
+++ b/test/utils/EmailProcessingUtil.test.ts
@@ -11,82 +11,89 @@ describe('EmailProcessingUtil', () => {
     vi.restoreAllMocks();
   });
 
-  it('marks Outlook messages as skipped when they are deleted before processing', async () => {
-    vi.spyOn(ConnectedApplicationDAO.prototype, 'getById').mockResolvedValue({
-      applicationId: 'app-1',
-      userEmail: 'owner@example.com',
-      providerId: 'microsoft-outlook',
-      providerEmail: 'owner@example.com',
-      credentials: { refreshToken: 'refresh-token' },
-    } as never);
-    vi.spyOn(ConnectedApplicationDAO.prototype, 'listContextEnabledApplicationIdsByUserEmail').mockResolvedValue([]);
-    vi.spyOn(OAuth2AccessTokenService, 'getAccessToken').mockResolvedValue('access-token');
-    const tryStart = vi.spyOn(ProcessedMessageDAO.prototype, 'tryStart').mockResolvedValue(true);
-    const markSkipped = vi.spyOn(ProcessedMessageDAO.prototype, 'markSkipped').mockResolvedValue();
-    const markError = vi.spyOn(ProcessedMessageDAO.prototype, 'markError').mockResolvedValue();
-    vi.spyOn(OutlookProviderUtil, 'getMessage').mockRejectedValue(
-      new Error(
-        'Microsoft Graph API error: The specified object was not found in the store., The process failed to get the correct properties.',
-      ),
-    );
+  describe('resolveApplication', () => {
+    it('classifies missing applications as non-retryable', async () => {
+      vi.spyOn(ConnectedApplicationDAO.prototype, 'getById').mockResolvedValue(undefined);
 
-    await expect(EmailProcessingUtil.processQueueMessage(createOutlookQueueMessage(), createEnv())).resolves.toBeUndefined();
+      await expect(
+        EmailProcessingUtil.resolveApplication(createOutlookQueueMessage(), createEnv()),
+      ).rejects.toThrow(NonRetryableError);
+    });
 
-    expect(tryStart).toHaveBeenCalledWith('app-1', 'microsoft-outlook', 'message-1', null, { allowExistingForRetry: false });
-    expect(markSkipped).toHaveBeenCalledWith('app-1', 'message-1', 'Outlook message was deleted before Mail-Otter could process it.');
-    expect(markError).not.toHaveBeenCalled();
+    it('classifies applications without a provider email as non-retryable', async () => {
+      vi.spyOn(ConnectedApplicationDAO.prototype, 'getById').mockResolvedValue({
+        applicationId: 'app-1',
+        userEmail: 'owner@example.com',
+        providerId: 'microsoft-outlook',
+        providerEmail: undefined,
+        credentials: { refreshToken: 'refresh-token' },
+      } as never);
+
+      await expect(
+        EmailProcessingUtil.resolveApplication(createOutlookQueueMessage(), createEnv()),
+      ).rejects.toThrow(NonRetryableError);
+    });
   });
 
-  it('allows workflow retry attempts to resume existing processed-message rows', async () => {
-    vi.spyOn(ConnectedApplicationDAO.prototype, 'getById').mockResolvedValue({
-      applicationId: 'app-1',
-      userEmail: 'owner@example.com',
-      providerId: 'microsoft-outlook',
-      providerEmail: 'owner@example.com',
-      credentials: { refreshToken: 'refresh-token' },
-    } as never);
-    vi.spyOn(ConnectedApplicationDAO.prototype, 'listContextEnabledApplicationIdsByUserEmail').mockResolvedValue([]);
-    vi.spyOn(OAuth2AccessTokenService, 'getAccessToken').mockResolvedValue('access-token');
-    const tryStart = vi.spyOn(ProcessedMessageDAO.prototype, 'tryStart').mockResolvedValue(true);
-    vi.spyOn(ProcessedMessageDAO.prototype, 'markSkipped').mockResolvedValue();
-    vi.spyOn(OutlookProviderUtil, 'getMessage').mockRejectedValue(
-      new Error(
-        'Microsoft Graph API error: The specified object was not found in the store., The process failed to get the correct properties.',
-      ),
-    );
+  describe('processOutlookMessage', () => {
+    it('marks Outlook messages as skipped when they are deleted before processing', async () => {
+      const tryStart = vi.spyOn(ProcessedMessageDAO.prototype, 'tryStart').mockResolvedValue(true);
+      const markSkipped = vi.spyOn(ProcessedMessageDAO.prototype, 'markSkipped').mockResolvedValue();
+      const markError = vi.spyOn(ProcessedMessageDAO.prototype, 'markError').mockResolvedValue();
+      vi.spyOn(OutlookProviderUtil, 'getMessage').mockRejectedValue(
+        new Error(
+          'Microsoft Graph API error: The specified object was not found in the store., The process failed to get the correct properties.',
+        ),
+      );
 
-    await expect(
-      EmailProcessingUtil.processQueueMessage(createOutlookQueueMessage(), createEnv(), { retryAttempt: 2 }),
-    ).resolves.toBeUndefined();
+      await expect(
+        EmailProcessingUtil.processOutlookMessage(createApplication(), 'access-token', 'message-1', createEnv(), []),
+      ).resolves.toBeUndefined();
 
-    expect(tryStart).toHaveBeenCalledWith('app-1', 'microsoft-outlook', 'message-1', null, { allowExistingForRetry: true });
-  });
+      expect(tryStart).toHaveBeenCalledWith('app-1', 'microsoft-outlook', 'message-1', null, { allowExistingForRetry: false });
+      expect(markSkipped).toHaveBeenCalledWith('app-1', 'message-1', 'Outlook message was deleted before Mail-Otter could process it.');
+      expect(markError).not.toHaveBeenCalled();
+    });
 
-  it('classifies missing applications as non-retryable', async () => {
-    vi.spyOn(ConnectedApplicationDAO.prototype, 'getById').mockResolvedValue(undefined);
+    it('allows workflow retry attempts to resume existing processed-message rows', async () => {
+      const tryStart = vi.spyOn(ProcessedMessageDAO.prototype, 'tryStart').mockResolvedValue(true);
+      vi.spyOn(ProcessedMessageDAO.prototype, 'markSkipped').mockResolvedValue();
+      vi.spyOn(OutlookProviderUtil, 'getMessage').mockRejectedValue(
+        new Error(
+          'Microsoft Graph API error: The specified object was not found in the store., The process failed to get the correct properties.',
+        ),
+      );
 
-    await expect(EmailProcessingUtil.processQueueMessage(createOutlookQueueMessage(), createEnv())).rejects.toThrow(NonRetryableError);
-  });
+      await expect(
+        EmailProcessingUtil.processOutlookMessage(createApplication(), 'access-token', 'message-1', createEnv(), [], { retryAttempt: 2 }),
+      ).resolves.toBeUndefined();
 
-  it('classifies unexpected processing failures as retryable and records the error', async () => {
-    vi.spyOn(ConnectedApplicationDAO.prototype, 'getById').mockResolvedValue({
-      applicationId: 'app-1',
-      userEmail: 'owner@example.com',
-      providerId: 'microsoft-outlook',
-      providerEmail: 'owner@example.com',
-      credentials: { refreshToken: 'refresh-token' },
-    } as never);
-    vi.spyOn(ConnectedApplicationDAO.prototype, 'listContextEnabledApplicationIdsByUserEmail').mockResolvedValue([]);
-    vi.spyOn(OAuth2AccessTokenService, 'getAccessToken').mockResolvedValue('access-token');
-    vi.spyOn(ProcessedMessageDAO.prototype, 'tryStart').mockResolvedValue(true);
-    const markError = vi.spyOn(ProcessedMessageDAO.prototype, 'markError').mockResolvedValue();
-    vi.spyOn(OutlookProviderUtil, 'getMessage').mockRejectedValue(new Error('Temporary Graph failure.'));
+      expect(tryStart).toHaveBeenCalledWith('app-1', 'microsoft-outlook', 'message-1', null, { allowExistingForRetry: true });
+    });
 
-    await expect(EmailProcessingUtil.processQueueMessage(createOutlookQueueMessage(), createEnv())).rejects.toThrow(RetryableError);
+    it('classifies unexpected processing failures as retryable and records the error', async () => {
+      vi.spyOn(ProcessedMessageDAO.prototype, 'tryStart').mockResolvedValue(true);
+      const markError = vi.spyOn(ProcessedMessageDAO.prototype, 'markError').mockResolvedValue();
+      vi.spyOn(OutlookProviderUtil, 'getMessage').mockRejectedValue(new Error('Temporary Graph failure.'));
 
-    expect(markError).toHaveBeenCalledWith('app-1', 'message-1', 'Temporary Graph failure.');
+      await expect(
+        EmailProcessingUtil.processOutlookMessage(createApplication(), 'access-token', 'message-1', createEnv(), []),
+      ).rejects.toThrow(RetryableError);
+
+      expect(markError).toHaveBeenCalledWith('app-1', 'message-1', 'Temporary Graph failure.');
+    });
   });
 });
+
+function createApplication() {
+  return {
+    applicationId: 'app-1',
+    userEmail: 'owner@example.com',
+    providerId: 'microsoft-outlook',
+    providerEmail: 'owner@example.com',
+    credentials: { refreshToken: 'refresh-token' },
+  } as never;
+}
 
 function createOutlookQueueMessage() {
   return {

--- a/test/utils/EmailProcessingUtil.test.ts
+++ b/test/utils/EmailProcessingUtil.test.ts
@@ -2,7 +2,6 @@ import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { EmailProcessingUtil } from '@mail-otter/backend-services/email';
 import type { EmailProcessingEnv } from '@mail-otter/backend-services/email';
 import { ConnectedApplicationDAO, ProcessedMessageDAO } from '@mail-otter/backend-data/dao';
-import { OAuth2AccessTokenService } from '@mail-otter/backend-services/oauth2';
 import { OutlookProviderUtil } from '@mail-otter/provider-clients/outlook';
 import { NonRetryableError, RetryableError } from '@mail-otter/backend-errors';
 

--- a/test/workers/EmailProcessingWorkflow.test.ts
+++ b/test/workers/EmailProcessingWorkflow.test.ts
@@ -10,7 +10,8 @@ vi.mock('@mail-otter/backend-services/email', async (importOriginal) => {
     ...actual,
     EmailProcessingUtil: {
       ...actual.EmailProcessingUtil,
-      processQueueMessage: vi.fn(),
+      resolveApplication: vi.fn(),
+      processOutlookMessage: vi.fn(),
     },
   };
 });
@@ -18,32 +19,53 @@ vi.mock('@mail-otter/backend-services/email', async (importOriginal) => {
 import { EmailProcessingWorkflow } from '@mail-otter/background';
 import { EmailProcessingUtil } from '@mail-otter/backend-services/email';
 
+const resolvedApplication = {
+  application: {
+    applicationId: 'app-1',
+    userEmail: 'owner@example.com',
+    providerId: 'microsoft-outlook',
+    providerEmail: 'owner@example.com',
+    credentials: { refreshToken: 'refresh-token' },
+  },
+  accessToken: 'access-token',
+  enabledApplicationIds: [],
+};
+
 describe('EmailProcessingWorkflow', () => {
   beforeEach(() => {
     vi.restoreAllMocks();
   });
 
   it('passes the workflow retry attempt into email processing', async () => {
-    vi.mocked(EmailProcessingUtil.processQueueMessage).mockResolvedValue();
+    vi.mocked(EmailProcessingUtil.resolveApplication).mockResolvedValue(resolvedApplication as never);
+    vi.mocked(EmailProcessingUtil.processOutlookMessage).mockResolvedValue();
     const workflow = new EmailProcessingWorkflow({} as ExecutionContext, {} as Env);
     const step = createStep(3);
     const event = createEvent();
 
     await workflow.run(event, step);
 
-    expect(EmailProcessingUtil.processQueueMessage).toHaveBeenCalledWith(event.payload, {}, { retryAttempt: 3 });
+    expect(EmailProcessingUtil.processOutlookMessage).toHaveBeenCalledWith(
+      resolvedApplication.application,
+      resolvedApplication.accessToken,
+      'message-1',
+      {},
+      resolvedApplication.enabledApplicationIds,
+      { retryAttempt: 3 },
+    );
   });
 
   it('leaves retryable errors retryable for the workflow step policy', async () => {
+    vi.mocked(EmailProcessingUtil.resolveApplication).mockResolvedValue(resolvedApplication as never);
     const error = new RetryableError('Temporary provider failure.');
-    vi.mocked(EmailProcessingUtil.processQueueMessage).mockRejectedValue(error);
+    vi.mocked(EmailProcessingUtil.processOutlookMessage).mockRejectedValue(error);
     const workflow = new EmailProcessingWorkflow({} as ExecutionContext, {} as Env);
 
     await expect(workflow.run(createEvent(), createStep(1))).rejects.toBe(error);
   });
 
   it('converts non-retryable errors into Cloudflare workflow fatal errors', async () => {
-    vi.mocked(EmailProcessingUtil.processQueueMessage).mockRejectedValue(new NonRetryableError('Application is not connected.'));
+    vi.mocked(EmailProcessingUtil.resolveApplication).mockRejectedValue(new NonRetryableError('Application is not connected.'));
     const workflow = new EmailProcessingWorkflow({} as ExecutionContext, {} as Env);
 
     await expect(workflow.run(createEvent(), createStep(1))).rejects.toThrow(WorkflowNonRetryableError);
@@ -76,7 +98,7 @@ function createStep(attempt: number): WorkflowStep {
           attempt,
           config: typeof configOrCallback === 'function' ? {} : configOrCallback,
           step: {
-            name: 'process email event',
+            name: _name,
             count: attempt,
           },
         });


### PR DESCRIPTION
Split the single `process email event` step into granular named steps so Cloudflare Workflows can checkpoint each stage independently. A failure in summarization or sending no longer re-runs app validation, token refresh, or already-succeeded messages.

New step structure:
- "Resolve Application" — validate app, fetch OAuth token, list enabled apps
- "List Gmail Messages" — check subscription, list message IDs from history
- "Summarize Gmail Message {id}" — per-message: fetch, dedup, RAG, summarize, send, mark done
- "Update Gmail History" — persist new historyId after all messages processed
- "Summarize Outlook Message" — single-message equivalent of the Gmail per-message step

`EmailProcessingUtil` gains three new public methods (`resolveApplication`, `listGmailMessages`, `updateGmailHistory`) and promotes `processGmailMessage` and `processOutlookMessage` from private to public. The old `processQueueMessage` convenience wrapper is removed.