### PR TITLE
Update Summary Footer Text

### DIFF
--- a/packages/backend-services/src/email/EmailSummaryUtil.ts
+++ b/packages/backend-services/src/email/EmailSummaryUtil.ts
@@ -104,7 +104,7 @@ class EmailSummaryUtil {
     if (!summary) {
       throw new AiSummaryRetryableError('Workers AI did not return a valid summary.');
     }
-    return { summary: EmailSummaryUtil.renderHtmlSummary(summary, model), usage };
+    return { summary: EmailSummaryUtil.renderHtmlSummary(summary), usage };
   }
 
   private static supportsJsonMode(model: string): boolean {
@@ -177,7 +177,7 @@ class EmailSummaryUtil {
     };
   }
 
-  static renderHtmlSummary(summary: EmailSummary, model: string): string {
+  static renderHtmlSummary(summary: EmailSummary): string {
     const gist: string = EmailSummaryUtil.normalizeSentence(summary.gist) || 'No clear gist available.';
     const keyDetails: string[] = EmailSummaryUtil.normalizeItems(summary.keyDetails);
     const actionItems: string[] = EmailSummaryUtil.normalizeItems(summary.actionItems);
@@ -195,12 +195,12 @@ class EmailSummaryUtil {
       ...EmailSummaryUtil.renderHtmlList(actionItems, '<li>None.</li>'),
       '</ul>',
       '',
-      `<p><em>Mail-Otter Summary - by ${model}</em></p>`,
+      '<p><em>Powered by Mail-Otter</em></p>',
     ].join('\n');
   }
 
-  static renderPlainTextSummary(summary: EmailSummary, model: string): string {
-    return EmailContentUtil.stripHtml(EmailSummaryUtil.renderHtmlSummary(summary, model));
+  static renderPlainTextSummary(summary: EmailSummary): string {
+    return EmailContentUtil.stripHtml(EmailSummaryUtil.renderHtmlSummary(summary));
   }
 
   private static parseLooseText(response: string): EmailSummary {

--- a/test/utils/EmailSummaryUtil.test.ts
+++ b/test/utils/EmailSummaryUtil.test.ts
@@ -27,7 +27,7 @@ describe('EmailSummaryUtil', () => {
 <li>Approve or reject the budget by Friday.</li>
 </ul>
 
-<p><em>Mail-Otter Summary - by @cf/meta/llama-3.1-8b-instruct</em></p>`);
+<p><em>Powered by Mail-Otter</em></p>`);
     expect(ai.run).toHaveBeenCalledWith(
       '@cf/meta/llama-3.1-8b-instruct',
       expect.objectContaining({
@@ -62,7 +62,7 @@ describe('EmailSummaryUtil', () => {
 <li>None.</li>
 </ul>
 
-<p><em>Mail-Otter Summary - by model</em></p>`);
+<p><em>Powered by Mail-Otter</em></p>`);
   });
 
   it('throws when the AI response cannot be parsed into the summary schema', async () => {
@@ -105,7 +105,7 @@ describe('EmailSummaryUtil', () => {
 <li>Approve the budget by Friday.</li>
 </ul>
 
-<p><em>Mail-Otter Summary - by @cf/openai/gpt-oss-120b</em></p>`);
+<p><em>Powered by Mail-Otter</em></p>`);
     expect(ai.run).toHaveBeenCalledWith(
       '@cf/openai/gpt-oss-120b',
       expect.not.objectContaining({
@@ -147,7 +147,7 @@ describe('EmailSummaryUtil', () => {
 <li>None.</li>
 </ul>
 
-<p><em>Mail-Otter Summary - by @cf/openai/gpt-oss-120b</em></p>`);
+<p><em>Powered by Mail-Otter</em></p>`);
   });
 
   it('returns token usage with summarized email output when available', async () => {


### PR DESCRIPTION
Remove model name and "Summary" from the email summary footer, replacing it with "Powered by Mail-Otter".