### PR TITLE
Optimize Database Schema, Indexes, And Pagination

### DIFF
--- a/migrations/0011_optimize_database.sql
+++ b/migrations/0011_optimize_database.sql
@@ -1,0 +1,80 @@
+-- ============================================================
+-- Migration 0011: Database Optimization
+-- ============================================================
+-- 1. Composite indexes for query performance
+-- 2. Normalize watched_folder_ids into own table
+-- 3. Normalize provider-specific config into own table
+-- ============================================================
+
+-- 1a. Composite index for processed_messages getLatestForApplication/getLatestErrorForApplication
+-- Query pattern: WHERE application_id = ? AND status = ? ORDER BY updated_at DESC LIMIT 1
+CREATE INDEX IF NOT EXISTS idx_processed_messages_app_status_updated
+  ON processed_messages(application_id, status, updated_at);
+
+-- 1b. Composite index for provider_subscriptions listActiveRenewalCandidates
+-- Query pattern: WHERE status = ? AND expires_at IS NOT NULL AND expires_at <= ?
+--               AND (renewal_next_retry_at IS NULL OR renewal_next_retry_at <= ?)
+--               ORDER BY expires_at ASC
+CREATE INDEX IF NOT EXISTS idx_provider_subscriptions_renewal
+  ON provider_subscriptions(status, expires_at, renewal_next_retry_at);
+
+-- 1c. Composite index for application_context_documents user listing queries
+-- Query pattern: WHERE user_email = ? [AND application_id = ?] [AND status = ?]
+--               ORDER BY updated_at DESC, created_at DESC
+CREATE INDEX IF NOT EXISTS idx_application_context_documents_user_sort
+  ON application_context_documents(user_email, updated_at, created_at);
+
+-- 1d. Composite index for oauth2_authorization_sessions getActive
+-- Query pattern: WHERE application_id = ? AND state_hash = ? AND expires_at > ? AND consumed_at IS NULL
+CREATE INDEX IF NOT EXISTS idx_oauth2_sessions_app_state
+  ON oauth2_authorization_sessions(application_id, state_hash);
+
+-- ============================================================
+-- 2. Normalize watched_folder_ids into application_watched_folders
+-- ============================================================
+
+CREATE TABLE IF NOT EXISTS application_watched_folders (
+    application_id TEXT NOT NULL,
+    folder_path TEXT NOT NULL,
+    created_at INTEGER NOT NULL,
+    PRIMARY KEY (application_id, folder_path),
+    FOREIGN KEY (application_id) REFERENCES connected_applications(application_id) ON DELETE CASCADE
+);
+
+INSERT OR IGNORE INTO application_watched_folders (application_id, folder_path, created_at)
+SELECT
+    ca.application_id,
+    JSON_EACH.value AS folder_path,
+    ca.created_at
+FROM connected_applications ca,
+JSON_EACH(ca.watched_folder_ids)
+WHERE ca.watched_folder_ids IS NOT NULL;
+
+CREATE INDEX IF NOT EXISTS idx_application_watched_folders_application
+  ON application_watched_folders(application_id);
+
+ALTER TABLE connected_applications DROP COLUMN watched_folder_ids;
+
+-- ============================================================
+-- 3. Normalize provider-specific config into provider_application_configs
+-- ============================================================
+
+CREATE TABLE IF NOT EXISTS provider_application_configs (
+    application_id TEXT NOT NULL,
+    config_key TEXT NOT NULL,
+    config_value TEXT NOT NULL,
+    created_at INTEGER NOT NULL,
+    updated_at INTEGER NOT NULL,
+    PRIMARY KEY (application_id, config_key),
+    FOREIGN KEY (application_id) REFERENCES connected_applications(application_id) ON DELETE CASCADE
+);
+
+INSERT OR IGNORE INTO provider_application_configs (application_id, config_key, config_value, created_at, updated_at)
+SELECT application_id, 'gmail_pubsub_topic_name', gmail_pubsub_topic_name, created_at, updated_at
+FROM connected_applications
+WHERE gmail_pubsub_topic_name IS NOT NULL;
+
+CREATE INDEX IF NOT EXISTS idx_provider_application_configs_app
+  ON provider_application_configs(application_id);
+
+ALTER TABLE connected_applications DROP COLUMN gmail_pubsub_topic_name;

