### PR TITLE
Handle Workers AI Allocation Exhaustion

### DIFF
--- a/packages/backend-services/src/email/EmailContextUtil.ts
+++ b/packages/backend-services/src/email/EmailContextUtil.ts
@@ -1,9 +1,11 @@
 import { AiDailyUsageDAO, ApplicationContextDAO } from '@mail-otter/backend-data/dao';
+import { NonRetryableError } from '@mail-otter/backend-errors';
 import { EmailContentUtil } from '@mail-otter/provider-clients/email-content';
 import type { ApplicationContextDocument, ConnectedApplication } from '@mail-otter/shared/model';
 import { CryptoUtil } from '@mail-otter/shared/utils';
 import { ConfigurationManager } from '@mail-otter/backend-runtime/config';
 import { AiUsageUtil, type AiEmbeddingUsageEstimate } from './AiUsageUtil';
+import { WorkersAiErrorUtil } from './WorkersAiErrorUtil';
 
 class EmailContextUtil {
   public static async getUserVectorNamespace(userEmail: string): Promise<string> {
@@ -18,6 +20,7 @@ class EmailContextUtil {
     const shouldRetrieve: boolean = enabledApplicationIds.size > 0;
     const shouldStore: boolean = input.application.contextIndexingEnabled;
     if (!shouldRetrieve && !shouldStore) return undefined;
+    if (await EmailContextUtil.shouldSkipWorkersAiForDailyUsage(input.env)) return undefined;
 
     const contextDAO = new ApplicationContextDAO(input.env.DB);
     const vectorNamespace: string = await EmailContextUtil.getUserVectorNamespace(input.application.userEmail);
@@ -69,6 +72,9 @@ class EmailContextUtil {
       console.warn('Email context indexing or retrieval failed:', error);
       if (document) {
         await contextDAO.markDocumentError(document.contextDocumentId, error instanceof Error ? error.message : String(error));
+      }
+      if (WorkersAiErrorUtil.isDailyFreeAllocationError(error)) {
+        throw new NonRetryableError(WorkersAiErrorUtil.getDailyFreeAllocationMessage());
       }
       return undefined;
     }
@@ -134,6 +140,18 @@ class EmailContextUtil {
     }
   }
 
+  private static async shouldSkipWorkersAiForDailyUsage(env: EmailContextEnv): Promise<boolean> {
+    const fallbackThreshold: number = ConfigurationManager.getAiDailyNeuronFallbackThreshold(env);
+    if (fallbackThreshold <= 0) return false;
+    try {
+      const estimatedNeurons: number = await new AiDailyUsageDAO(env.DB).getEstimatedNeuronsForDate(AiUsageUtil.getCurrentUtcUsageDate());
+      return estimatedNeurons >= fallbackThreshold;
+    } catch (error: unknown) {
+      console.warn('Failed to read Workers AI daily usage estimate for context:', error);
+      return false;
+    }
+  }
+
   private static async queryRelevantContext(
     env: EmailContextEnv,
     embedding: number[],
@@ -196,6 +214,7 @@ interface EmailContextEnv {
   AES_ENCRYPTION_KEY_SECRET: SecretsStoreSecret;
   AI: Ai;
   EMAIL_CONTEXT_INDEX?: Vectorize | undefined;
+  AI_DAILY_NEURON_FALLBACK_THRESHOLD?: string | undefined;
   AI_EMBEDDING_MODEL?: string | undefined;
   RAG_TOP_K?: string | undefined;
   RAG_VECTOR_QUERY_TOP_K?: string | undefined;

--- a/packages/backend-services/src/email/EmailProcessingUtil.ts
+++ b/packages/backend-services/src/email/EmailProcessingUtil.ts
@@ -13,6 +13,7 @@ import type { ProviderId } from '@mail-otter/shared/constants';
 import { EmailContextUtil } from './EmailContextUtil';
 import { EmailSummaryUtil, type EmailSummaryResult } from './EmailSummaryUtil';
 import { AiUsageUtil, type AiTextGenerationUsageEstimate } from './AiUsageUtil';
+import { WorkersAiErrorUtil } from './WorkersAiErrorUtil';
 import { OAuth2AccessTokenService } from '../oauth2/OAuth2AccessTokenService';
 
 const EMAIL_SUMMARY_MAX_COMPLETION_TOKENS = 512;
@@ -270,8 +271,8 @@ class EmailProcessingUtil {
     if (error instanceof RetryableError || error instanceof NonRetryableError) {
       return error;
     }
-    if (EmailProcessingUtil.isWorkersAiDailyLimitError(error)) {
-      return new NonRetryableError('Workers AI daily free allocation was exceeded.');
+    if (WorkersAiErrorUtil.isDailyFreeAllocationError(error)) {
+      return new NonRetryableError(WorkersAiErrorUtil.getDailyFreeAllocationMessage());
     }
     if (error instanceof BadRequestError) {
       return new NonRetryableError(error.message);
@@ -282,10 +283,6 @@ class EmailProcessingUtil {
     return new RetryableError(String(error));
   }
 
-  private static isWorkersAiDailyLimitError(error: unknown): boolean {
-    const message: string = EmailProcessingUtil.formatError(error);
-    return /3036|daily free allocation|10,?000 neurons|account limited/i.test(message);
-  }
 }
 
 interface ResolvedApplication {

--- a/packages/backend-services/src/email/WorkersAiErrorUtil.ts
+++ b/packages/backend-services/src/email/WorkersAiErrorUtil.ts
@@ -1,0 +1,34 @@
+const WORKERS_AI_DAILY_LIMIT_CODES: ReadonlySet<string> = new Set<string>(['3036', '4006']);
+
+class WorkersAiErrorUtil {
+  public static isDailyFreeAllocationError(error: unknown): boolean {
+    const values: string[] = WorkersAiErrorUtil.collectErrorValues(error);
+    const text: string = values.join(' ');
+    if (/daily free allocation|10,?000 neurons|account limited/i.test(text)) return true;
+    return values.some((value: string): boolean => WORKERS_AI_DAILY_LIMIT_CODES.has(value.trim()));
+  }
+
+  public static getDailyFreeAllocationMessage(): string {
+    return 'Workers AI daily free allocation was exceeded.';
+  }
+
+  private static collectErrorValues(error: unknown, seen: WeakSet<object> = new WeakSet<object>(), depth = 0): string[] {
+    if (error === null || error === undefined || depth > 6) return [];
+    if (typeof error === 'string' || typeof error === 'number') return [String(error)];
+    if (typeof error !== 'object') return [];
+    if (seen.has(error)) return [];
+    seen.add(error);
+
+    const values: string[] = [];
+    if (error instanceof Error) {
+      values.push(error.name, error.message);
+    }
+
+    for (const value of Object.values(error as Record<string, unknown>)) {
+      values.push(...WorkersAiErrorUtil.collectErrorValues(value, seen, depth + 1));
+    }
+    return values;
+  }
+}
+
+export { WorkersAiErrorUtil };

--- a/packages/backend-services/src/email/index.ts
+++ b/packages/backend-services/src/email/index.ts
@@ -3,3 +3,4 @@ export * from './AiUsageUtil';
 export * from './EmailContextUtil';
 export * from './EmailProcessingUtil';
 export * from './EmailSummaryUtil';
+export * from './WorkersAiErrorUtil';

--- a/test/utils/EmailContextUtil.test.ts
+++ b/test/utils/EmailContextUtil.test.ts
@@ -1,6 +1,8 @@
+import { AiDailyUsageDAO } from '@mail-otter/backend-data/dao';
+import { NonRetryableError } from '@mail-otter/backend-errors';
 import { EmailContextUtil } from '@mail-otter/backend-services/email';
 import type { ConnectedApplication } from '@mail-otter/shared/model';
-import { describe, expect, it, vi } from 'vitest';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
 
 class FakeStatement {
   private readonly database: FakeD1Database;
@@ -65,6 +67,10 @@ class FakeD1Database {
 }
 
 describe('EmailContextUtil', () => {
+  beforeEach(() => {
+    vi.restoreAllMocks();
+  });
+
   it('keeps plaintext email context out of D1 while preserving Vectorize metadata', async () => {
     const database = new FakeD1Database();
     const vectorize = {
@@ -120,4 +126,85 @@ describe('EmailContextUtil', () => {
     });
     expect(String(vectorPayload?.metadata?.indexedText)).toContain('A confidential plan for the next quarter.');
   });
+
+  it('skips context embedding when the local daily neuron estimate reached the threshold', async () => {
+    vi.spyOn(AiDailyUsageDAO.prototype, 'getEstimatedNeuronsForDate').mockResolvedValue(9000);
+    const database = new FakeD1Database();
+    const vectorize = {
+      upsert: vi.fn().mockResolvedValue({ mutationId: 'mutation-1' }),
+    };
+    const ai = {
+      run: vi.fn().mockResolvedValue({ data: [[0.1, 0.2, 0.3]] }),
+    };
+
+    await expect(
+      EmailContextUtil.prepareEmailRagContext({
+        env: {
+          DB: database as unknown as D1Database,
+          AES_ENCRYPTION_KEY_SECRET: { get: vi.fn().mockResolvedValue('test-secret') } as unknown as SecretsStoreSecret,
+          AI: ai as unknown as Ai,
+          EMAIL_CONTEXT_INDEX: vectorize as unknown as Vectorize,
+          AI_DAILY_NEURON_FALLBACK_THRESHOLD: '9000',
+        },
+        application: createApplication(),
+        enabledApplicationIds: [],
+        subject: 'Quarterly roadmap',
+        from: 'sender@example.com',
+        body: 'A confidential plan for the next quarter.',
+        sourceDocumentId: 'gmail-message-123',
+        sourceThreadId: 'gmail-thread-456',
+      }),
+    ).resolves.toBeUndefined();
+
+    expect(ai.run).not.toHaveBeenCalled();
+    expect(vectorize.upsert).not.toHaveBeenCalled();
+    expect(database.documentRow).toBeUndefined();
+  });
+
+  it('rethrows Workers AI embedding free allocation exhaustion as non-retryable', async () => {
+    const database = new FakeD1Database();
+    const vectorize = {
+      upsert: vi.fn().mockResolvedValue({ mutationId: 'mutation-1' }),
+    };
+    const ai = {
+      run: vi.fn().mockRejectedValue(new Error('4006: you have used up your daily free allocation of 10,000 neurons')),
+    };
+
+    await expect(
+      EmailContextUtil.prepareEmailRagContext({
+        env: {
+          DB: database as unknown as D1Database,
+          AES_ENCRYPTION_KEY_SECRET: { get: vi.fn().mockResolvedValue('test-secret') } as unknown as SecretsStoreSecret,
+          AI: ai as unknown as Ai,
+          EMAIL_CONTEXT_INDEX: vectorize as unknown as Vectorize,
+          AI_DAILY_NEURON_FALLBACK_THRESHOLD: '0',
+        },
+        application: createApplication(),
+        enabledApplicationIds: [],
+        subject: 'Quarterly roadmap',
+        from: 'sender@example.com',
+        body: 'A confidential plan for the next quarter.',
+        sourceDocumentId: 'gmail-message-123',
+        sourceThreadId: 'gmail-thread-456',
+      }),
+    ).rejects.toThrow(NonRetryableError);
+
+    expect(vectorize.upsert).not.toHaveBeenCalled();
+  });
 });
+
+function createApplication(): ConnectedApplication {
+  return {
+    applicationId: '11111111-1111-4111-8111-111111111111',
+    userEmail: 'owner@example.com',
+    providerEmail: 'owner@example.com',
+    displayName: 'Work inbox',
+    providerId: 'google-gmail',
+    connectionMethod: 'oauth2',
+    status: 'connected',
+    contextIndexingEnabled: true,
+    createdAt: 1,
+    updatedAt: 1,
+    credentials: { clientId: 'client', clientSecret: 'secret', refreshToken: 'refresh' },
+  };
+}

--- a/test/utils/EmailProcessingUtil.test.ts
+++ b/test/utils/EmailProcessingUtil.test.ts
@@ -200,13 +200,35 @@ describe('EmailProcessingUtil', () => {
       });
     });
 
-    it('classifies Workers AI free allocation exhaustion as non-retryable', async () => {
+    it('classifies Workers AI 4006 free allocation exhaustion as non-retryable', async () => {
       vi.spyOn(ProcessedMessageDAO.prototype, 'tryStart').mockResolvedValue(true);
       const markError = vi.spyOn(ProcessedMessageDAO.prototype, 'markError').mockResolvedValue();
       vi.spyOn(OutlookProviderUtil, 'getMessage').mockResolvedValue(createOutlookMessage());
       vi.spyOn(EmailSummaryUtil, 'summarizeEmailWithUsage').mockRejectedValue(
-        new Error('Account limited 3036: You have used up your daily free allocation of 10,000 neurons.'),
+        new Error(
+          "4006: you have used up your daily free allocation of 10,000 neurons, please upgrade to Cloudflare's Workers Paid plan if you would like to continue usage.",
+        ),
       );
+
+      await expect(
+        EmailProcessingUtil.processOutlookMessage(createApplication(), 'access-token', 'message-1', createEnv(), []),
+      ).rejects.toThrow(NonRetryableError);
+
+      expect(markError).toHaveBeenCalledWith('app-1', 'message-1', 'Workers AI daily free allocation was exceeded.');
+    });
+
+    it('classifies nested Workers AI free allocation payloads as non-retryable', async () => {
+      vi.spyOn(ProcessedMessageDAO.prototype, 'tryStart').mockResolvedValue(true);
+      const markError = vi.spyOn(ProcessedMessageDAO.prototype, 'markError').mockResolvedValue();
+      vi.spyOn(OutlookProviderUtil, 'getMessage').mockResolvedValue(createOutlookMessage());
+      vi.spyOn(EmailSummaryUtil, 'summarizeEmailWithUsage').mockRejectedValue({
+        errors: [
+          {
+            code: 4006,
+            message: "you have used up your daily free allocation of 10,000 neurons",
+          },
+        ],
+      });
 
       await expect(
         EmailProcessingUtil.processOutlookMessage(createApplication(), 'access-token', 'message-1', createEnv(), []),


### PR DESCRIPTION
Detect Cloudflare Workers AI daily free-allocation errors more reliably, including the observed `4006` runtime code and nested Cloudflare error payloads.

- Share free-allocation detection between summary and context embedding paths.
- Rethrow embedding quota exhaustion as non-retryable instead of continuing to another Workers AI call.
- Skip context embedding when the local daily neuron estimate already reached the configured threshold.
- Cover exact `4006` messages, nested payloads, embedding failures, and local-threshold skips in tests.

Verification:
- `source ~/.customrc && volta run pnpm run checks`