### PR TITLE
Support Env Var Patching In Continuous Deployments

### DIFF
--- a/.github/workflows/continuous-deployment.yml
+++ b/.github/workflows/continuous-deployment.yml
@@ -48,6 +48,7 @@ jobs:
         run: pnpm exec tsx scripts/prepare-wrangler-config.ts
         env:
           WRANGLER_JSONC: ${{ vars.WRANGLER_JSONC }}
+          WRANGLER_VARS_PATCH_JSON: ${{ vars.WRANGLER_VARS_PATCH_JSON }}
           CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
           CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
 

--- a/README.md
+++ b/README.md
@@ -76,15 +76,29 @@ After OAuth succeeds, start the watch in Mail-Otter. The UI shows a one-time web
 
 Set these in `wrangler.jsonc` under `vars` to override defaults:
 
-| Variable | Default | Description |
-| --- | --- | --- |
-| `MAX_APPLICATIONS_PER_USER` | `99` | Hard limit on connected applications per user |
-| `MAX_CONTEXT_DOCUMENTS_PER_APPLICATION` | `10000` | Global ceiling on indexed documents per application |
-| `MAX_EMAIL_BODY_CHARS` | `12000` | Characters of email body sent to AI for summarization |
-| `AI_SUMMARY_MODEL` | `@cf/openai/gpt-oss-120b` | Workers AI model for email summarization |
-| `AI_SUMMARY_FALLBACK_MODEL` | `@cf/openai/gpt-oss-20b` | Workers AI summary model used after the daily neuron fallback threshold is reached |
-| `AI_DAILY_NEURON_FALLBACK_THRESHOLD` | `9000` | Estimated UTC daily Workers AI neuron usage where summaries switch to the fallback model; set `0` to disable |
-| `AI_EMBEDDING_MODEL` | `@cf/baai/bge-m3` | Workers AI model for context embeddings |
+| Variable                                | Default                   | Description                                                                                                  |
+| --------------------------------------- | ------------------------- | ------------------------------------------------------------------------------------------------------------ |
+| `MAX_APPLICATIONS_PER_USER`             | `99`                      | Hard limit on connected applications per user                                                                |
+| `MAX_CONTEXT_DOCUMENTS_PER_APPLICATION` | `10000`                   | Global ceiling on indexed documents per application                                                          |
+| `MAX_EMAIL_BODY_CHARS`                  | `12000`                   | Characters of email body sent to AI for summarization                                                        |
+| `AI_SUMMARY_MODEL`                      | `@cf/openai/gpt-oss-120b` | Workers AI model for email summarization                                                                     |
+| `AI_SUMMARY_FALLBACK_MODEL`             | `@cf/openai/gpt-oss-20b`  | Workers AI summary model used after the daily neuron fallback threshold is reached                           |
+| `AI_DAILY_NEURON_FALLBACK_THRESHOLD`    | `9000`                    | Estimated UTC daily Workers AI neuron usage where summaries switch to the fallback model; set `0` to disable |
+| `AI_EMBEDDING_MODEL`                    | `@cf/baai/bge-m3`         | Workers AI model for context embeddings                                                                      |
+
+## Continuous Deployment Variables
+
+GitHub Actions deployments can patch Worker `vars` without replacing the whole Wrangler configuration. Set the repository variable `WRANGLER_VARS_PATCH_JSON` to a JSON object of string values. The deployment merges it into top-level `vars` after loading `WRANGLER_JSONC` or `apps/api/wrangler.template.jsonc`.
+
+```json
+{
+  "POLICY_AUD": "your-cloudflare-zero-trust-application-aud",
+  "TEAM_DOMAIN": "https://your-cloudflare-zero-trust-team-domain.cloudflareaccess.com",
+  "SERVE_SPA_FROM_WORKER": "true"
+}
+```
+
+Do not put secrets in `WRANGLER_VARS_PATCH_JSON`; use GitHub secrets, Wrangler secrets, or Cloudflare Secrets Store for sensitive values.
 
 ## Commands
 

