### PR TITLE
Send Summary As HTML

### DIFF
--- a/packages/provider-clients/src/EmailContentUtil.ts
+++ b/packages/provider-clients/src/EmailContentUtil.ts
@@ -43,6 +43,35 @@ class EmailContentUtil {
     });
   }
 
+  public static renderPlainTextAsHtml(value: string): string {
+    const escaped: string = EmailContentUtil.escapeHtml(value.replace(/\r\n/g, '\n').replace(/\r/g, '\n')).replace(/\n/g, '<br>\n');
+    return [
+      '<!doctype html>',
+      '<html>',
+      '<body style="margin:0;padding:0;font-family:Arial,sans-serif;line-height:1.5;color:#111827;">',
+      `<div style="font-size:14px;">${escaped}</div>`,
+      '</body>',
+      '</html>',
+    ].join('\n');
+  }
+
+  public static buildAlternativeMimeBody(textBody: string, htmlBody: string, boundary: string): string {
+    return [
+      `--${boundary}`,
+      'Content-Type: text/plain; charset=utf-8',
+      'Content-Transfer-Encoding: 8bit',
+      '',
+      EmailContentUtil.toCrlf(textBody),
+      `--${boundary}`,
+      'Content-Type: text/html; charset=utf-8',
+      'Content-Transfer-Encoding: 8bit',
+      '',
+      EmailContentUtil.toCrlf(htmlBody),
+      `--${boundary}--`,
+      '',
+    ].join('\r\n');
+  }
+
   public static normalizeText(value: string): string {
     return value
       .replace(/\r\n/g, '\n')
@@ -60,6 +89,29 @@ class EmailContentUtil {
   public static isFromMailbox(fromHeaderOrAddress: string | undefined | null, mailboxAddress: string | undefined | null): boolean {
     if (!fromHeaderOrAddress || !mailboxAddress) return false;
     return fromHeaderOrAddress.toLowerCase().includes(mailboxAddress.toLowerCase());
+  }
+
+  private static toCrlf(value: string): string {
+    return value.replace(/\r\n/g, '\n').replace(/\r/g, '\n').replace(/\n/g, '\r\n');
+  }
+
+  private static escapeHtml(value: string): string {
+    return value.replace(/[&<>"']/g, (char: string): string => {
+      switch (char) {
+        case '&':
+          return '&amp;';
+        case '<':
+          return '&lt;';
+        case '>':
+          return '&gt;';
+        case '"':
+          return '&quot;';
+        case "'":
+          return '&#39;';
+        default:
+          return char;
+      }
+    });
   }
 
   private static findGmailPart(part: GmailMessagePart | undefined, mimeType: string): string | undefined {

--- a/packages/provider-clients/src/GmailProviderUtil.ts
+++ b/packages/provider-clients/src/GmailProviderUtil.ts
@@ -113,6 +113,8 @@ class GmailProviderUtil {
     const originalReferences: string | undefined = EmailContentUtil.getHeader(headers, 'References');
     const replySubject: string = /^re:/i.test(originalSubject) ? originalSubject : `Re: ${originalSubject}`;
     const references: string = [originalReferences, originalMessageId].filter(Boolean).join(' ');
+    const boundary: string = GmailProviderUtil.createSummaryMimeBoundary(originalMessage.id);
+    const htmlSummary: string = EmailContentUtil.renderPlainTextAsHtml(summary);
     const message: string = [
       `From: ${from}`,
       `To: ${from}`,
@@ -121,9 +123,9 @@ class GmailProviderUtil {
       ...(references ? [`References: ${references}`] : []),
       'X-Mail-Otter-Summary: true',
       'MIME-Version: 1.0',
-      'Content-Type: text/plain; charset=utf-8',
+      `Content-Type: multipart/alternative; boundary="${boundary}"`,
       '',
-      summary,
+      EmailContentUtil.buildAlternativeMimeBody(summary, htmlSummary, boundary),
     ].join('\r\n');
     const response: Response = await fetch('https://gmail.googleapis.com/gmail/v1/users/me/messages/send', {
       method: 'POST',
@@ -177,6 +179,11 @@ class GmailProviderUtil {
 
   private static isRetryableStatus(status: number): boolean {
     return status === 408 || status === 409 || status === 425 || status === 429 || status >= 500;
+  }
+
+  private static createSummaryMimeBoundary(seed: string): string {
+    const safeSeed: string = seed.replace(/[^A-Za-z0-9_-]/g, '').slice(0, 32) || 'message';
+    return `mail-otter-summary-${safeSeed}`;
   }
 }
 

--- a/packages/provider-clients/src/OutlookProviderUtil.ts
+++ b/packages/provider-clients/src/OutlookProviderUtil.ts
@@ -144,35 +144,19 @@ class OutlookProviderUtil {
     mailboxAddress: string,
     summary: string,
   ): Promise<void> {
+    const mimeMessage: string = OutlookProviderUtil.createSummaryReplyMimeMessage(originalMessage, mailboxAddress, summary);
     const draft = await OutlookProviderUtil.fetchJson<{ id?: string | undefined }>(
       `https://graph.microsoft.com/v1.0/me/messages/${encodeURIComponent(originalMessage.id)}/createReply`,
       accessToken,
       {
         method: 'POST',
-        headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({ comment: '' }),
+        headers: { 'Content-Type': 'text/plain' },
+        body: OutlookProviderUtil.base64EncodeString(mimeMessage),
       },
     );
     if (!draft.id) {
       throw new ProviderApiRetryableError('Microsoft Graph createReply did not return a draft id.');
     }
-    await OutlookProviderUtil.fetchJson<unknown>(
-      `https://graph.microsoft.com/v1.0/me/messages/${encodeURIComponent(draft.id)}`,
-      accessToken,
-      {
-        method: 'PATCH',
-        headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({
-          body: {
-            contentType: 'Text',
-            content: summary,
-          },
-          toRecipients: [{ emailAddress: { address: mailboxAddress } }],
-          ccRecipients: [],
-          bccRecipients: [],
-        }),
-      },
-    );
     const response = await fetch(`https://graph.microsoft.com/v1.0/me/messages/${encodeURIComponent(draft.id)}/send`, {
       method: 'POST',
       headers: {
@@ -213,6 +197,43 @@ class OutlookProviderUtil {
 
   private static isRetryableStatus(status: number): boolean {
     return status === 408 || status === 409 || status === 425 || status === 429 || status >= 500;
+  }
+
+  private static createSummaryReplyMimeMessage(originalMessage: OutlookMessage, mailboxAddress: string, summary: string): string {
+    const originalSubject: string = originalMessage.subject || '(no subject)';
+    const originalMessageId: string | undefined = EmailContentUtil.getHeader(originalMessage.internetMessageHeaders, 'Message-ID');
+    const originalReferences: string | undefined = EmailContentUtil.getHeader(originalMessage.internetMessageHeaders, 'References');
+    const replySubject: string = /^re:/i.test(originalSubject) ? originalSubject : `Re: ${originalSubject}`;
+    const references: string = [originalReferences, originalMessageId].filter(Boolean).join(' ');
+    const boundary: string = OutlookProviderUtil.createSummaryMimeBoundary(originalMessage.id);
+    const htmlSummary: string = EmailContentUtil.renderPlainTextAsHtml(summary);
+
+    return [
+      `From: ${mailboxAddress}`,
+      `To: ${mailboxAddress}`,
+      `Subject: ${replySubject}`,
+      ...(originalMessageId ? [`In-Reply-To: ${originalMessageId}`] : []),
+      ...(references ? [`References: ${references}`] : []),
+      'X-Mail-Otter-Summary: true',
+      'MIME-Version: 1.0',
+      `Content-Type: multipart/alternative; boundary="${boundary}"`,
+      '',
+      EmailContentUtil.buildAlternativeMimeBody(summary, htmlSummary, boundary),
+    ].join('\r\n');
+  }
+
+  private static createSummaryMimeBoundary(seed: string): string {
+    const safeSeed: string = seed.replace(/[^A-Za-z0-9_-]/g, '').slice(0, 32) || 'message';
+    return `mail-otter-summary-${safeSeed}`;
+  }
+
+  private static base64EncodeString(value: string): string {
+    const bytes: Uint8Array = new TextEncoder().encode(value);
+    let binary = '';
+    bytes.forEach((byte: number): void => {
+      binary += String.fromCharCode(byte);
+    });
+    return btoa(binary);
   }
 
   private static async deleteSentCopy(accessToken: string, messageId: string): Promise<void> {

--- a/test/utils/GmailProviderUtil.test.ts
+++ b/test/utils/GmailProviderUtil.test.ts
@@ -26,13 +26,30 @@ describe('GmailProviderUtil', () => {
         },
       };
 
-      await GmailProviderUtil.sendSummaryReply('test-access-token', 'sender@example.com', originalMessage as never, 'Summary text');
+      await GmailProviderUtil.sendSummaryReply(
+        'test-access-token',
+        'sender@example.com',
+        originalMessage as never,
+        'Summary <tag> & text\nNext line',
+      );
 
       expect(fetchMock).toHaveBeenCalledTimes(2);
 
       const sendCall = fetchMock.mock.calls[0];
       expect(sendCall[0]).toBe('https://gmail.googleapis.com/gmail/v1/users/me/messages/send');
       expect(sendCall[1].method).toBe('POST');
+
+      const sendBody = JSON.parse(sendCall[1].body as string) as { threadId?: string; raw?: string };
+      const rawMessage: string = decodeBase64Url(sendBody.raw || '');
+      const boundary: string = extractMimeBoundary(rawMessage);
+      expect(sendBody.threadId).toBe('thread-123');
+      expect(rawMessage).toContain('X-Mail-Otter-Summary: true');
+      expect(rawMessage).toContain(`Content-Type: multipart/alternative; boundary="${boundary}"`);
+      expect(rawMessage).toContain(`--${boundary}\r\nContent-Type: text/plain; charset=utf-8`);
+      expect(rawMessage).toContain('Summary <tag> & text\r\nNext line');
+      expect(rawMessage).toContain(`--${boundary}\r\nContent-Type: text/html; charset=utf-8`);
+      expect(rawMessage).toContain('Summary &lt;tag&gt; &amp; text<br>\r\nNext line');
+      expect(rawMessage).toContain(`--${boundary}--`);
 
       const trashCall = fetchMock.mock.calls[1];
       expect(trashCall[0]).toBe('https://gmail.googleapis.com/gmail/v1/users/me/messages/sent-message-id-123/trash');
@@ -78,3 +95,17 @@ describe('GmailProviderUtil', () => {
     });
   });
 });
+
+function decodeBase64Url(value: string): string {
+  const normalized: string = value.replace(/-/g, '+').replace(/_/g, '/');
+  const padded: string = normalized.padEnd(normalized.length + ((4 - (normalized.length % 4)) % 4), '=');
+  const binary: string = atob(padded);
+  const bytes: Uint8Array = Uint8Array.from(binary, (char: string): number => char.charCodeAt(0));
+  return new TextDecoder().decode(bytes);
+}
+
+function extractMimeBoundary(rawMessage: string): string {
+  const match: RegExpMatchArray | null = rawMessage.match(/boundary="([^"]+)"/);
+  expect(match).not.toBeNull();
+  return match![1]!;
+}

--- a/test/utils/OutlookProviderUtil.test.ts
+++ b/test/utils/OutlookProviderUtil.test.ts
@@ -8,15 +8,13 @@ describe('OutlookProviderUtil', () => {
 
   describe('sendSelfSummaryReply', () => {
     it('sends a threaded reply and deletes the sent copy', async () => {
-      const mockCreateReplyResponse = new Response(JSON.stringify({ id: 'draft-id-123' }), { status: 200 });
-      const mockPatchResponse = new Response('', { status: 200 });
+      const mockCreateReplyResponse = new Response(JSON.stringify({ id: 'draft-id-123' }), { status: 201 });
       const mockSendResponse = new Response('', { status: 202 });
       const mockDeleteResponse = new Response(null, { status: 204 });
 
       const fetchMock = vi
         .fn()
         .mockResolvedValueOnce(mockCreateReplyResponse)
-        .mockResolvedValueOnce(mockPatchResponse)
         .mockResolvedValueOnce(mockSendResponse)
         .mockResolvedValueOnce(mockDeleteResponse);
 
@@ -31,32 +29,45 @@ describe('OutlookProviderUtil', () => {
         ],
       };
 
-      await OutlookProviderUtil.sendSelfSummaryReply('test-access-token', originalMessage, 'sender@example.com', 'Summary text');
+      await OutlookProviderUtil.sendSelfSummaryReply(
+        'test-access-token',
+        originalMessage,
+        'sender@example.com',
+        'Summary <tag> & text\nNext line',
+      );
 
-      expect(fetchMock).toHaveBeenCalledTimes(4);
+      expect(fetchMock).toHaveBeenCalledTimes(3);
       expect(fetchMock).toHaveBeenNthCalledWith(
         1,
         'https://graph.microsoft.com/v1.0/me/messages/original-msg-id/createReply',
         expect.objectContaining({ method: 'POST' }),
       );
 
-      const patchCall = fetchMock.mock.calls[1];
-      const patchBody = JSON.parse(patchCall[1].body as string);
+      const createReplyCall = fetchMock.mock.calls[0];
+      const createReplyHeaders = createReplyCall[1].headers as Headers;
+      const rawMessage: string = decodeBase64(createReplyCall[1].body as string);
+      const boundary: string = extractMimeBoundary(rawMessage);
 
-      expect(patchBody).toMatchObject({
-        body: { contentType: 'Text', content: 'Summary text' },
-        toRecipients: [{ emailAddress: { address: 'sender@example.com' } }],
-        ccRecipients: [],
-        bccRecipients: [],
-      });
-      expect(patchBody.internetMessageHeaders).toBeUndefined();
+      expect(createReplyHeaders.get('Content-Type')).toBe('text/plain');
+      expect(rawMessage).toContain('From: sender@example.com');
+      expect(rawMessage).toContain('To: sender@example.com');
+      expect(rawMessage).toContain('Subject: Re: Original subject');
+      expect(rawMessage).toContain('In-Reply-To: <original@example.com>');
+      expect(rawMessage).toContain('References: <root@example.com> <original@example.com>');
+      expect(rawMessage).toContain('X-Mail-Otter-Summary: true');
+      expect(rawMessage).toContain(`Content-Type: multipart/alternative; boundary="${boundary}"`);
+      expect(rawMessage).toContain(`--${boundary}\r\nContent-Type: text/plain; charset=utf-8`);
+      expect(rawMessage).toContain('Summary <tag> & text\r\nNext line');
+      expect(rawMessage).toContain(`--${boundary}\r\nContent-Type: text/html; charset=utf-8`);
+      expect(rawMessage).toContain('Summary &lt;tag&gt; &amp; text<br>\r\nNext line');
+      expect(rawMessage).toContain(`--${boundary}--`);
       expect(fetchMock).toHaveBeenNthCalledWith(
-        3,
+        2,
         'https://graph.microsoft.com/v1.0/me/messages/draft-id-123/send',
         expect.objectContaining({ method: 'POST' }),
       );
       expect(fetchMock).toHaveBeenNthCalledWith(
-        4,
+        3,
         'https://graph.microsoft.com/v1.0/me/messages/draft-id-123',
         expect.objectContaining({ method: 'DELETE' }),
       );
@@ -64,13 +75,11 @@ describe('OutlookProviderUtil', () => {
 
     it('throws when send fails', async () => {
       const mockCreateReplyResponse = new Response(JSON.stringify({ id: 'draft-id-123' }), { status: 200 });
-      const mockPatchResponse = new Response('', { status: 200 });
       const mockSendResponse = new Response('Send failed', { status: 500 });
 
       const fetchMock = vi
         .fn()
         .mockResolvedValueOnce(mockCreateReplyResponse)
-        .mockResolvedValueOnce(mockPatchResponse)
         .mockResolvedValueOnce(mockSendResponse);
 
       vi.stubGlobal('fetch', fetchMock);
@@ -101,3 +110,15 @@ describe('OutlookProviderUtil', () => {
     });
   });
 });
+
+function decodeBase64(value: string): string {
+  const binary: string = atob(value);
+  const bytes: Uint8Array = Uint8Array.from(binary, (char: string): number => char.charCodeAt(0));
+  return new TextDecoder().decode(bytes);
+}
+
+function extractMimeBoundary(rawMessage: string): string {
+  const match: RegExpMatchArray | null = rawMessage.match(/boundary="([^"]+)"/);
+  expect(match).not.toBeNull();
+  return match![1]!;
+}


### PR DESCRIPTION
Send email summaries as multipart messages with an HTML body and plain-text fallback for Gmail and Outlook.\n\nUpdate provider-client tests to decode outbound MIME and verify both alternatives.