### PR TITLE
Show Error Timestamps On Web UI

### DIFF
--- a/apps/web/components/types.ts
+++ b/apps/web/components/types.ts
@@ -23,11 +23,13 @@ export interface ConnectedApplication {
   watchExpiresAt?: number | null;
   lastSummaryAt?: number | null;
   lastError?: string | null;
+  lastErrorAt?: number | null;
   contextIndexingEnabled: boolean;
   contextDocumentCount?: number;
   contextLastIndexedAt?: number | null;
   contextLastDeleteAcceptedAt?: number | null;
   contextLastError?: string | null;
+  contextLastErrorAt?: number | null;
   updatedAt: number;
 }
 

--- a/apps/web/src/SpaApp.tsx
+++ b/apps/web/src/SpaApp.tsx
@@ -559,6 +559,7 @@ export default function SpaApp() {
                       label="Last error"
                       value={selectedApplication.lastError || 'None'}
                       tone={selectedApplication.lastError ? 'error' : 'muted'}
+                      subtitle={selectedApplication.lastError ? formatTimestamp(selectedApplication.lastErrorAt) : undefined}
                     />
                   </div>
                 </div>
@@ -587,6 +588,7 @@ export default function SpaApp() {
                       label="Context error"
                       value={selectedApplication.contextLastError || 'None'}
                       tone={selectedApplication.contextLastError ? 'error' : 'muted'}
+                      subtitle={selectedApplication.contextLastError ? formatTimestamp(selectedApplication.contextLastErrorAt) : undefined}
                     />
                   </div>
                   <div className="mt-5 flex flex-wrap gap-2">
@@ -1039,11 +1041,12 @@ function ReadOnlyField({ label, value, showCopy = false }: { label: string; valu
   );
 }
 
-function Metric({ label, value, tone = 'muted' }: { label: string; value: string; tone?: 'muted' | 'error' }) {
+function Metric({ label, value, tone = 'muted', subtitle }: { label: string; value: string; tone?: 'muted' | 'error'; subtitle?: string }) {
   return (
     <div className="rounded-md border border-[#2d3745] bg-[#11161f] p-4 min-w-0">
       <div className="text-xs uppercase tracking-normal text-[#7d8896]">{label}</div>
       <div className={`mt-2 break-words ${tone === 'error' ? 'text-[#fca5a5]' : 'text-[#d1d5db]'}`}>{value}</div>
+      {subtitle && <div className="mt-1 text-xs text-[#7d8896]">{subtitle}</div>}
     </div>
   );
 }

--- a/packages/backend-data/src/dao/ApplicationContextDAO.ts
+++ b/packages/backend-data/src/dao/ApplicationContextDAO.ts
@@ -171,10 +171,10 @@ class ApplicationContextDAO {
       )
       .bind(applicationId, APPLICATION_CONTEXT_DELETION_STATUS_ACCEPTED)
       .first<{ last_delete_accepted_at: number | null }>();
-    const documentError: { last_error: string | null } | null = await this.database
+    const documentError: { last_error: string | null; updated_at: number } | null = await this.database
       .prepare(
         `
-          SELECT last_error
+          SELECT last_error, updated_at
           FROM application_context_documents
           WHERE application_id = ? AND last_error IS NOT NULL
           ORDER BY updated_at DESC
@@ -182,11 +182,11 @@ class ApplicationContextDAO {
         `,
       )
       .bind(applicationId)
-      .first<{ last_error: string | null }>();
-    const deletionError: { error_message: string | null } | null = await this.database
+      .first<{ last_error: string | null; updated_at: number }>();
+    const deletionError: { error_message: string | null; updated_at: number } | null = await this.database
       .prepare(
         `
-          SELECT error_message
+          SELECT error_message, updated_at
           FROM application_context_deletion_runs
           WHERE application_id = ? AND status = ? AND error_message IS NOT NULL
           ORDER BY updated_at DESC
@@ -194,13 +194,16 @@ class ApplicationContextDAO {
         `,
       )
       .bind(applicationId, APPLICATION_CONTEXT_DELETION_STATUS_ERROR)
-      .first<{ error_message: string | null }>();
+      .first<{ error_message: string | null; updated_at: number }>();
     return {
       applicationId,
       documentCount: countRow?.count ?? 0,
       lastIndexedAt: countRow?.last_indexed_at ?? null,
       lastDeleteAcceptedAt: deletionRow?.last_delete_accepted_at ?? null,
       lastError: documentError?.last_error || deletionError?.error_message || null,
+      lastErrorAt: documentError?.last_error
+        ? documentError.updated_at
+        : (deletionError?.error_message ? deletionError.updated_at : null),
     };
   }
 

--- a/packages/backend-services/src/application/ApplicationResponseUtil.ts
+++ b/packages/backend-services/src/application/ApplicationResponseUtil.ts
@@ -31,10 +31,12 @@ class ApplicationResponseUtil {
       watchExpiresAt: subscription?.expiresAt,
       lastSummaryAt: latestMessage?.summarySentAt,
       lastError: subscription?.lastError || latestError?.errorMessage,
+      lastErrorAt: subscription?.lastError ? subscription.updatedAt : (latestError?.errorMessage ? latestError.updatedAt : null),
       contextDocumentCount: contextSummary.documentCount,
       contextLastIndexedAt: contextSummary.lastIndexedAt,
       contextLastDeleteAcceptedAt: contextSummary.lastDeleteAcceptedAt,
       contextLastError: contextSummary.lastError,
+      contextLastErrorAt: contextSummary.lastErrorAt,
     };
   }
 }
