### PR TITLE
Add Watched Folder Selection

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -51,6 +51,7 @@ volta run pnpm run typecheck
 volta run pnpm run test
 volta run pnpm run build
 volta run pnpm run lint
+volta run pnpm run checks
 volta run pnpm run deploy
 volta run pnpm run cf-typegen
 ```

--- a/apps/api/src/endpoints/index.ts
+++ b/apps/api/src/endpoints/index.ts
@@ -10,6 +10,8 @@ import { DeleteApplicationContextDocumentsRoute as OriginalDeleteApplicationCont
 import { ListApplicationContextDocumentsRoute as OriginalListApplicationContextDocumentsRoute } from './user/application/context/documents/GET';
 import { ListApplicationContextDeletionRunsRoute as OriginalListApplicationContextDeletionRunsRoute } from './user/application/context/deletions/GET';
 import { GetApplicationContextDocumentProviderLinkRoute as OriginalGetApplicationContextDocumentProviderLinkRoute } from './user/application/context/document/provider-link/GET';
+import { GetApplicationFoldersRoute as OriginalGetApplicationFoldersRoute } from './user/application/folders/GET';
+import { UpdateApplicationWatchSettingsRoute as OriginalUpdateApplicationWatchSettingsRoute } from './user/application/watch-settings/PUT';
 import { CreateOAuth2AuthorizationRoute as OriginalCreateOAuth2AuthorizationRoute } from './user/application/oauth2/authorize/POST';
 import { StartApplicationWatchRoute as OriginalStartApplicationWatchRoute } from './user/application/watch/POST';
 import { StopApplicationWatchRoute as OriginalStopApplicationWatchRoute } from './user/application/stop/POST';
@@ -28,6 +30,8 @@ export const DeleteApplicationContextDocumentsRoute: any = OriginalDeleteApplica
 export const ListApplicationContextDocumentsRoute: any = OriginalListApplicationContextDocumentsRoute;
 export const ListApplicationContextDeletionRunsRoute: any = OriginalListApplicationContextDeletionRunsRoute;
 export const GetApplicationContextDocumentProviderLinkRoute: any = OriginalGetApplicationContextDocumentProviderLinkRoute;
+export const GetApplicationFoldersRoute: any = OriginalGetApplicationFoldersRoute;
+export const UpdateApplicationWatchSettingsRoute: any = OriginalUpdateApplicationWatchSettingsRoute;
 export const CreateOAuth2AuthorizationRoute: any = OriginalCreateOAuth2AuthorizationRoute;
 export const StartApplicationWatchRoute: any = OriginalStartApplicationWatchRoute;
 export const StopApplicationWatchRoute: any = OriginalStopApplicationWatchRoute;

--- a/apps/api/src/endpoints/user/application/folders/GET.ts
+++ b/apps/api/src/endpoints/user/application/folders/GET.ts
@@ -1,0 +1,40 @@
+import { IUserRoute } from '@/endpoints/IUserRoute';
+import type { IUserEnv, IRequest, IResponse, RouteContext } from '@/endpoints/IUserRoute';
+import { FolderService } from '@mail-otter/backend-services/application';
+import type { ProviderFolder } from '@mail-otter/backend-services/application';
+
+class GetApplicationFoldersRoute extends IUserRoute<GetApplicationFoldersRequest, GetApplicationFoldersResponse, GetApplicationFoldersEnv> {
+  schema = {
+    tags: ['Applications'],
+    summary: 'List available folders/labels from the connected provider',
+    responses: {
+      '200': {
+        description: 'Provider folders',
+      },
+    },
+  };
+
+  protected async handleRequest(
+    request: GetApplicationFoldersRequest,
+    env: GetApplicationFoldersEnv,
+    cxt: RouteContext<GetApplicationFoldersEnv>,
+  ): Promise<GetApplicationFoldersResponse> {
+    const applicationId = new URL(request.raw.url).searchParams.get('applicationId') || '';
+    const folders = await FolderService.listFolders(this.getAuthenticatedUserEmailAddress(cxt), applicationId, env);
+    return { folders };
+  }
+}
+
+type GetApplicationFoldersRequest = IRequest;
+
+interface GetApplicationFoldersResponse extends IResponse {
+  folders: ProviderFolder[];
+}
+
+interface GetApplicationFoldersEnv extends IUserEnv {
+  OAUTH2_TOKEN_CACHE: KVNamespace;
+  OAUTH2_TOKEN_REFRESHERS: DurableObjectNamespace;
+  OAUTH2_ACCESS_TOKEN_MIN_VALID_SECONDS?: string | undefined;
+}
+
+export { GetApplicationFoldersRoute };

--- a/apps/api/src/endpoints/user/application/watch-settings/PUT.ts
+++ b/apps/api/src/endpoints/user/application/watch-settings/PUT.ts
@@ -1,0 +1,43 @@
+import { IUserRoute } from '@/endpoints/IUserRoute';
+import type { IUserEnv, IRequest, IResponse, RouteContext } from '@/endpoints/IUserRoute';
+import { ApplicationService } from '@mail-otter/backend-services/application';
+import type { ApplicationResponse } from '@mail-otter/backend-services/application';
+
+class UpdateApplicationWatchSettingsRoute extends IUserRoute<
+  UpdateApplicationWatchSettingsRequest,
+  UpdateApplicationWatchSettingsResponse,
+  UpdateApplicationWatchSettingsEnv
+> {
+  schema = {
+    tags: ['Applications'],
+    summary: 'Update watched folder IDs for a connected application',
+    responses: {
+      '200': {
+        description: 'Application watch settings updated',
+      },
+    },
+  };
+
+  protected async handleRequest(
+    request: UpdateApplicationWatchSettingsRequest,
+    env: UpdateApplicationWatchSettingsEnv,
+    cxt: RouteContext<UpdateApplicationWatchSettingsEnv>,
+  ): Promise<UpdateApplicationWatchSettingsResponse> {
+    return {
+      application: await ApplicationService.updateWatchedFolderIds(this.getAuthenticatedUserEmailAddress(cxt), request, env, request.raw),
+    };
+  }
+}
+
+interface UpdateApplicationWatchSettingsRequest extends IRequest {
+  applicationId: string;
+  folderIds: string[] | null;
+}
+
+interface UpdateApplicationWatchSettingsResponse extends IResponse {
+  application: ApplicationResponse;
+}
+
+type UpdateApplicationWatchSettingsEnv = IUserEnv;
+
+export { UpdateApplicationWatchSettingsRoute };

--- a/apps/api/src/workers/MailOtterWorker.ts
+++ b/apps/api/src/workers/MailOtterWorker.ts
@@ -8,6 +8,7 @@ import {
   DeleteApplicationContextDocumentsRoute,
   GetCurrentUserRoute,
   GetApplicationContextDocumentProviderLinkRoute,
+  GetApplicationFoldersRoute,
   GmailWebhookRoute,
   ListApplicationContextDeletionRunsRoute,
   ListApplicationContextDocumentsRoute,
@@ -19,6 +20,7 @@ import {
   StopApplicationWatchRoute,
   UpdateApplicationContextRoute,
   UpdateApplicationRoute,
+  UpdateApplicationWatchSettingsRoute,
 } from '@/endpoints';
 import { MiddlewareHandlers } from '@/middleware';
 import { SPA_HTML } from '@/generated/spa-shell';
@@ -76,6 +78,8 @@ class MailOtterWorker extends AbstractEntrypointWorker {
     openapi.get('/user/application/context/documents', ListApplicationContextDocumentsRoute);
     openapi.get('/user/application/context/deletions', ListApplicationContextDeletionRunsRoute);
     openapi.get('/user/application/context/document/:contextDocumentId/provider-link', GetApplicationContextDocumentProviderLinkRoute);
+    openapi.get('/user/application/folders', GetApplicationFoldersRoute);
+    openapi.put('/user/application/watch-settings', UpdateApplicationWatchSettingsRoute);
     openapi.post('/user/application/oauth2/authorize', CreateOAuth2AuthorizationRoute);
     openapi.post('/user/application/watch', StartApplicationWatchRoute);
     openapi.post('/user/application/stop', StopApplicationWatchRoute);

--- a/apps/web/components/types.ts
+++ b/apps/web/components/types.ts
@@ -16,6 +16,7 @@ export interface ConnectedApplication {
   connectionMethod: 'oauth2';
   status: 'draft' | 'connected' | 'error';
   gmailPubsubTopicName?: string | null;
+  watchedFolderIds?: string[] | null;
   oauth2RedirectUri?: string;
   webhookUrl?: string;
   watchStatus?: 'active' | 'stopped' | 'error';

--- a/apps/web/src/SpaApp.tsx
+++ b/apps/web/src/SpaApp.tsx
@@ -54,6 +54,8 @@ export default function SpaApp() {
   const [contextDeletionRuns, setContextDeletionRuns] = useState<ApplicationContextDeletionRun[]>([]);
   const [contextDeletionRunsCursor, setContextDeletionRunsCursor] = useState<string | undefined>();
   const [confirmDelete, setConfirmDelete] = useState<{ applicationId: string; displayName: string } | null>(null);
+  const [availableFolders, setAvailableFolders] = useState<Array<{ id: string; name: string }> | null>(null);
+  const [loadingFolders, setLoadingFolders] = useState(false);
 
   useEffect(() => {
     if (!confirmDelete) return;
@@ -67,6 +69,11 @@ export default function SpaApp() {
       window.removeEventListener('resize', close);
     };
   }, [confirmDelete]);
+
+  useEffect(() => {
+    setAvailableFolders(null);
+    setLoadingFolders(false);
+  }, [selectedApplicationId]);
 
   const selectedApplication = useMemo(
     () => applications.find((application) => application.applicationId === selectedApplicationId),
@@ -273,6 +280,40 @@ export default function SpaApp() {
       if (activeView === 'context') await loadContextAudit();
     } catch (error) {
       showNotice('error', error instanceof Error ? error.message : 'Unable to update context setting.');
+    } finally {
+      setIsBusy(false);
+    }
+  };
+
+  const loadFolders = async (applicationId: string) => {
+    setLoadingFolders(true);
+    try {
+      const data = await readJson<{ folders: Array<{ id: string; name: string }> }>(
+        await fetch(`/user/application/folders?applicationId=${encodeURIComponent(applicationId)}`),
+      );
+      setAvailableFolders(data.folders);
+    } catch (error) {
+      showNotice('error', error instanceof Error ? error.message : 'Unable to load folders.');
+    } finally {
+      setLoadingFolders(false);
+    }
+  };
+
+  const updateWatchedFolderIds = async (applicationId: string, folderIds: string[] | null) => {
+    setIsBusy(true);
+    try {
+      const data = await readJson<{ application: ConnectedApplication }>(
+        await fetch('/user/application/watch-settings', {
+          method: 'PUT',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({ applicationId, folderIds }),
+        }),
+      );
+      setApplications((current) =>
+        current.map((application) => (application.applicationId === data.application.applicationId ? data.application : application)),
+      );
+    } catch (error) {
+      showNotice('error', error instanceof Error ? error.message : 'Unable to update watch folders.');
     } finally {
       setIsBusy(false);
     }
@@ -566,6 +607,57 @@ export default function SpaApp() {
                       Delete Indexed Documents
                     </button>
                   </div>
+                </div>
+
+                <div className="rounded-md border border-[#2d3745] bg-[#171c25] p-5">
+                  <div className="flex flex-col md:flex-row md:items-center justify-between gap-4 mb-4">
+                    <h2 className="text-xl font-semibold">Watch Folders</h2>
+                    <button
+                      className="px-3 py-1.5 rounded-md bg-[#2d3745] hover:bg-[#3b4655] text-sm disabled:opacity-50"
+                      onClick={() => loadFolders(selectedApplication.applicationId)}
+                      disabled={isBusy || loadingFolders || selectedApplication.status !== 'connected'}
+                    >
+                      {loadingFolders ? 'Loading…' : 'Load Folders'}
+                    </button>
+                  </div>
+                  {availableFolders ? (
+                    availableFolders.length === 0 ? (
+                      <p className="text-sm text-[#aab4c2]">No folders found.</p>
+                    ) : (
+                      <div className="flex flex-col gap-2">
+                        {availableFolders.map((folder) => {
+                          const isOutlook = selectedApplication.providerId === 'microsoft-outlook';
+                          const checked = selectedApplication.watchedFolderIds?.includes(folder.id) ?? false;
+                          return (
+                            <label key={folder.id} className="inline-flex items-center gap-3 text-sm text-[#d1d5db]">
+                              <input
+                                type={isOutlook ? 'radio' : 'checkbox'}
+                                name={isOutlook ? `watch-folder-${selectedApplication.applicationId}` : undefined}
+                                checked={checked}
+                                onChange={() => {
+                                  const next = isOutlook
+                                    ? checked ? [] : [folder.id]
+                                    : checked
+                                      ? (selectedApplication.watchedFolderIds || []).filter((id) => id !== folder.id)
+                                      : [...(selectedApplication.watchedFolderIds || []), folder.id];
+                                  updateWatchedFolderIds(selectedApplication.applicationId, next.length > 0 ? next : null);
+                                }}
+                                disabled={isBusy}
+                                className="h-4 w-4 accent-[#0d9488]"
+                              />
+                              {folder.name}
+                            </label>
+                          );
+                        })}
+                      </div>
+                    )
+                  ) : selectedApplication.watchedFolderIds && selectedApplication.watchedFolderIds.length > 0 ? (
+                    <p className="text-sm text-[#aab4c2]">
+                      Watching: {selectedApplication.watchedFolderIds.join(', ')} — click &quot;Load Folders&quot; to change.
+                    </p>
+                  ) : (
+                    <p className="text-sm text-[#aab4c2]">Watching default folder (Inbox). Click &quot;Load Folders&quot; to customize.</p>
+                  )}
                 </div>
               </>
             ) : (

--- a/migrations/0007_watched_folder_ids.sql
+++ b/migrations/0007_watched_folder_ids.sql
@@ -1,0 +1,1 @@
+ALTER TABLE connected_applications ADD COLUMN watched_folder_ids TEXT;

--- a/packages/backend-data/src/dao/ConnectedApplicationDAO.ts
+++ b/packages/backend-data/src/dao/ConnectedApplicationDAO.ts
@@ -74,7 +74,7 @@ class ConnectedApplicationDAO {
     const rows: ConnectedApplicationInternal[] = await this.database
       .prepare(
         `
