### PR TITLE
Enable Dependabot Auto Merge

### DIFF
--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -67,6 +67,24 @@ jobs:
       - name: Type Check API Worker
         run: pnpm --filter @mail-otter/api typecheck
 
+  dependabot-auto-merge:
+    if: ${{ github.event_name == 'pull_request' && github.event.pull_request.user.login == 'dependabot[bot]' && github.event.pull_request.state == 'open' && !github.event.repository.fork }}
+    name: Auto-Merge Dependabot PR
+    needs:
+      - checks
+      - build
+    permissions:
+      contents: write
+      pull-requests: write
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Enable Auto-Merge
+        run: gh pr merge --auto --merge "$PR_URL"
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PR_URL: ${{ github.event.pull_request.html_url }}
+
   dispatch-upstream-sync-deployment:
     if: ${{ github.event_name == 'repository_dispatch' && github.event.action == 'Upstream Sync' }}
     name: Dispatch Upstream Sync Deployment


### PR DESCRIPTION
Add a Dependabot-only CI job that enables GitHub native auto-merge after checks and build pass.