### PR TITLE
Display Summary Model In Footer

### DIFF
--- a/packages/backend-services/src/email/EmailSummaryUtil.ts
+++ b/packages/backend-services/src/email/EmailSummaryUtil.ts
@@ -101,7 +101,7 @@ class EmailSummaryUtil {
     if (!summary) {
       throw new AiSummaryRetryableError('Workers AI did not return a valid summary.');
     }
-    return { summary: EmailSummaryUtil.renderSummary(summary), usage };
+    return { summary: EmailSummaryUtil.renderSummary(summary, model), usage };
   }
 
   private static supportsJsonMode(model: string): boolean {
@@ -174,7 +174,7 @@ class EmailSummaryUtil {
     };
   }
 
-  static renderSummary(summary: EmailSummary): string {
+  static renderSummary(summary: EmailSummary, model: string): string {
     const gist: string = EmailSummaryUtil.normalizeSentence(summary.gist) || 'No clear gist available.';
     const keyDetails: string[] = EmailSummaryUtil.normalizeItems(summary.keyDetails);
     const actionItems: string[] = EmailSummaryUtil.normalizeItems(summary.actionItems);
@@ -188,7 +188,7 @@ class EmailSummaryUtil {
       'Action items:',
       ...EmailSummaryUtil.renderList(actionItems, 'None.'),
       '',
-      '<Mail-Otter Summary>',
+      `<Mail-Otter Summary - AI model: ${model}>`,
     ].join('\n');
   }
 

--- a/test/utils/EmailSummaryUtil.test.ts
+++ b/test/utils/EmailSummaryUtil.test.ts
@@ -23,7 +23,7 @@ Key details:
 Action items:
 - Approve or reject the budget by Friday.
 
-<Mail-Otter Summary>`);
+<Mail-Otter Summary - AI model: @cf/meta/llama-3.1-8b-instruct>`);
     expect(ai.run).toHaveBeenCalledWith(
       '@cf/meta/llama-3.1-8b-instruct',
       expect.objectContaining({
@@ -54,7 +54,7 @@ Key details:
 Action items:
 - None.
 
-<Mail-Otter Summary>`);
+<Mail-Otter Summary - AI model: model>`);
   });
 
   it('throws when the AI response cannot be parsed into the summary schema', async () => {
@@ -93,7 +93,7 @@ Key details:
 Action items:
 - Approve the budget by Friday.
 
-<Mail-Otter Summary>`);
+<Mail-Otter Summary - AI model: @cf/openai/gpt-oss-120b>`);
     expect(ai.run).toHaveBeenCalledWith(
       '@cf/openai/gpt-oss-120b',
       expect.not.objectContaining({
@@ -131,7 +131,7 @@ Key details:
 Action items:
 - None.
 
-<Mail-Otter Summary>`);
+<Mail-Otter Summary - AI model: @cf/openai/gpt-oss-120b>`);
   });
 
   it('returns token usage with summarized email output when available', async () => {


### PR DESCRIPTION
Adds the selected Workers AI summary model to the Mail-Otter summary footer so each generated summary shows which model was used.