### PR TITLE
Dispatch Repository Event After Upstream Sync To Trigger CI

### DIFF
--- a/.github/workflows/upstream-sync.yml
+++ b/.github/workflows/upstream-sync.yml
@@ -25,3 +25,14 @@ jobs:
           target_sync_branch: main
           target_repo_token: ${{ secrets.GITHUB_TOKEN }}
           test_mode: false
+
+      - name: Trigger CI for synced commits
+        if: steps.sync.outputs.has_new_commits == 'true'
+        uses: actions/github-script@v7
+        with:
+          script: |
+            await github.rest.repos.createDispatchEvent({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              event_type: 'upstream-sync',
+            });


### PR DESCRIPTION
Pushes made via GITHUB_TOKEN do not fire the `push` event for other workflows (GitHub's loop-prevention restriction), so CI — and therefore CD — never ran after an upstream sync.

`continuous-integration.yml` already had a `repository_dispatch` trigger typed `upstream-sync` for exactly this purpose; this commit wires it up by adding a post-sync step that dispatches the event, guarded by the action's `has_new_commits` output so no unnecessary CI run is created when there is nothing new to sync.