### PR TITLE
Deduplicate Moved Emails By Stable Message Id

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -153,7 +153,7 @@ Do not reintroduce password signup or user-managed refresh-token paste flows.
 - When creating a commit from `main`, first switch to a new branch generated from the planned commit subject.
 - Use lowercase slash-separated branch names: `type/description` when there is no scope, or `type/scope/description` when there is a scope.
 - Convert the description to kebab-case for the branch, for example `docs/latest-agents-context-reflection`, `docs/agents/document-commit-standard`, or `feat/bootstrap/bootstrap-jqanywhere-v0.1-framework`.
-- Use Markdown for optional commit bodies, separated from the subject by a blank line.
+- Always include a Markdown commit body description for every new commit, separated from the subject by a blank line.
 - Use optional footers after the body, separated by a blank line, following git trailer-style formatting.
 - Use `FIX` for bug patches and `FEAT` for new features; other conventional types are allowed when they better communicate intent.
 - Mark breaking API changes with `!` after the type or scope, or with a `BREAKING CHANGE: <description>` footer.

--- a/docs/DEVELOPMENT.md
+++ b/docs/DEVELOPMENT.md
@@ -48,7 +48,7 @@ Public routes:
 
 ## Processing
 
-Webhook routes validate provider secrets or client state, enqueue lightweight jobs, and acknowledge quickly. The queue consumer dispatches an `EmailProcessingWorkflow` instance for each job. The workflow refreshes provider access tokens, fetches the new message, deduplicates by provider message id, retrieves per-user Vectorize context from enabled applications, calls Workers AI, sends a self-addressed summary reply in the original thread, and stores the new document in Vectorize when that application has indexing enabled.
+Webhook routes validate provider secrets or client state, enqueue lightweight jobs, and acknowledge quickly. The queue consumer dispatches an `EmailProcessingWorkflow` instance for each job. The workflow refreshes provider access tokens, fetches the new message, deduplicates by provider message id or stable provider message fingerprint, retrieves per-user Vectorize context from enabled applications, calls Workers AI, sends a self-addressed summary reply in the original thread, and stores the new document in Vectorize when that application has indexing enabled.
 
 ## Configuration
 

--- a/migrations/0009_processed_message_stable_fingerprint.sql
+++ b/migrations/0009_processed_message_stable_fingerprint.sql
@@ -1,0 +1,6 @@
+ALTER TABLE processed_messages
+ADD COLUMN provider_stable_message_fingerprint TEXT;
+
+CREATE UNIQUE INDEX idx_processed_messages_stable_fingerprint
+ON processed_messages(application_id, provider_id, provider_stable_message_fingerprint)
+WHERE provider_stable_message_fingerprint IS NOT NULL;