@@ -50,10 +52,12 @@ interface ApplicationResponse extends ConnectedApplicationMetadata {
   watchExpiresAt?: number | null | undefined;
   lastSummaryAt?: number | null | undefined;
   lastError?: string | null | undefined;
+  lastErrorAt?: number | null | undefined;
   contextDocumentCount: number;
   contextLastIndexedAt?: number | null | undefined;
   contextLastDeleteAcceptedAt?: number | null | undefined;
   contextLastError?: string | null | undefined;
+  contextLastErrorAt?: number | null | undefined;
 }
 
 export { ApplicationResponseUtil };

--- a/packages/shared/src/model/ApplicationContextDocument.ts
+++ b/packages/shared/src/model/ApplicationContextDocument.ts
@@ -52,6 +52,7 @@ interface ApplicationContextSummary {
   lastIndexedAt?: number | null | undefined;
   lastDeleteAcceptedAt?: number | null | undefined;
   lastError?: string | null | undefined;
+  lastErrorAt?: number | null | undefined;
 }
 
 interface ApplicationContextDocumentList {

--- a/packages/shared/src/model/ConnectedApplication.ts
+++ b/packages/shared/src/model/ConnectedApplication.ts
@@ -25,10 +25,12 @@ interface ConnectedApplicationMetadata {
   watchExpiresAt?: number | null | undefined;
   lastSummaryAt?: number | null | undefined;
   lastError?: string | null | undefined;
+  lastErrorAt?: number | null | undefined;
   contextDocumentCount?: number | undefined;
   contextLastIndexedAt?: number | null | undefined;
   contextLastDeleteAcceptedAt?: number | null | undefined;
   contextLastError?: string | null | undefined;
+  contextLastErrorAt?: number | null | undefined;
   createdAt: number;
   updatedAt: number;
 }


### PR DESCRIPTION
Display the time of error below the error message in the "Last error" and "Context error" metric tiles. Timestamps are sourced from the `updated_at` of the relevant row (processed_message, subscription, application_context_documents, or application_context_deletion_runs) without requiring a DB migration.

- Add `lastErrorAt` / `contextLastErrorAt` fields through shared models, DAO, service layer, and frontend types
- Extend `Metric` component with an optional `subtitle` prop
- Pass `formatTimestamp(...)` as subtitle only when an error is present