--- a/packages/backend-data/src/dao/ApplicationContextDAO.ts
+++ b/packages/backend-data/src/dao/ApplicationContextDAO.ts
@@ -4,6 +4,7 @@ import {
   APPLICATION_CONTEXT_DOCUMENT_STATUS_ACTIVE,
   APPLICATION_CONTEXT_DOCUMENT_STATUS_DELETED,
   APPLICATION_CONTEXT_DOCUMENT_STATUS_ERROR,
+  SOURCE_TYPE_EMAIL,
 } from '@mail-otter/shared/constants';
 import { DatabaseError } from '@mail-otter/backend-errors';
 import type {
@@ -37,7 +38,7 @@ class ApplicationContextDAO {
           LIMIT 1
         `,
       )
-      .bind(input.applicationId, 'email', input.sourceDocumentId)
+      .bind(input.applicationId, SOURCE_TYPE_EMAIL, input.sourceDocumentId)
       .first<ApplicationContextDocumentInternal>();
 
     if (existing) {
@@ -91,7 +92,7 @@ class ApplicationContextDAO {
         contextDocumentId,
         input.applicationId,
         input.userEmail,
-        'email',
+        SOURCE_TYPE_EMAIL,
         input.sourceProviderId,
         input.sourceDocumentId,
         input.sourceThreadId || null,
@@ -209,7 +210,6 @@ class ApplicationContextDAO {
 
   public async listDocumentsForUser(userEmail: string, input: ListContextDocumentsInput = {}): Promise<ApplicationContextDocumentList> {
     const limit: number = Math.min(Math.max(input.limit ?? 25, 1), 100);
-    const offset: number = ApplicationContextDAO.parseCursor(input.cursor);
     const conditions: string[] = ['user_email = ?'];
     const bindings: Array<string | number> = [userEmail];
     if (input.applicationId) {
@@ -220,6 +220,11 @@ class ApplicationContextDAO {
       conditions.push('status = ?');
       bindings.push(input.status);
     }
+    const cursor: { updatedAt: number; createdAt: number } | undefined = ApplicationContextDAO.parseDocumentCursor(input.cursor);
+    if (cursor) {
+      conditions.push('(updated_at < ? OR (updated_at = ? AND created_at < ?))');
+      bindings.push(cursor.updatedAt, cursor.updatedAt, cursor.createdAt);
+    }
     const rows: ApplicationContextDocumentInternal[] = await this.database
       .prepare(
         `
@@ -227,27 +232,31 @@ class ApplicationContextDAO {
           FROM application_context_documents
           WHERE ${conditions.join(' AND ')}
           ORDER BY updated_at DESC, created_at DESC
-          LIMIT ? OFFSET ?
+          LIMIT ?
         `,
       )
-      .bind(...bindings, limit + 1, offset)
+      .bind(...bindings, limit + 1)
       .all<ApplicationContextDocumentInternal>()
       .then((result: D1Result<ApplicationContextDocumentInternal>): ApplicationContextDocumentInternal[] => result.results || []);
     const pageRows: ApplicationContextDocumentInternal[] = rows.slice(0, limit);
     return {
       documents: pageRows.map((row: ApplicationContextDocumentInternal): ApplicationContextDocument => this.toDocument(row)),
-      nextCursor: rows.length > limit ? String(offset + limit) : undefined,
+      nextCursor: rows.length > limit ? ApplicationContextDAO.encodeDocumentCursor(pageRows[pageRows.length - 1].updated_at, pageRows[pageRows.length - 1].created_at) : undefined,
     };
   }
 
   public async listDeletionRunsForUser(userEmail: string, input: ListDeletionRunsInput = {}): Promise<ApplicationContextDeletionRunList> {
     const limit: number = Math.min(Math.max(input.limit ?? 25, 1), 100);
-    const offset: number = ApplicationContextDAO.parseCursor(input.cursor);
     const conditions: string[] = ['user_email = ?'];
     const bindings: Array<string | number> = [userEmail];
     if (input.applicationId) {
       conditions.push('application_id = ?');
       bindings.push(input.applicationId);
+    }
+    const cursor: { createdAt: number } | undefined = ApplicationContextDAO.parseDeletionRunCursor(input.cursor);
+    if (cursor) {
+      conditions.push('created_at < ?');
+      bindings.push(cursor.createdAt);
     }
     const rows: ApplicationContextDeletionRunInternal[] = await this.database
       .prepare(
@@ -257,16 +266,16 @@ class ApplicationContextDAO {
           FROM application_context_deletion_runs
           WHERE ${conditions.join(' AND ')}
           ORDER BY created_at DESC
-          LIMIT ? OFFSET ?
+          LIMIT ?
         `,
       )
-      .bind(...bindings, limit + 1, offset)
+      .bind(...bindings, limit + 1)
       .all<ApplicationContextDeletionRunInternal>()
       .then((result: D1Result<ApplicationContextDeletionRunInternal>): ApplicationContextDeletionRunInternal[] => result.results || []);
     const pageRows: ApplicationContextDeletionRunInternal[] = rows.slice(0, limit);
     return {
       deletionRuns: pageRows.map((row: ApplicationContextDeletionRunInternal): ApplicationContextDeletionRun => this.toDeletionRun(row)),
-      nextCursor: rows.length > limit ? String(offset + limit) : undefined,
+      nextCursor: rows.length > limit ? ApplicationContextDAO.encodeDeletionRunCursor(pageRows[pageRows.length - 1].created_at) : undefined,
     };
   }
 
@@ -497,10 +506,40 @@ class ApplicationContextDAO {
     };
   }
 
