### PR TITLE
Reduce Queue Max Batch Timeout To 2 Seconds

### DIFF
--- a/apps/api/wrangler.template.jsonc
+++ b/apps/api/wrangler.template.jsonc
@@ -88,7 +88,7 @@
       {
         "queue": "mail-otter-email-events",
         "max_batch_size": 10,
-        "max_batch_timeout": 5,
+        "max_batch_timeout": 2,
         "max_retries": 5,
       },
     ],


### PR DESCRIPTION
Reduce the EMAIL_EVENTS_QUEUE consumer max_batch_timeout from 5s to 2s to lower the maximum queue delivery delay.

The queue batch delay accounted for ~15-30% of total user-perceived latency for single-email notifications. This change caps it at 2s while still allowing batching for burst arrivals.