### PR TITLE
Trigger Deployment After Upstream Sync

### DIFF
--- a/.github/workflows/continuous-deployment.yml
+++ b/.github/workflows/continuous-deployment.yml
@@ -11,15 +11,18 @@ on:
       - main
     types:
       - completed
+  repository_dispatch:
+    types:
+      - Upstream Sync Deployment
   workflow_dispatch:
 
 concurrency:
-  group: continuous-deployment-${{ github.event.workflow_run.head_branch || github.ref }}
+  group: continuous-deployment-${{ github.event.workflow_run.head_branch || github.event.client_payload.branch || github.ref }}
   cancel-in-progress: false
 
 jobs:
   deploy-worker:
-    if: ${{ github.event_name == 'workflow_dispatch' || github.event.workflow_run.conclusion == 'success' }}
+    if: ${{ github.event_name == 'workflow_dispatch' || github.event_name == 'repository_dispatch' || github.event.workflow_run.conclusion == 'success' }}
     name: Deploy Cloudflare Worker
     runs-on: ubuntu-latest
 
@@ -27,7 +30,7 @@ jobs:
       - name: Checkout Repository
         uses: actions/checkout@v6
         with:
-          ref: ${{ github.event.workflow_run.head_sha || github.sha }}
+          ref: ${{ github.event.workflow_run.head_sha || github.event.client_payload.sha || github.sha }}
 
       - name: Install pnpm
         uses: pnpm/action-setup@v4
@@ -95,7 +98,7 @@ jobs:
           CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
 
   deploy-pages:
-    if: ${{ github.event_name == 'workflow_dispatch' || github.event.workflow_run.conclusion == 'success' }}
+    if: ${{ github.event_name == 'workflow_dispatch' || github.event_name == 'repository_dispatch' || github.event.workflow_run.conclusion == 'success' }}
     name: Deploy Cloudflare Pages
     runs-on: ubuntu-latest
 
@@ -103,7 +106,7 @@ jobs:
       - name: Checkout Repository
         uses: actions/checkout@v6
         with:
-          ref: ${{ github.event.workflow_run.head_sha || github.sha }}
+          ref: ${{ github.event.workflow_run.head_sha || github.event.client_payload.sha || github.sha }}
 
       - name: Install pnpm
         uses: pnpm/action-setup@v4
@@ -141,5 +144,5 @@ jobs:
           CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
           CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
           CLOUDFLARE_PAGES_PROJECT_NAME: ${{ vars.CLOUDFLARE_PAGES_PROJECT_NAME }}
-          DEPLOY_BRANCH: ${{ github.event.workflow_run.head_branch || github.ref_name }}
-          DEPLOY_SHA: ${{ github.event.workflow_run.head_sha || github.sha }}
+          DEPLOY_BRANCH: ${{ github.event.workflow_run.head_branch || github.event.client_payload.branch || github.ref_name }}
+          DEPLOY_SHA: ${{ github.event.workflow_run.head_sha || github.event.client_payload.sha || github.sha }}

--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -6,7 +6,7 @@ permissions:
 on:
   repository_dispatch:
     types:
-      - upstream-sync
+      - Upstream Sync
   pull_request:
   push:
     branches:
@@ -66,3 +66,28 @@ jobs:
 
       - name: Type Check API Worker
         run: pnpm --filter @mail-otter/api typecheck
+
+  dispatch-upstream-sync-deployment:
+    if: ${{ github.event_name == 'repository_dispatch' && github.event.action == 'Upstream Sync' }}
+    name: Dispatch Upstream Sync Deployment
+    needs:
+      - checks
+      - build
+    permissions:
+      contents: write
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Dispatch Deployment
+        uses: actions/github-script@v7
+        with:
+          script: |
+            await github.rest.repos.createDispatchEvent({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              event_type: 'Upstream Sync Deployment',
+              client_payload: {
+                branch: context.payload.client_payload?.branch || 'main',
+                sha: context.payload.client_payload?.sha || context.sha,
+              },
+            });


### PR DESCRIPTION
Dispatch a dedicated deployment repository event after upstream sync CI succeeds.

This keeps the existing push and workflow_run deployment path intact while allowing the GITHUB_TOKEN-triggered upstream sync flow to continue through a repository_dispatch event.