--- a/packages/backend-data/src/dao/ProcessedMessageDAO.ts
+++ b/packages/backend-data/src/dao/ProcessedMessageDAO.ts
@@ -29,8 +29,8 @@ class ProcessedMessageDAO {
       .prepare(
         `
           INSERT OR IGNORE INTO processed_messages
-            (processed_message_id, application_id, provider_id, provider_message_id, provider_thread_id, status, summary_sent_at, error_message, created_at, updated_at)
-          VALUES (?, ?, ?, ?, ?, ?, NULL, NULL, ?, ?)
+            (processed_message_id, application_id, provider_id, provider_message_id, provider_thread_id, provider_stable_message_fingerprint, status, summary_sent_at, error_message, created_at, updated_at)
+          VALUES (?, ?, ?, ?, ?, ?, ?, NULL, NULL, ?, ?)
         `,
       )
       .bind(
@@ -39,6 +39,7 @@ class ProcessedMessageDAO {
         providerId,
         providerMessageId,
         providerThreadId || null,
+        options.providerStableMessageFingerprint || null,
         PROCESSED_MESSAGE_STATUS_PROCESSING,
         now,
         now,
@@ -51,8 +52,22 @@ class ProcessedMessageDAO {
     if (inserted || !options.allowExistingForRetry) {
       return inserted;
     }
-    const status: ProcessedMessageStatus | undefined = await this.getStatus(applicationId, providerMessageId);
-    return status === PROCESSED_MESSAGE_STATUS_PROCESSING || status === PROCESSED_MESSAGE_STATUS_ERROR;
+    const existing: ProcessedMessageInternal | null = await this.getInternalByMessageId(applicationId, providerMessageId);
+    if (!existing || (existing.status !== PROCESSED_MESSAGE_STATUS_PROCESSING && existing.status !== PROCESSED_MESSAGE_STATUS_ERROR)) {
+      return false;
+    }
+    if (options.providerStableMessageFingerprint) {
+      const stableMatch: ProcessedMessageInternal | null = await this.getInternalByStableMessageFingerprint(
+        applicationId,
+        providerId,
+        options.providerStableMessageFingerprint,
+      );
+      if (stableMatch && stableMatch.provider_message_id !== providerMessageId) {
+        return false;
+      }
+    }
+    await this.updateRetryMetadata(applicationId, providerMessageId, providerThreadId, options.providerStableMessageFingerprint);
+    return true;
   }
 
   public async markSummarized(applicationId: string, providerMessageId: string): Promise<void> {
@@ -71,7 +86,7 @@ class ProcessedMessageDAO {
     const row: ProcessedMessageInternal | null = await this.database
       .prepare(
         `
-          SELECT processed_message_id, application_id, provider_id, provider_message_id, provider_thread_id, status, summary_sent_at, error_message, created_at, updated_at
+          SELECT ${ProcessedMessageDAO.processedMessageColumns}
           FROM processed_messages
           WHERE application_id = ? AND status = ?
           ORDER BY updated_at DESC
@@ -87,7 +102,7 @@ class ProcessedMessageDAO {
     const row: ProcessedMessageInternal | null = await this.database
       .prepare(
         `
-          SELECT processed_message_id, application_id, provider_id, provider_message_id, provider_thread_id, status, summary_sent_at, error_message, created_at, updated_at
+          SELECT ${ProcessedMessageDAO.processedMessageColumns}
           FROM processed_messages
           WHERE application_id = ? AND status = ?
           ORDER BY updated_at DESC
@@ -122,19 +137,60 @@ class ProcessedMessageDAO {
     }
   }
 
-  private async getStatus(applicationId: string, providerMessageId: string): Promise<ProcessedMessageStatus | undefined> {
-    const row: { status: ProcessedMessageStatus } | null = await this.database
+  private async getInternalByMessageId(applicationId: string, providerMessageId: string): Promise<ProcessedMessageInternal | null> {
+    return this.database
       .prepare(
         `
-          SELECT status
+          SELECT ${ProcessedMessageDAO.processedMessageColumns}
           FROM processed_messages
           WHERE application_id = ? AND provider_message_id = ?
           LIMIT 1
         `,
       )
       .bind(applicationId, providerMessageId)
-      .first<{ status: ProcessedMessageStatus }>();
-    return row?.status;
+      .first<ProcessedMessageInternal>();
+  }
+
+  private async getInternalByStableMessageFingerprint(
+    applicationId: string,
+    providerId: ProviderId,
+    providerStableMessageFingerprint: string,
+  ): Promise<ProcessedMessageInternal | null> {
+    return this.database
+      .prepare(
+        `
+          SELECT ${ProcessedMessageDAO.processedMessageColumns}
+          FROM processed_messages
+          WHERE application_id = ? AND provider_id = ? AND provider_stable_message_fingerprint = ?
+          LIMIT 1
+        `,
+      )
+      .bind(applicationId, providerId, providerStableMessageFingerprint)
+      .first<ProcessedMessageInternal>();
+  }
+
+  private async updateRetryMetadata(
+    applicationId: string,
+    providerMessageId: string,
+    providerThreadId: string | null | undefined,
+    providerStableMessageFingerprint: string | null | undefined,
+  ): Promise<void> {
+    const now: number = TimestampUtil.getCurrentUnixTimestampInSeconds();
+    const result: D1Result = await this.database
+      .prepare(
+        `
+          UPDATE processed_messages
+          SET provider_thread_id = COALESCE(?, provider_thread_id),
+              provider_stable_message_fingerprint = COALESCE(?, provider_stable_message_fingerprint),
+              updated_at = ?
+          WHERE application_id = ? AND provider_message_id = ?
+        `,
+      )
+      .bind(providerThreadId || null, providerStableMessageFingerprint || null, now, applicationId, providerMessageId)
+      .run();
+    if (!result.success) {
+      throw new DatabaseError(`Failed to update processed message retry metadata: ${result.error}`);
+    }
   }
 
   private toProcessedMessage(row: ProcessedMessageInternal): ProcessedMessage {
@@ -144,6 +200,7 @@ class ProcessedMessageDAO {
       providerId: row.provider_id,
       providerMessageId: row.provider_message_id,
       providerThreadId: row.provider_thread_id,
+      providerStableMessageFingerprint: row.provider_stable_message_fingerprint,
       status: row.status,
       summarySentAt: row.summary_sent_at,
       errorMessage: row.error_message,
@@ -151,10 +208,25 @@ class ProcessedMessageDAO {
       updatedAt: row.updated_at,
     };
   }
+
+  private static readonly processedMessageColumns: string = [
+    'processed_message_id',
+    'application_id',
+    'provider_id',
+    'provider_message_id',
+    'provider_thread_id',
+    'provider_stable_message_fingerprint',
+    'status',
+    'summary_sent_at',
+    'error_message',
+    'created_at',
+    'updated_at',
+  ].join(', ');
 }
 
 interface TryStartProcessedMessageOptions {
   allowExistingForRetry?: boolean | undefined;
+  providerStableMessageFingerprint?: string | null | undefined;
 }
 
 export { ProcessedMessageDAO };

--- a/packages/backend-services/src/email/EmailProcessingUtil.ts
+++ b/packages/backend-services/src/email/EmailProcessingUtil.ts
@@ -8,6 +8,8 @@ import type { OutlookMessage } from '@mail-otter/provider-clients/outlook';
 import type { ConnectedApplication, EmailQueueMessage, ProviderSubscription } from '@mail-otter/shared/model';
 import { BadRequestError, NonRetryableError, RetryableError } from '@mail-otter/backend-errors';
 import { ConfigurationManager } from '@mail-otter/backend-runtime/config';
+import { CryptoUtil } from '@mail-otter/shared/utils';
+import type { ProviderId } from '@mail-otter/shared/constants';
 import { EmailContextUtil } from './EmailContextUtil';
 import { EmailSummaryUtil } from './EmailSummaryUtil';
 import { OAuth2AccessTokenService } from '../oauth2/OAuth2AccessTokenService';
@@ -60,9 +62,15 @@ class EmailProcessingUtil {
     const subject: string = EmailContentUtil.getHeader(headers, 'Subject') || '(no subject)';
     const from: string = EmailContentUtil.getHeader(headers, 'From') || '';
     const isSummary: boolean = EmailContentUtil.getHeader(headers, 'X-Mail-Otter-Summary')?.toLowerCase() === 'true';
+    const stableMessageFingerprint: string | null = await EmailProcessingUtil.getStableMessageFingerprint(
+      env,
+      application.providerId,
+      EmailContentUtil.getHeader(headers, 'Message-ID'),
+    );
     const processedDAO = new ProcessedMessageDAO(env.DB);
     const started: boolean = await processedDAO.tryStart(application.applicationId, application.providerId, message.id, message.threadId, {
       allowExistingForRetry: EmailProcessingUtil.isRetryAttempt(options),
+      providerStableMessageFingerprint: stableMessageFingerprint,
     });
     if (!started) return;
     try {
@@ -100,16 +108,15 @@ class EmailProcessingUtil {
     options: EmailProcessingOptions = {},
   ): Promise<void> {
     const processedDAO = new ProcessedMessageDAO(env.DB);
-    const started: boolean = await processedDAO.tryStart(application.applicationId, application.providerId, messageId, null, {
-      allowExistingForRetry: EmailProcessingUtil.isRetryAttempt(options),
-    });
-    if (!started) return;
-
     let message: OutlookMessage;
     try {
       message = await OutlookProviderUtil.getMessage(accessToken, messageId);
     } catch (error: unknown) {
       if (OutlookProviderUtil.isMessageNotFoundError(error)) {
+        const started: boolean = await processedDAO.tryStart(application.applicationId, application.providerId, messageId, null, {
+          allowExistingForRetry: EmailProcessingUtil.isRetryAttempt(options),
+        });
+        if (!started) return;
         await processedDAO.markSkipped(
           application.applicationId,
           messageId,
@@ -118,6 +125,10 @@ class EmailProcessingUtil {
         return;
       }
       const processingError: Error = EmailProcessingUtil.classifyError(error);
+      const started: boolean = await processedDAO.tryStart(application.applicationId, application.providerId, messageId, null, {
+        allowExistingForRetry: EmailProcessingUtil.isRetryAttempt(options),
+      });
+      if (!started) return;
       await processedDAO.markError(application.applicationId, messageId, EmailProcessingUtil.formatError(processingError));
       throw processingError;
     }
@@ -129,6 +140,22 @@ class EmailProcessingUtil {
         (header: { name: string; value: string }): boolean =>
           header.name.toLowerCase() === 'x-mail-otter-summary' && header.value.toLowerCase() === 'true',
       ) ?? false;
+    const stableMessageFingerprint: string | null = await EmailProcessingUtil.getStableMessageFingerprint(
+      env,
+      application.providerId,
+      message.internetMessageId,
+    );
+    const started: boolean = await processedDAO.tryStart(
+      application.applicationId,
+      application.providerId,
+      message.id,
+      message.conversationId || null,
+      {
+        allowExistingForRetry: EmailProcessingUtil.isRetryAttempt(options),
+        providerStableMessageFingerprint: stableMessageFingerprint,
+      },
+    );
+    if (!started) return;
 
     try {
       if (isSummary || EmailContentUtil.isFromMailbox(from, application.providerEmail)) {
@@ -174,6 +201,17 @@ class EmailProcessingUtil {
 
   private static isRetryAttempt(options: EmailProcessingOptions): boolean {
     return typeof options.retryAttempt === 'number' && options.retryAttempt > 1;
+  }
+
+  private static async getStableMessageFingerprint(
+    env: EmailProcessingEnv,
+    providerId: ProviderId,
+    stableMessageId: string | undefined,
+  ): Promise<string | null> {
+    const normalizedStableMessageId: string = stableMessageId?.trim() || '';
+    if (!normalizedStableMessageId) return null;
+    const secret: string = await env.AES_ENCRYPTION_KEY_SECRET.get();
+    return CryptoUtil.hmacSha256Hex(`provider-stable-message-id\n${providerId}\n${normalizedStableMessageId}`, secret);
   }
 
   private static classifyError(error: unknown): Error {

--- a/packages/provider-clients/src/OutlookProviderUtil.ts
+++ b/packages/provider-clients/src/OutlookProviderUtil.ts
@@ -20,6 +20,7 @@ interface OutlookMessage {
   id: string;
   subject?: string | undefined;
   conversationId?: string | undefined;
+  internetMessageId?: string | undefined;
   body?: { contentType?: string | undefined; content?: string | undefined } | undefined;
   from?: { emailAddress?: { address?: string | undefined; name?: string | undefined } | undefined } | undefined;
   sender?: { emailAddress?: { address?: string | undefined; name?: string | undefined } | undefined } | undefined;
@@ -123,7 +124,7 @@ class OutlookProviderUtil {
 
   public static async getMessage(accessToken: string, messageId: string): Promise<OutlookMessage> {
     const url: URL = new URL(`https://graph.microsoft.com/v1.0/me/messages/${encodeURIComponent(messageId)}`);
-    url.searchParams.set('$select', 'id,subject,conversationId,body,from,sender,internetMessageHeaders');
+    url.searchParams.set('$select', 'id,subject,conversationId,internetMessageId,body,from,sender,internetMessageHeaders');
     return OutlookProviderUtil.fetchJson<OutlookMessage>(url.toString(), accessToken, {
       headers: { Prefer: 'outlook.body-content-type="text"' },
     });

--- a/packages/shared/src/model/ProcessedMessage.ts
+++ b/packages/shared/src/model/ProcessedMessage.ts
@@ -6,6 +6,7 @@ interface ProcessedMessage {
   providerId: ProviderId;
   providerMessageId: string;
   providerThreadId?: string | null | undefined;
+  providerStableMessageFingerprint?: string | null | undefined;
   status: ProcessedMessageStatus;
   summarySentAt?: number | null | undefined;
   errorMessage?: string | null | undefined;
@@ -19,6 +20,7 @@ interface ProcessedMessageInternal {
   provider_id: ProviderId;
   provider_message_id: string;
   provider_thread_id: string | null;
+  provider_stable_message_fingerprint: string | null;
   status: ProcessedMessageStatus;
   summary_sent_at: number | null;
   error_message: string | null;

--- a/test/dao/ProcessedMessageDAO.test.ts
+++ b/test/dao/ProcessedMessageDAO.test.ts
@@ -1,0 +1,140 @@
+import { ProcessedMessageDAO } from '@mail-otter/backend-data/dao';
+import {
+  PROCESSED_MESSAGE_STATUS_PROCESSING,
+  PROCESSED_MESSAGE_STATUS_SUMMARIZED,
+  type ProcessedMessageStatus,
+  type ProviderId,
+} from '@mail-otter/shared/constants';
+import type { ProcessedMessageInternal } from '@mail-otter/shared/model';
+import { describe, expect, it } from 'vitest';
+
+class FakeProcessedMessageStatement {
+  private bindings: unknown[] = [];
+
+  constructor(
+    private readonly database: FakeProcessedMessageD1Database,
+    private readonly sql: string,
+  ) {}
+
+  bind(...bindings: unknown[]): FakeProcessedMessageStatement {
+    this.bindings = bindings;
+    return this;
+  }
+
+  async run(): Promise<D1Result> {
+    if (this.sql.includes('INSERT OR IGNORE INTO processed_messages')) {
+      const row: ProcessedMessageInternal = {
+        processed_message_id: this.bindings[0] as string,
+        application_id: this.bindings[1] as string,
+        provider_id: this.bindings[2] as ProviderId,
+        provider_message_id: this.bindings[3] as string,
+        provider_thread_id: this.bindings[4] as string | null,
+        provider_stable_message_fingerprint: this.bindings[5] as string | null,
+        status: this.bindings[6] as ProcessedMessageStatus,
+        summary_sent_at: null,
+        error_message: null,
+        created_at: this.bindings[7] as number,
+        updated_at: this.bindings[8] as number,
+      };
+      if (this.database.conflictsWithExistingRow(row)) {
+        return { success: true, meta: { changes: 0 } } as D1Result;
+      }
+      this.database.rows.push(row);
+      return { success: true, meta: { changes: 1 } } as D1Result;
+    }
+
+    return { success: true, meta: { changes: 0 } } as D1Result;
+  }
+
+  async first<T>(): Promise<T | null> {
+    if (this.sql.includes('WHERE application_id = ? AND provider_message_id = ?')) {
+      return (this.database.rows.find(
+        (row: ProcessedMessageInternal): boolean =>
+          row.application_id === this.bindings[0] && row.provider_message_id === this.bindings[1],
+      ) || null) as T | null;
+    }
+    if (this.sql.includes('WHERE application_id = ? AND provider_id = ? AND provider_stable_message_fingerprint = ?')) {
+      return (this.database.rows.find(
+        (row: ProcessedMessageInternal): boolean =>
+          row.application_id === this.bindings[0] &&
+          row.provider_id === this.bindings[1] &&
+          row.provider_stable_message_fingerprint === this.bindings[2],
+      ) || null) as T | null;
+    }
+    return null;
+  }
+}
+
+class FakeProcessedMessageD1Database {
+  public readonly rows: ProcessedMessageInternal[] = [];
+
+  prepare(sql: string): FakeProcessedMessageStatement {
+    return new FakeProcessedMessageStatement(this, sql);
+  }
+
+  conflictsWithExistingRow(row: ProcessedMessageInternal): boolean {
+    return this.rows.some((existingRow: ProcessedMessageInternal): boolean => {
+      const sameProviderMessage =
+        existingRow.application_id === row.application_id && existingRow.provider_message_id === row.provider_message_id;
+      const sameStableProviderMessage =
+        Boolean(row.provider_stable_message_fingerprint) &&
+        existingRow.application_id === row.application_id &&
+        existingRow.provider_id === row.provider_id &&
+        existingRow.provider_stable_message_fingerprint === row.provider_stable_message_fingerprint;
+      return sameProviderMessage || sameStableProviderMessage;
+    });
+  }
+}
+
+describe('ProcessedMessageDAO', () => {
+  it('does not start a moved message when the stable provider message fingerprint already exists', async () => {
+    const database = new FakeProcessedMessageD1Database();
+    database.rows.push(createProcessedMessageRow({ provider_message_id: 'old-provider-id', provider_stable_message_fingerprint: 'stable-1' }));
+    const dao = new ProcessedMessageDAO(database as unknown as D1Database);
+
+    await expect(
+      dao.tryStart('app-1', 'microsoft-outlook', 'new-provider-id', 'conversation-1', {
+        providerStableMessageFingerprint: 'stable-1',
+      }),
+    ).resolves.toBe(false);
+
+    expect(database.rows).toHaveLength(1);
+  });
+
+  it('starts a new message in the same thread when its stable provider message fingerprint is new', async () => {
+    const database = new FakeProcessedMessageD1Database();
+    database.rows.push(createProcessedMessageRow({ provider_message_id: 'old-provider-id', provider_stable_message_fingerprint: 'stable-1' }));
+    const dao = new ProcessedMessageDAO(database as unknown as D1Database);
+
+    await expect(
+      dao.tryStart('app-1', 'microsoft-outlook', 'new-reply-provider-id', 'conversation-1', {
+        providerStableMessageFingerprint: 'stable-2',
+      }),
+    ).resolves.toBe(true);
+
+    expect(database.rows).toHaveLength(2);
+    expect(database.rows[1]).toMatchObject({
+      provider_message_id: 'new-reply-provider-id',
+      provider_thread_id: 'conversation-1',
+      provider_stable_message_fingerprint: 'stable-2',
+      status: PROCESSED_MESSAGE_STATUS_PROCESSING,
+    });
+  });
+});
+
+function createProcessedMessageRow(overrides: Partial<ProcessedMessageInternal> = {}): ProcessedMessageInternal {
+  return {
+    processed_message_id: 'processed-message-1',
+    application_id: 'app-1',
+    provider_id: 'microsoft-outlook',
+    provider_message_id: 'provider-message-1',
+    provider_thread_id: 'conversation-1',
+    provider_stable_message_fingerprint: 'stable-1',
+    status: PROCESSED_MESSAGE_STATUS_SUMMARIZED,
+    summary_sent_at: 1778200000,
+    error_message: null,
+    created_at: 1778200000,
+    updated_at: 1778200000,
+    ...overrides,
+  };
+}

--- a/test/utils/EmailProcessingUtil.test.ts
+++ b/test/utils/EmailProcessingUtil.test.ts
@@ -1,8 +1,9 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
-import { EmailProcessingUtil } from '@mail-otter/backend-services/email';
+import { EmailProcessingUtil, EmailSummaryUtil } from '@mail-otter/backend-services/email';
 import type { EmailProcessingEnv } from '@mail-otter/backend-services/email';
 import { ConnectedApplicationDAO, ProcessedMessageDAO } from '@mail-otter/backend-data/dao';
 import { OutlookProviderUtil } from '@mail-otter/provider-clients/outlook';
+import type { OutlookMessage } from '@mail-otter/provider-clients/outlook';
 import { NonRetryableError, RetryableError } from '@mail-otter/backend-errors';
 
 describe('EmailProcessingUtil', () => {
@@ -81,6 +82,49 @@ describe('EmailProcessingUtil', () => {
 
       expect(markError).toHaveBeenCalledWith('app-1', 'message-1', 'Temporary Graph failure.');
     });
+
+    it('skips moved Outlook messages when the stable internet message id was already processed', async () => {
+      const tryStart = vi.spyOn(ProcessedMessageDAO.prototype, 'tryStart').mockResolvedValue(false);
+      const summarizeEmail = vi.spyOn(EmailSummaryUtil, 'summarizeEmail').mockResolvedValue('Summary text');
+      const sendSelfSummaryReply = vi.spyOn(OutlookProviderUtil, 'sendSelfSummaryReply').mockResolvedValue();
+      vi.spyOn(OutlookProviderUtil, 'getMessage').mockResolvedValue(
+        createOutlookMessage({ id: 'moved-message-2', conversationId: 'conversation-1', internetMessageId: '<original@example.com>' }),
+      );
+
+      await expect(
+        EmailProcessingUtil.processOutlookMessage(createApplication(), 'access-token', 'moved-message-2', createEnv(), []),
+      ).resolves.toBeUndefined();
+
+      expect(tryStart).toHaveBeenCalledWith('app-1', 'microsoft-outlook', 'moved-message-2', 'conversation-1', {
+        allowExistingForRetry: false,
+        providerStableMessageFingerprint: expect.any(String),
+      });
+      expect(summarizeEmail).not.toHaveBeenCalled();
+      expect(sendSelfSummaryReply).not.toHaveBeenCalled();
+    });
+
+    it('summarizes new Outlook replies in an already seen conversation when the stable message id is new', async () => {
+      const tryStart = vi.spyOn(ProcessedMessageDAO.prototype, 'tryStart').mockResolvedValue(true);
+      const markSummarized = vi.spyOn(ProcessedMessageDAO.prototype, 'markSummarized').mockResolvedValue();
+      vi.spyOn(ProcessedMessageDAO.prototype, 'markError').mockResolvedValue();
+      const summarizeEmail = vi.spyOn(EmailSummaryUtil, 'summarizeEmail').mockResolvedValue('Summary text');
+      const sendSelfSummaryReply = vi.spyOn(OutlookProviderUtil, 'sendSelfSummaryReply').mockResolvedValue();
+      vi.spyOn(OutlookProviderUtil, 'getMessage').mockResolvedValue(
+        createOutlookMessage({ id: 'reply-message-2', conversationId: 'conversation-1', internetMessageId: '<reply-2@example.com>' }),
+      );
+
+      await expect(
+        EmailProcessingUtil.processOutlookMessage(createApplication(), 'access-token', 'reply-message-2', createEnv(), []),
+      ).resolves.toBeUndefined();
+
+      expect(tryStart).toHaveBeenCalledWith('app-1', 'microsoft-outlook', 'reply-message-2', 'conversation-1', {
+        allowExistingForRetry: false,
+        providerStableMessageFingerprint: expect.any(String),
+      });
+      expect(summarizeEmail).toHaveBeenCalledOnce();
+      expect(sendSelfSummaryReply).toHaveBeenCalledOnce();
+      expect(markSummarized).toHaveBeenCalledWith('app-1', 'reply-message-2');
+    });
   });
 });
 
@@ -101,6 +145,19 @@ function createOutlookQueueMessage() {
     subscriptionId: 'subscription-1',
     messageId: 'message-1',
   } as never;
+}
+
+function createOutlookMessage(overrides: Partial<OutlookMessage> = {}): OutlookMessage {
+  return {
+    id: 'message-1',
+    subject: 'Project update',
+    conversationId: 'conversation-1',
+    internetMessageId: '<message-1@example.com>',
+    body: { contentType: 'text', content: 'Please review the project update.' },
+    from: { emailAddress: { address: 'sender@example.com' } },
+    internetMessageHeaders: [],
+    ...overrides,
+  };
 }
 
 function createEnv(): EmailProcessingEnv {


### PR DESCRIPTION
- Add a D1 migration for `provider_stable_message_fingerprint`.
- Dedupe moved Gmail and Outlook messages by an HMAC fingerprint from provider-stable message IDs.
- Preserve summaries for new replies in existing threads and conversations.
- Add regression coverage and update processing docs.