-          SELECT application_id, user_email, provider_email, display_name, provider_id, connection_method, encrypted_credentials, credentials_iv, status, context_indexing_enabled, gmail_pubsub_topic_name, created_at, updated_at
+          SELECT application_id, user_email, provider_email, display_name, provider_id, connection_method, encrypted_credentials, credentials_iv, status, context_indexing_enabled, gmail_pubsub_topic_name, watched_folder_ids, created_at, updated_at
           FROM connected_applications
           WHERE user_email = ?
           ORDER BY updated_at DESC, created_at DESC
@@ -227,6 +227,28 @@ class ConnectedApplicationDAO {
     return this.getMetadataByIdForUser(applicationId, userEmail);
   }
 
+  public async updateWatchedFolderIdsForUser(
+    applicationId: string,
+    userEmail: string,
+    folderIds: string[] | null,
+  ): Promise<ConnectedApplicationMetadata | undefined> {
+    const now: number = TimestampUtil.getCurrentUnixTimestampInSeconds();
+    const result: D1Result = await this.database
+      .prepare(
+        `
+          UPDATE connected_applications
+          SET watched_folder_ids = ?, updated_at = ?
+          WHERE application_id = ? AND user_email = ?
+        `,
+      )
+      .bind(folderIds ? JSON.stringify(folderIds) : null, now, applicationId, userEmail)
+      .run();
+    if (!result.success) {
+      throw new DatabaseError(`Failed to update watched folder IDs: ${result.error}`);
+    }
+    return this.getMetadataByIdForUser(applicationId, userEmail);
+  }
+
   public async deleteForUser(applicationId: string, userEmail: string): Promise<void> {
     const result: D1Result = await this.database
       .prepare('DELETE FROM connected_applications WHERE application_id = ? AND user_email = ?')
@@ -243,7 +265,7 @@ class ConnectedApplicationDAO {
     const row: ConnectedApplicationInternal | null = await this.database
       .prepare(
         `
-          SELECT application_id, user_email, provider_email, display_name, provider_id, connection_method, encrypted_credentials, credentials_iv, status, context_indexing_enabled, gmail_pubsub_topic_name, created_at, updated_at
+          SELECT application_id, user_email, provider_email, display_name, provider_id, connection_method, encrypted_credentials, credentials_iv, status, context_indexing_enabled, gmail_pubsub_topic_name, watched_folder_ids, created_at, updated_at
           FROM connected_applications
           WHERE application_id = ?${whereUser}
           LIMIT 1
@@ -279,6 +301,7 @@ class ConnectedApplicationDAO {
       status,
       contextIndexingEnabled: row.context_indexing_enabled !== 0,
       gmailPubsubTopicName: row.gmail_pubsub_topic_name,
+      watchedFolderIds: row.watched_folder_ids ? (JSON.parse(row.watched_folder_ids) as string[]) : null,
       createdAt: row.created_at,
       updatedAt: row.updated_at,
     };

--- a/packages/backend-services/src/application/ApplicationService.ts
+++ b/packages/backend-services/src/application/ApplicationService.ts
@@ -85,6 +85,24 @@ class ApplicationService {
     return ApplicationResponseUtil.decorateApplication(application, env, raw);
   }
 
+  public static async updateWatchedFolderIds(
+    userEmail: string,
+    input: UpdateWatchedFolderIdsInput,
+    env: ApplicationServiceEnv,
+    raw: Request,
+  ): Promise<ApplicationResponse> {
+    const applicationDAO: ConnectedApplicationDAO = await ApplicationService.createApplicationDAO(env);
+    const application: ConnectedApplicationMetadata | undefined = await applicationDAO.updateWatchedFolderIdsForUser(
+      input.applicationId,
+      userEmail,
+      input.folderIds,
+    );
+    if (!application) {
+      throw new BadRequestError('Connected application was not found.');
+    }
+    return ApplicationResponseUtil.decorateApplication(application, env, raw);
+  }
+
   public static async deleteUserApplication(userEmail: string, applicationId: string, env: DeleteUserApplicationEnv): Promise<void> {
     const masterKey: string = await env.AES_ENCRYPTION_KEY_SECRET.get();
     const applicationDAO = new ConnectedApplicationDAO(env.DB, masterKey);
@@ -130,5 +148,16 @@ interface DeleteUserApplicationEnv extends ApplicationServiceEnv {
   OAUTH2_TOKEN_CACHE: KVNamespace;
 }
 
+interface UpdateWatchedFolderIdsInput {
+  applicationId: string;
+  folderIds: string[] | null;
+}
+
 export { ApplicationService };
-export type { ApplicationServiceEnv, CreateUserApplicationInput, DeleteUserApplicationEnv, UpdateUserApplicationInput };
+export type {
+  ApplicationServiceEnv,
+  CreateUserApplicationInput,
+  DeleteUserApplicationEnv,
+  UpdateUserApplicationInput,
+  UpdateWatchedFolderIdsInput,
+};

--- a/packages/backend-services/src/application/FolderService.ts
+++ b/packages/backend-services/src/application/FolderService.ts
@@ -1,0 +1,44 @@
+import { PROVIDER_GOOGLE_GMAIL, PROVIDER_MICROSOFT_OUTLOOK } from '@mail-otter/shared/constants';
+import { ConnectedApplicationDAO } from '@mail-otter/backend-data/dao';
+import { BadRequestError } from '@mail-otter/backend-errors';
+import type { ConnectedApplication } from '@mail-otter/shared/model';
+import { GmailProviderUtil } from '@mail-otter/provider-clients/gmail';
+import { OutlookProviderUtil } from '@mail-otter/provider-clients/outlook';
+import { OAuth2AccessTokenService } from '../oauth2/OAuth2AccessTokenService';
+
+interface ProviderFolder {
+  id: string;
+  name: string;
+}
+
+class FolderService {
+  public static async listFolders(userEmail: string, applicationId: string, env: FolderServiceEnv): Promise<ProviderFolder[]> {
+    const masterKey: string = await env.AES_ENCRYPTION_KEY_SECRET.get();
+    const applicationDAO = new ConnectedApplicationDAO(env.DB, masterKey);
+    const application: ConnectedApplication | undefined = await applicationDAO.getByIdForUser(applicationId, userEmail);
+    if (!application) {
+      throw new BadRequestError('Connected application was not found.');
+    }
+    const accessToken: string = await OAuth2AccessTokenService.getAccessToken(application.applicationId, env);
+    if (application.providerId === PROVIDER_GOOGLE_GMAIL) {
+      const labels = await GmailProviderUtil.listLabels(accessToken);
+      return labels.map((label) => ({ id: label.id, name: label.name }));
+    }
+    if (application.providerId === PROVIDER_MICROSOFT_OUTLOOK) {
+      const folders = await OutlookProviderUtil.listMailFolders(accessToken);
+      return folders.map((folder) => ({ id: folder.id, name: folder.displayName }));
+    }
+    throw new BadRequestError('Unsupported provider.');
+  }
+}
+
+interface FolderServiceEnv {
+  DB: D1Database;
+  AES_ENCRYPTION_KEY_SECRET: SecretsStoreSecret;
+  OAUTH2_TOKEN_CACHE: KVNamespace;
+  OAUTH2_TOKEN_REFRESHERS: DurableObjectNamespace;
+  OAUTH2_ACCESS_TOKEN_MIN_VALID_SECONDS?: string | undefined;
+}
+
+export { FolderService };
+export type { FolderServiceEnv, ProviderFolder };

--- a/packages/backend-services/src/application/index.ts
+++ b/packages/backend-services/src/application/index.ts
@@ -1,2 +1,3 @@
 export * from './ApplicationService';
 export * from './ApplicationResponseUtil';
+export * from './FolderService';

--- a/packages/backend-services/src/email/EmailProcessingUtil.ts
+++ b/packages/backend-services/src/email/EmailProcessingUtil.ts
@@ -38,7 +38,7 @@ class EmailProcessingUtil {
     const subscription: ProviderSubscription | undefined = await subscriptionDAO.getByApplication(application.applicationId);
     if (!subscription || subscription.status !== PROVIDER_SUBSCRIPTION_STATUS_ACTIVE) return null;
     const startHistoryId: string | undefined = subscription.gmailHistoryId || notificationHistoryId;
-    const history = await GmailProviderUtil.listMessageIdsSince(accessToken, startHistoryId);
+    const history = await GmailProviderUtil.listMessageIdsSince(accessToken, startHistoryId, application.watchedFolderIds ?? undefined);
     return { messageIds: history.messageIds, historyId: history.historyId || notificationHistoryId, subscriptionId: subscription.subscriptionId };
   }
 

--- a/packages/backend-services/src/subscription/SubscriptionRenewalUtil.ts
+++ b/packages/backend-services/src/subscription/SubscriptionRenewalUtil.ts
@@ -52,7 +52,7 @@ class SubscriptionRenewalUtil {
     const application: ConnectedApplication | undefined = await applicationDAO.getById(subscription.applicationId);
     if (!application || !application.gmailPubsubTopicName) return;
     const accessToken: string = await OAuth2AccessTokenService.getAccessToken(application.applicationId, _env);
-    const watch = await GmailProviderUtil.watchInbox(accessToken, application.gmailPubsubTopicName);
+    const watch = await GmailProviderUtil.watchInbox(accessToken, application.gmailPubsubTopicName, application.watchedFolderIds ?? undefined);
     await subscriptionDAO.upsertActive({
       applicationId: application.applicationId,
       providerId: application.providerId,

--- a/packages/backend-services/src/subscription/WatchService.ts
+++ b/packages/backend-services/src/subscription/WatchService.ts
@@ -70,7 +70,7 @@ class WatchService {
       throw new BadRequestError('Gmail Pub/Sub topic name is required before starting Gmail watch.');
     }
     const webhookSecret: string = WebhookSecurityUtil.generateSecret();
-    const watch = await GmailProviderUtil.watchInbox(accessToken, application.gmailPubsubTopicName);
+    const watch = await GmailProviderUtil.watchInbox(accessToken, application.gmailPubsubTopicName, application.watchedFolderIds ?? undefined);
     const subscription: ProviderSubscription = await subscriptionDAO.upsertActive({
       applicationId: application.applicationId,
       providerId: application.providerId,
@@ -105,6 +105,7 @@ class WatchService {
       lifecycleNotificationUrl,
       clientState,
       expiresAt,
+      application.watchedFolderIds?.[0] ?? undefined,
     );
     const subscription: ProviderSubscription = await subscriptionDAO.upsertActive({
       applicationId: application.applicationId,

--- a/packages/provider-clients/src/GmailProviderUtil.ts
+++ b/packages/provider-clients/src/GmailProviderUtil.ts
@@ -24,12 +24,26 @@ interface GmailProfile {
   emailAddress: string;
 }
 
+interface GmailLabel {
+  id: string;
+  name: string;
+  type: string;
+}
+
 class GmailProviderUtil {
   public static async getProfile(accessToken: string): Promise<GmailProfile> {
     return GmailProviderUtil.fetchJson<GmailProfile>('https://gmail.googleapis.com/gmail/v1/users/me/profile', accessToken);
   }
 
-  public static async watchInbox(accessToken: string, topicName: string): Promise<GmailWatchResult> {
+  public static async listLabels(accessToken: string): Promise<GmailLabel[]> {
+    const data = await GmailProviderUtil.fetchJson<{ labels?: GmailLabel[] | undefined }>(
+      'https://gmail.googleapis.com/gmail/v1/users/me/labels',
+      accessToken,
+    );
+    return (data.labels || []).sort((a, b) => a.name.localeCompare(b.name));
+  }
+
+  public static async watchInbox(accessToken: string, topicName: string, labelIds?: string[]): Promise<GmailWatchResult> {
     const response = await fetch('https://gmail.googleapis.com/gmail/v1/users/me/watch', {
       method: 'POST',
       headers: {
@@ -38,7 +52,7 @@ class GmailProviderUtil {
       },
       body: JSON.stringify({
         topicName,
-        labelIds: ['INBOX'],
+        labelIds: labelIds && labelIds.length > 0 ? labelIds : ['INBOX'],
         labelFilterBehavior: 'INCLUDE',
       }),
     });
@@ -62,15 +76,16 @@ class GmailProviderUtil {
     }
   }
 
-  public static async listMessageIdsSince(accessToken: string, startHistoryId: string): Promise<GmailHistoryResult> {
+  public static async listMessageIdsSince(accessToken: string, startHistoryId: string, labelIds?: string[]): Promise<GmailHistoryResult> {
     const messageIds: Set<string> = new Set<string>();
     let pageToken: string | undefined;
     let currentHistoryId = startHistoryId;
+    const singleLabelId: string = labelIds && labelIds.length === 1 ? labelIds[0] : ((!labelIds || labelIds.length === 0) ? 'INBOX' : '');
     do {
       const url: URL = new URL('https://gmail.googleapis.com/gmail/v1/users/me/history');
       url.searchParams.set('startHistoryId', startHistoryId);
       url.searchParams.set('historyTypes', 'messageAdded');
-      url.searchParams.set('labelId', 'INBOX');
+      if (singleLabelId) url.searchParams.set('labelId', singleLabelId);
       url.searchParams.set('maxResults', '500');
       if (pageToken) url.searchParams.set('pageToken', pageToken);
       const data = await GmailProviderUtil.fetchJson<GmailHistoryListResponse>(url.toString(), accessToken);
@@ -180,4 +195,4 @@ interface GmailHistoryListResponse {
 }
 
 export { GmailProviderUtil };
-export type { GmailHistoryResult, GmailMessage, GmailProfile, GmailWatchResult };
+export type { GmailHistoryResult, GmailLabel, GmailMessage, GmailProfile, GmailWatchResult };

--- a/packages/provider-clients/src/OutlookProviderUtil.ts
+++ b/packages/provider-clients/src/OutlookProviderUtil.ts
@@ -5,6 +5,11 @@ interface OutlookMailboxProfile {
   emailAddress: string;
 }
 
+interface OutlookMailFolder {
+  id: string;
+  displayName: string;
+}
+
 interface OutlookSubscriptionResult {
   id: string;
   expiresAt: number;
@@ -28,6 +33,14 @@ class OutlookProviderUtil {
     /erroritemnotfound/i,
   ];
 
+  public static async listMailFolders(accessToken: string): Promise<OutlookMailFolder[]> {
+    const data = await OutlookProviderUtil.fetchJson<{ value?: OutlookMailFolder[] | undefined }>(
+      'https://graph.microsoft.com/v1.0/me/mailFolders?$select=id,displayName&$top=100',
+      accessToken,
+    );
+    return data.value || [];
+  }
+
   public static async getProfile(accessToken: string): Promise<OutlookMailboxProfile> {
     const data = await OutlookProviderUtil.fetchJson<{
       mail?: string | null | undefined;
@@ -44,8 +57,9 @@ class OutlookProviderUtil {
     lifecycleNotificationUrl: string,
     clientState: string,
     expiresAt: number,
+    folderId?: string,
   ): Promise<OutlookSubscriptionResult> {
-    const resource = "/me/mailFolders('Inbox')/messages";
+    const resource = `/me/mailFolders('${folderId ?? 'Inbox'}')/messages`;
     const data = await OutlookProviderUtil.fetchJson<{
       id?: string | undefined;
       expirationDateTime?: string | undefined;
@@ -212,4 +226,4 @@ class OutlookProviderUtil {
 }
 
 export { OutlookProviderUtil };
-export type { OutlookMailboxProfile, OutlookMessage, OutlookSubscriptionResult };
+export type { OutlookMailboxProfile, OutlookMailFolder, OutlookMessage, OutlookSubscriptionResult };

--- a/packages/shared/src/model/ConnectedApplication.ts
+++ b/packages/shared/src/model/ConnectedApplication.ts
@@ -18,6 +18,7 @@ interface ConnectedApplicationMetadata {
   status: ConnectedApplicationStatus;
   contextIndexingEnabled: boolean;
   gmailPubsubTopicName?: string | null | undefined;
+  watchedFolderIds?: string[] | null | undefined;
   oauth2RedirectUri?: string | undefined;
   webhookUrl?: string | undefined;
   watchStatus?: string | undefined;
@@ -48,6 +49,7 @@ interface ConnectedApplicationInternal {
   status: ConnectedApplicationStatus;
   context_indexing_enabled: number;
   gmail_pubsub_topic_name: string | null;
+  watched_folder_ids: string | null;
   created_at: number;
   updated_at: number;
 }

--- a/packages/shared/src/schema/input.ts
+++ b/packages/shared/src/schema/input.ts
@@ -52,6 +52,15 @@ const OAuth2AuthorizeBodySchema = z.object({
   applicationId: UuidSchema,
 });
 
+const ApplicationFoldersQuerySchema = z.object({
+  applicationId: UuidSchema,
+});
+
+const UpdateApplicationWatchSettingsBodySchema = z.object({
+  applicationId: UuidSchema,
+  folderIds: z.array(nonEmptyStringSchema('folderIds', 512)).nullable(),
+});
+
 const WatchApplicationBodySchema = z.object({
   applicationId: UuidSchema,
 });
@@ -112,6 +121,8 @@ const RequestInputSchemas: Record<string, RequestInputSchema> = {
   'GET /user/application/context/deletions': { query: ApplicationContextDeletionRunsQuerySchema },
   'GET /user/application/context/document/:contextDocumentId/provider-link': {},
   'POST /user/application/oauth2/authorize': { body: OAuth2AuthorizeBodySchema },
+  'GET /user/application/folders': { query: ApplicationFoldersQuerySchema },
+  'PUT /user/application/watch-settings': { body: UpdateApplicationWatchSettingsBodySchema },
   'POST /user/application/watch': { body: WatchApplicationBodySchema },
   'POST /user/application/stop': { body: StopApplicationBodySchema },
   'GET /api/oauth2/callback/:applicationId': { query: OAuth2CallbackQuerySchema },


### PR DESCRIPTION
Allow users to select which Gmail labels or Outlook mail folder to monitor per connected application, replacing the hardcoded INBOX default.

- Add `watched_folder_ids` column (migration 0007) to persist a JSON array of folder/label IDs on `connected_applications`
- Expose `watchedFolderIds` on the shared model, DAO, and all API responses
- Add `listLabels` to `GmailProviderUtil` and `listMailFolders` to `OutlookProviderUtil`; parameterise `watchInbox`, `listMessageIdsSince`, and `createInboxSubscription` to accept custom folder/label IDs
- Introduce `FolderService` (backend-services) for fetching available folders via the provider API
- Add `GET /user/application/folders` and `PUT /user/application/watch-settings` API endpoints
- Thread `watchedFolderIds` through `WatchService`, `SubscriptionRenewalUtil`, and `EmailProcessingUtil` so the saved selection is used on watch start, renewal, and history queries
- Add a "Watch Folders" panel to the management UI with radio/checkbox selection (single-select for Outlook, multi-select for Gmail) and lazy folder loading