--- a/scripts/prepare-wrangler-config.ts
+++ b/scripts/prepare-wrangler-config.ts
@@ -17,6 +17,7 @@ const VECTORIZE_DIMENSIONS = 1024;
 
 interface WranglerConfig {
   name?: string;
+  vars?: Record<string, unknown>;
   d1_databases?: Array<{
     binding?: string;
     database_id?: string;
@@ -75,9 +76,40 @@ function readConfig(): { content: string; config: WranglerConfig } {
   return { content, config: parse(content) as WranglerConfig };
 }
 
-function writeConfigValue(content: string, path: Array<string | number>, value: string): string {
+function writeConfigValue(content: string, path: Array<string | number>, value: unknown): string {
   const edits = modify(content, path, value, { formattingOptions: { insertSpaces: true, tabSize: 2, eol: '\n' } });
   return applyEdits(content, edits);
+}
+
+function parseVarsPatch(): Record<string, string> | undefined {
+  const rawPatch = process.env.WRANGLER_VARS_PATCH_JSON;
+  if (!rawPatch?.trim()) {
+    return undefined;
+  }
+
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(rawPatch) as unknown;
+  } catch {
+    throw new Error('WRANGLER_VARS_PATCH_JSON must be a valid JSON object of string values.');
+  }
+
+  if (!parsed || typeof parsed !== 'object' || Array.isArray(parsed)) {
+    throw new Error('WRANGLER_VARS_PATCH_JSON must be a JSON object of string values.');
+  }
+
+  const patch: Record<string, string> = {};
+  for (const [key, value] of Object.entries(parsed)) {
+    if (!key.trim()) {
+      throw new Error('WRANGLER_VARS_PATCH_JSON contains an empty variable name.');
+    }
+    if (typeof value !== 'string') {
+      throw new Error(`WRANGLER_VARS_PATCH_JSON value for ${key} must be a string.`);
+    }
+    patch[key] = value;
+  }
+
+  return patch;
 }
 
 function prepareConfigFile(): void {
@@ -90,6 +122,32 @@ function prepareConfigFile(): void {
 
   copyFileSync(TEMPLATE_PATH, CONFIG_PATH);
   console.log('WRANGLER_JSONC is empty; copied apps/api/wrangler.template.jsonc to wrangler.jsonc.');
+}
+
+function applyVarsPatch(): void {
+  const patch = parseVarsPatch();
+  const patchEntries = Object.entries(patch ?? {});
+  if (patchEntries.length === 0) {
+    return;
+  }
+
+  const preparedConfig = readConfig();
+  let content = preparedConfig.content;
+  const { config } = preparedConfig;
+  if (config.vars !== undefined && (config.vars === null || typeof config.vars !== 'object' || Array.isArray(config.vars))) {
+    throw new Error('wrangler.jsonc vars must be an object before applying WRANGLER_VARS_PATCH_JSON.');
+  }
+
+  if (!config.vars) {
+    content = writeConfigValue(content, ['vars'], {});
+  }
+
+  for (const [key, value] of patchEntries) {
+    content = writeConfigValue(content, ['vars', key], value);
+  }
+
+  writeFileSync(CONFIG_PATH, content.endsWith('\n') ? content : `${content}\n`);
+  console.log(`Applied ${patchEntries.length} Wrangler vars patch entr${patchEntries.length === 1 ? 'y' : 'ies'}.`);
 }
 
 function parseJsonArray<T>(output: string, commandDescription: string): T[] {
@@ -295,5 +353,6 @@ function provisionWranglerResources(): void {
 }
 
 prepareConfigFile();
+applyVarsPatch();
 provisionWranglerResources();
 console.log('Wrangler configuration is ready.');


### PR DESCRIPTION
## Summary

- Add `WRANGLER_VARS_PATCH_JSON` validation and merge support in Wrangler config preparation.
- Wire the GitHub Actions repository variable into continuous deployment.
- Document safe usage for non-secret Worker vars.

## Validation

- `source ~/.customrc && volta run pnpm run typecheck`
- `source ~/.customrc && volta run pnpm run test`
- `source ~/.customrc && volta run pnpm exec prettier --check scripts/prepare-wrangler-config.ts .github/workflows/continuous-deployment.yml README.md`
- `source ~/.customrc && volta run pnpm exec eslint --ext .ts,.tsx scripts/prepare-wrangler-config.ts`