-  private static parseCursor(cursor: string | undefined): number {
-    if (!cursor) return 0;
-    const parsed: number = Number.parseInt(cursor, 10);
-    return Number.isFinite(parsed) && parsed > 0 ? parsed : 0;
+  private static parseDocumentCursor(cursor: string | undefined): { updatedAt: number; createdAt: number } | undefined {
+    if (!cursor) return undefined;
+    try {
+      const decoded: string = atob(cursor);
+      const parsed: unknown = JSON.parse(decoded);
+      if (Array.isArray(parsed) && parsed.length === 2 && typeof parsed[0] === 'number' && typeof parsed[1] === 'number') {
+        return { updatedAt: parsed[0], createdAt: parsed[1] };
+      }
+      return undefined;
+    } catch {
+      return undefined;
+    }
+  }
+
+  private static encodeDocumentCursor(updatedAt: number, createdAt: number): string {
+    return btoa(JSON.stringify([updatedAt, createdAt]));
+  }
+
+  private static parseDeletionRunCursor(cursor: string | undefined): { createdAt: number } | undefined {
+    if (!cursor) return undefined;
+    try {
+      const decoded: string = atob(cursor);
+      const parsed: unknown = JSON.parse(decoded);
+      if (Array.isArray(parsed) && parsed.length === 1 && typeof parsed[0] === 'number') {
+        return { createdAt: parsed[0] };
+      }
+      return undefined;
+    } catch {
+      return undefined;
+    }
+  }
+
+  private static encodeDeletionRunCursor(createdAt: number): string {
+    return btoa(JSON.stringify([createdAt]));
   }
 
   private static parseMutationIds(value: string | null): string[] {

--- a/packages/backend-data/src/dao/ConnectedApplicationDAO.ts
+++ b/packages/backend-data/src/dao/ConnectedApplicationDAO.ts
@@ -40,8 +40,8 @@ class ConnectedApplicationDAO {
       .prepare(
         `
           INSERT INTO connected_applications
-            (application_id, user_email, provider_email, display_name, provider_id, connection_method, encrypted_credentials, credentials_iv, status, context_indexing_enabled, gmail_pubsub_topic_name, created_at, updated_at)
-          VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+            (application_id, user_email, provider_email, display_name, provider_id, connection_method, encrypted_credentials, credentials_iv, status, context_indexing_enabled, created_at, updated_at)
+          VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
         `,
       )
       .bind(
@@ -55,13 +55,15 @@ class ConnectedApplicationDAO {
         encrypted.iv,
         status,
         1,
-        gmailPubsubTopicName || null,
         now,
         now,
       )
       .run();
     if (!result.success) {
       throw new DatabaseError(`Failed to create connected application: ${result.error}`);
+    }
+    if (gmailPubsubTopicName) {
+      await this.setProviderConfig(applicationId, 'gmail_pubsub_topic_name', gmailPubsubTopicName, now);
     }
     const application: ConnectedApplicationMetadata | undefined = await this.getMetadataByIdForUser(applicationId, userEmail);
     if (!application) {
@@ -74,7 +76,7 @@ class ConnectedApplicationDAO {
     const rows: ConnectedApplicationInternal[] = await this.database
       .prepare(
         `
-          SELECT application_id, user_email, provider_email, display_name, provider_id, connection_method, encrypted_credentials, credentials_iv, status, context_indexing_enabled, max_context_documents, gmail_pubsub_topic_name, watched_folder_ids, created_at, updated_at
+          SELECT application_id, user_email, provider_email, display_name, provider_id, connection_method, encrypted_credentials, credentials_iv, status, context_indexing_enabled, max_context_documents, created_at, updated_at
           FROM connected_applications
           WHERE user_email = ?
           ORDER BY updated_at DESC, created_at DESC
@@ -83,7 +85,7 @@ class ConnectedApplicationDAO {
       .bind(userEmail)
       .all<ConnectedApplicationInternal>()
       .then((result: D1Result<ConnectedApplicationInternal>): ConnectedApplicationInternal[] => result.results || []);
-    return rows.map((row: ConnectedApplicationInternal): ConnectedApplicationMetadata => this.toMetadata(row));
+    return Promise.all(rows.map((row: ConnectedApplicationInternal): Promise<ConnectedApplicationMetadata> => this.toMetadata(row)));
   }
 
   public async countByUserEmail(userEmail: string): Promise<number> {
@@ -111,17 +113,17 @@ class ConnectedApplicationDAO {
 
   public async getMetadataByIdForUser(applicationId: string, userEmail: string): Promise<ConnectedApplicationMetadata | undefined> {
     const row: ConnectedApplicationInternal | undefined = await this.getRowById(applicationId, userEmail);
-    return row ? this.toMetadata(row) : undefined;
+    return row ? await this.toMetadata(row) : undefined;
   }
 
   public async getById(applicationId: string): Promise<ConnectedApplication | undefined> {
     const row: ConnectedApplicationInternal | undefined = await this.getRowById(applicationId);
-    return row ? this.toApplication(row) : undefined;
+    return row ? await this.toApplication(row) : undefined;
   }
 
   public async getByIdForUser(applicationId: string, userEmail: string): Promise<ConnectedApplication | undefined> {
     const row: ConnectedApplicationInternal | undefined = await this.getRowById(applicationId, userEmail);
-    return row ? this.toApplication(row) : undefined;
+    return row ? await this.toApplication(row) : undefined;
   }
 
   public async updateForUser(
@@ -138,14 +140,19 @@ class ConnectedApplicationDAO {
       .prepare(
         `
           UPDATE connected_applications
-          SET display_name = ?, encrypted_credentials = ?, credentials_iv = ?, status = ?, gmail_pubsub_topic_name = ?, updated_at = ?
+          SET display_name = ?, encrypted_credentials = ?, credentials_iv = ?, status = ?, updated_at = ?
           WHERE application_id = ? AND user_email = ?
         `,
       )
-      .bind(displayName, encrypted.encrypted, encrypted.iv, status, gmailPubsubTopicName || null, now, applicationId, userEmail)
+      .bind(displayName, encrypted.encrypted, encrypted.iv, status, now, applicationId, userEmail)
       .run();
     if (!result.success) {
       throw new DatabaseError(`Failed to update connected application: ${result.error}`);
+    }
+    if (gmailPubsubTopicName) {
+      await this.setProviderConfig(applicationId, 'gmail_pubsub_topic_name', gmailPubsubTopicName, now);
+    } else if (gmailPubsubTopicName === null) {
+      await this.deleteProviderConfig(applicationId, 'gmail_pubsub_topic_name');
     }
     return this.getMetadataByIdForUser(applicationId, userEmail);
   }
@@ -233,18 +240,22 @@ class ConnectedApplicationDAO {
     folderIds: string[] | null,
   ): Promise<ConnectedApplicationMetadata | undefined> {
     const now: number = TimestampUtil.getCurrentUnixTimestampInSeconds();
-    const result: D1Result = await this.database
-      .prepare(
-        `
-          UPDATE connected_applications
-          SET watched_folder_ids = ?, updated_at = ?
-          WHERE application_id = ? AND user_email = ?
-        `,
-      )
-      .bind(folderIds ? JSON.stringify(folderIds) : null, now, applicationId, userEmail)
-      .run();
-    if (!result.success) {
-      throw new DatabaseError(`Failed to update watched folder IDs: ${result.error}`);
+    if (folderIds && folderIds.length > 0) {
+      await this.database
+        .prepare('DELETE FROM application_watched_folders WHERE application_id = ?')
+        .bind(applicationId)
+        .run();
+      const stmt = this.database.prepare(
+        'INSERT INTO application_watched_folders (application_id, folder_path, created_at) VALUES (?, ?, ?)',
+      );
+      for (const folderPath of folderIds) {
+        await stmt.bind(applicationId, folderPath, now).run();
+      }
+    } else {
+      await this.database
+        .prepare('DELETE FROM application_watched_folders WHERE application_id = ?')
+        .bind(applicationId)
+        .run();
     }
     return this.getMetadataByIdForUser(applicationId, userEmail);
   }
@@ -281,13 +292,54 @@ class ConnectedApplicationDAO {
     }
   }
 
+  public async getProviderConfig(applicationId: string, configKey: string): Promise<string | null> {
+    const row: { config_value: string } | null = await this.database
+      .prepare('SELECT config_value FROM provider_application_configs WHERE application_id = ? AND config_key = ?')
+      .bind(applicationId, configKey)
+      .first<{ config_value: string }>();
+    return row?.config_value ?? null;
+  }
+
+  public async setProviderConfig(applicationId: string, configKey: string, configValue: string, now?: number): Promise<void> {
+    const timestamp: number = now ?? TimestampUtil.getCurrentUnixTimestampInSeconds();
+    const result: D1Result = await this.database
+      .prepare(
+        `
+          INSERT INTO provider_application_configs (application_id, config_key, config_value, created_at, updated_at)
+          VALUES (?, ?, ?, ?, ?)
+          ON CONFLICT(application_id, config_key) DO UPDATE SET config_value = excluded.config_value, updated_at = excluded.updated_at
+        `,
+      )
+      .bind(applicationId, configKey, configValue, timestamp, timestamp)
+      .run();
+    if (!result.success) {
+      throw new DatabaseError(`Failed to set provider config: ${result.error}`);
+    }
+  }
+
+  public async deleteProviderConfig(applicationId: string, configKey: string): Promise<void> {
+    await this.database
+      .prepare('DELETE FROM provider_application_configs WHERE application_id = ? AND config_key = ?')
+      .bind(applicationId, configKey)
+      .run();
+  }
+
+  public async getWatchedFolderPaths(applicationId: string): Promise<string[]> {
+    const rows: Array<{ folder_path: string }> = await this.database
+      .prepare('SELECT folder_path FROM application_watched_folders WHERE application_id = ? ORDER BY folder_path ASC')
+      .bind(applicationId)
+      .all<{ folder_path: string }>()
+      .then((result: D1Result<{ folder_path: string }>): Array<{ folder_path: string }> => result.results || []);
+    return rows.map((row: { folder_path: string }): string => row.folder_path);
+  }
+
   private async getRowById(applicationId: string, userEmail?: string): Promise<ConnectedApplicationInternal | undefined> {
     const whereUser: string = userEmail ? ' AND user_email = ?' : '';
     const bindings: string[] = userEmail ? [applicationId, userEmail] : [applicationId];
     const row: ConnectedApplicationInternal | null = await this.database
       .prepare(
         `
-          SELECT application_id, user_email, provider_email, display_name, provider_id, connection_method, encrypted_credentials, credentials_iv, status, context_indexing_enabled, max_context_documents, gmail_pubsub_topic_name, watched_folder_ids, created_at, updated_at
+          SELECT application_id, user_email, provider_email, display_name, provider_id, connection_method, encrypted_credentials, credentials_iv, status, context_indexing_enabled, max_context_documents, created_at, updated_at
           FROM connected_applications
           WHERE application_id = ?${whereUser}
           LIMIT 1
@@ -301,18 +353,22 @@ class ConnectedApplicationDAO {
   private async toApplication(row: ConnectedApplicationInternal): Promise<ConnectedApplication> {
     const decryptedCredentials: string = await decryptData(row.encrypted_credentials, row.credentials_iv, this.masterKey);
     return {
-      ...this.toMetadata(row),
+      ...(await this.toMetadata(row)),
       credentials: JSON.parse(decryptedCredentials) as ConnectedApplicationCredentials,
     };
   }
 
-  private toMetadata(row: ConnectedApplicationInternal): ConnectedApplicationMetadata {
+  private async toMetadata(row: ConnectedApplicationInternal): Promise<ConnectedApplicationMetadata> {
     const status: ConnectedApplicationMetadata['status'] =
       row.status === CONNECTED_APPLICATION_STATUS_CONNECTED
         ? CONNECTED_APPLICATION_STATUS_CONNECTED
         : row.status === CONNECTED_APPLICATION_STATUS_ERROR
           ? CONNECTED_APPLICATION_STATUS_ERROR
           : CONNECTED_APPLICATION_STATUS_DRAFT;
+    const [watchedFolderPaths, gmailPubsubTopicName]: [string[], string | null] = await Promise.all([
+      this.getWatchedFolderPaths(row.application_id),
+      this.getProviderConfig(row.application_id, 'gmail_pubsub_topic_name'),
+    ]);
     return {
       applicationId: row.application_id,
       userEmail: row.user_email,
@@ -323,10 +379,10 @@ class ConnectedApplicationDAO {
       status,
       contextIndexingEnabled: row.context_indexing_enabled !== 0,
       maxContextDocuments: row.max_context_documents ?? null,
-      gmailPubsubTopicName: row.gmail_pubsub_topic_name,
-      watchedFolderIds: row.watched_folder_ids ? (JSON.parse(row.watched_folder_ids) as string[]) : null,
+      watchedFolderIds: watchedFolderPaths.length > 0 ? watchedFolderPaths : null,
       createdAt: row.created_at,
       updatedAt: row.updated_at,
+      gmailPubsubTopicName: gmailPubsubTopicName ?? undefined,
     };
   }
 }

--- a/packages/shared/src/constants/Providers.ts
+++ b/packages/shared/src/constants/Providers.ts
@@ -12,6 +12,8 @@ const PROVIDER_SUBSCRIPTION_STATUS_STOPPED = 'stopped';
 const PROVIDER_SUBSCRIPTION_STATUS_ERROR = 'error';
 
 const PROCESSED_MESSAGE_STATUS_PROCESSING = 'processing';
+
+const SOURCE_TYPE_EMAIL = 'email';
 const PROCESSED_MESSAGE_STATUS_SUMMARIZED = 'summarized';
 const PROCESSED_MESSAGE_STATUS_SKIPPED = 'skipped';
 const PROCESSED_MESSAGE_STATUS_ERROR = 'error';
@@ -37,6 +39,8 @@ type ProcessedMessageStatus =
   | typeof PROCESSED_MESSAGE_STATUS_SKIPPED
   | typeof PROCESSED_MESSAGE_STATUS_ERROR;
 
+type SourceType = typeof SOURCE_TYPE_EMAIL;
+
 export {
   CONNECTED_APPLICATION_STATUS_CONNECTED,
   CONNECTED_APPLICATION_STATUS_DRAFT,
@@ -49,8 +53,9 @@ export {
   PROVIDER_GOOGLE_GMAIL,
   PROVIDER_MICROSOFT_OUTLOOK,
   PROVIDER_SUBSCRIPTION_STATUS_ACTIVE,
+  SOURCE_TYPE_EMAIL,
   PROVIDER_SUBSCRIPTION_STATUS_ERROR,
   PROVIDER_SUBSCRIPTION_STATUS_STOPPED,
   SUPPORTED_PROVIDER_CONNECTIONS,
 };
-export type { ConnectedApplicationStatus, ConnectionMethod, ProcessedMessageStatus, ProviderId, ProviderSubscriptionStatus };
+export type { ConnectedApplicationStatus, ConnectionMethod, ProcessedMessageStatus, ProviderId, ProviderSubscriptionStatus, SourceType };

--- a/packages/shared/src/model/ConnectedApplication.ts
+++ b/packages/shared/src/model/ConnectedApplication.ts
@@ -52,8 +52,6 @@ interface ConnectedApplicationInternal {
   status: ConnectedApplicationStatus;
   context_indexing_enabled: number;
   max_context_documents: number | null;
-  gmail_pubsub_topic_name: string | null;
-  watched_folder_ids: string | null;
   created_at: number;
   updated_at: number;
 }


### PR DESCRIPTION
Add migration 0011 with four composite indexes targeting the hottest query patterns:
- processed_messages(application_id, status, updated_at) for getLatest queries
- provider_subscriptions(status, expires_at, renewal_next_retry_at) for renewal candidate queries
- application_context_documents(user_email, updated_at, created_at) for user listing queries
- oauth2_authorization_sessions(application_id, state_hash) for getActive queries

Normalize watched_folder_ids into application_watched_folders table and gmail_pubsub_topic_name into provider_application_configs table, removing both denormalized JSON TEXT columns from connected_applications. The DAO layer transparently migrates reads/writes.

Implement keyset pagination replacing offset-based pagination in listDocumentsForUser and listDeletionRunsForUser, using base64url-encoded (updated_at, created_at) tuple cursors.

Add SOURCE_TYPE_EMAIL constant replacing hardcoded 'email' string in ApplicationContextDAO.