### PR TITLE
Store And Display Human Readable Folder Names In Watched Folders

### DIFF
--- a/apps/api/src/endpoints/user/application/watch-settings/PUT.ts
+++ b/apps/api/src/endpoints/user/application/watch-settings/PUT.ts
@@ -32,6 +32,7 @@ class UpdateApplicationWatchSettingsRoute extends IUserRoute<
 interface UpdateApplicationWatchSettingsRequest extends IRequest {
   applicationId: string;
   folderIds: string[] | null;
+  folderNames?: Record<string, string>;
 }
 
 interface UpdateApplicationWatchSettingsResponse extends IResponse {

--- a/apps/web/components/types.ts
+++ b/apps/web/components/types.ts
@@ -17,7 +17,7 @@ export interface ConnectedApplication {
   connectionMethod: 'oauth2';
   status: 'draft' | 'connected' | 'error';
   gmailPubsubTopicName?: string | null;
-  watchedFolderIds?: string[] | null;
+  watchedFolders?: Array<{ id: string; name: string }> | null;
   oauth2RedirectUri?: string;
   webhookUrl?: string;
   watchStatus?: 'active' | 'stopped' | 'error';

--- a/apps/web/src/SpaApp.tsx
+++ b/apps/web/src/SpaApp.tsx
@@ -323,11 +323,18 @@ export default function SpaApp() {
   const updateWatchedFolderIds = async (applicationId: string, folderIds: string[] | null) => {
     setIsBusy(true);
     try {
+      const folderNames: Record<string, string> = {};
+      if (folderIds && availableFolders) {
+        for (const folderId of folderIds) {
+          const folder = availableFolders.find((f) => f.id === folderId);
+          if (folder) folderNames[folderId] = folder.name;
+        }
+      }
       const data = await readJson<{ application: ConnectedApplication }>(
         await fetch('/user/application/watch-settings', {
           method: 'PUT',
           headers: { 'Content-Type': 'application/json' },
-          body: JSON.stringify({ applicationId, folderIds }),
+          body: JSON.stringify({ applicationId, folderIds, folderNames }),
         }),
       );
       setApplications((current) =>
@@ -668,7 +675,7 @@ export default function SpaApp() {
                       <div className="flex flex-col gap-2">
                         {availableFolders.map((folder) => {
                           const isOutlook = selectedApplication.providerId === 'microsoft-outlook';
-                          const checked = selectedApplication.watchedFolderIds?.includes(folder.id) ?? false;
+                          const checked = selectedApplication.watchedFolders?.some((wf) => wf.id === folder.id) ?? false;
                           return (
                             <label key={folder.id} className="inline-flex items-center gap-3 text-sm text-[#d1d5db]">
                               <input
@@ -676,11 +683,12 @@ export default function SpaApp() {
                                 name={isOutlook ? `watch-folder-${selectedApplication.applicationId}` : undefined}
                                 checked={checked}
                                 onChange={() => {
+                                  const currentIds = (selectedApplication.watchedFolders || []).map((wf) => wf.id);
                                   const next = isOutlook
                                     ? checked ? [] : [folder.id]
                                     : checked
-                                      ? (selectedApplication.watchedFolderIds || []).filter((id) => id !== folder.id)
-                                      : [...(selectedApplication.watchedFolderIds || []), folder.id];
+                                      ? currentIds.filter((id) => id !== folder.id)
+                                      : [...currentIds, folder.id];
                                   updateWatchedFolderIds(selectedApplication.applicationId, next.length > 0 ? next : null);
                                 }}
                                 disabled={isBusy}
@@ -692,9 +700,9 @@ export default function SpaApp() {
                         })}
                       </div>
                     )
-                  ) : selectedApplication.watchedFolderIds && selectedApplication.watchedFolderIds.length > 0 ? (
+                  ) : selectedApplication.watchedFolders && selectedApplication.watchedFolders.length > 0 ? (
                     <p className="text-sm text-[#aab4c2]">
-                      Watching: {selectedApplication.watchedFolderIds.join(', ')} — click &quot;Load Folders&quot; to change.
+                      Watching: {selectedApplication.watchedFolders.map((wf) => wf.name).join(', ')} — click &quot;Load Folders&quot; to change.
                     </p>
                   ) : (
                     <p className="text-sm text-[#aab4c2]">Watching default folder (Inbox). Click &quot;Load Folders&quot; to customize.</p>

--- a/migrations/0012_watched_folder_names.sql
+++ b/migrations/0012_watched_folder_names.sql
@@ -1,0 +1,1 @@
+ALTER TABLE application_watched_folders ADD COLUMN folder_name TEXT;

--- a/packages/backend-data/src/dao/ConnectedApplicationDAO.ts
+++ b/packages/backend-data/src/dao/ConnectedApplicationDAO.ts
@@ -238,6 +238,7 @@ class ConnectedApplicationDAO {
     applicationId: string,
     userEmail: string,
     folderIds: string[] | null,
+    folderNames?: Record<string, string>,
   ): Promise<ConnectedApplicationMetadata | undefined> {
     const now: number = TimestampUtil.getCurrentUnixTimestampInSeconds();
     if (folderIds && folderIds.length > 0) {
@@ -246,10 +247,11 @@ class ConnectedApplicationDAO {
         .bind(applicationId)
         .run();
       const stmt = this.database.prepare(
-        'INSERT INTO application_watched_folders (application_id, folder_path, created_at) VALUES (?, ?, ?)',
+        'INSERT INTO application_watched_folders (application_id, folder_path, folder_name, created_at) VALUES (?, ?, ?, ?)',
       );
       for (const folderPath of folderIds) {
-        await stmt.bind(applicationId, folderPath, now).run();
+        const folderName: string = folderNames?.[folderPath] || folderPath;
+        await stmt.bind(applicationId, folderPath, folderName, now).run();
       }
     } else {
       await this.database
@@ -324,13 +326,16 @@ class ConnectedApplicationDAO {
       .run();
   }
 
-  public async getWatchedFolderPaths(applicationId: string): Promise<string[]> {
-    const rows: Array<{ folder_path: string }> = await this.database
-      .prepare('SELECT folder_path FROM application_watched_folders WHERE application_id = ? ORDER BY folder_path ASC')
+  public async getWatchedFolders(applicationId: string): Promise<Array<{ folderPath: string; folderName: string }>> {
+    const rows: Array<{ folder_path: string; folder_name: string | null }> = await this.database
+      .prepare('SELECT folder_path, folder_name FROM application_watched_folders WHERE application_id = ? ORDER BY folder_path ASC')
       .bind(applicationId)
-      .all<{ folder_path: string }>()
-      .then((result: D1Result<{ folder_path: string }>): Array<{ folder_path: string }> => result.results || []);
-    return rows.map((row: { folder_path: string }): string => row.folder_path);
+      .all<{ folder_path: string; folder_name: string | null }>()
+      .then((result: D1Result<{ folder_path: string; folder_name: string | null }>): Array<{ folder_path: string; folder_name: string | null }> => result.results || []);
+    return rows.map((row: { folder_path: string; folder_name: string | null }): { folderPath: string; folderName: string } => ({
+      folderPath: row.folder_path,
+      folderName: row.folder_name || row.folder_path,
+    }));
   }
 
   private async getRowById(applicationId: string, userEmail?: string): Promise<ConnectedApplicationInternal | undefined> {
@@ -365,8 +370,8 @@ class ConnectedApplicationDAO {
         : row.status === CONNECTED_APPLICATION_STATUS_ERROR
           ? CONNECTED_APPLICATION_STATUS_ERROR
           : CONNECTED_APPLICATION_STATUS_DRAFT;
-    const [watchedFolderPaths, gmailPubsubTopicName]: [string[], string | null] = await Promise.all([
-      this.getWatchedFolderPaths(row.application_id),
+    const [watchedFolders, gmailPubsubTopicName]: [Array<{ folderPath: string; folderName: string }>, string | null] = await Promise.all([
+      this.getWatchedFolders(row.application_id),
       this.getProviderConfig(row.application_id, 'gmail_pubsub_topic_name'),
     ]);
     return {
@@ -379,7 +384,7 @@ class ConnectedApplicationDAO {
       status,
       contextIndexingEnabled: row.context_indexing_enabled !== 0,
       maxContextDocuments: row.max_context_documents ?? null,
-      watchedFolderIds: watchedFolderPaths.length > 0 ? watchedFolderPaths : null,
+      watchedFolders: watchedFolders.length > 0 ? watchedFolders.map((f) => ({ id: f.folderPath, name: f.folderName })) : null,
       createdAt: row.created_at,
       updatedAt: row.updated_at,
       gmailPubsubTopicName: gmailPubsubTopicName ?? undefined,

--- a/packages/backend-services/src/application/ApplicationService.ts
+++ b/packages/backend-services/src/application/ApplicationService.ts
@@ -96,6 +96,7 @@ class ApplicationService {
       input.applicationId,
       userEmail,
       input.folderIds,
+      input.folderNames,
     );
     if (!application) {
       throw new BadRequestError('Connected application was not found.');
@@ -151,6 +152,7 @@ interface DeleteUserApplicationEnv extends ApplicationServiceEnv {
 interface UpdateWatchedFolderIdsInput {
   applicationId: string;
   folderIds: string[] | null;
+  folderNames?: Record<string, string>;
 }
 
 export { ApplicationService };

--- a/packages/backend-services/src/email/EmailProcessingUtil.ts
+++ b/packages/backend-services/src/email/EmailProcessingUtil.ts
@@ -44,7 +44,7 @@ class EmailProcessingUtil {
     const subscription: ProviderSubscription | undefined = await subscriptionDAO.getByApplication(application.applicationId);
     if (!subscription || subscription.status !== PROVIDER_SUBSCRIPTION_STATUS_ACTIVE) return null;
     const startHistoryId: string | undefined = subscription.gmailHistoryId || notificationHistoryId;
-    const history = await GmailProviderUtil.listMessageIdsSince(accessToken, startHistoryId, application.watchedFolderIds ?? undefined);
+    const history = await GmailProviderUtil.listMessageIdsSince(accessToken, startHistoryId, application.watchedFolders?.map((f) => f.id) ?? undefined);
     return { messageIds: history.messageIds, historyId: history.historyId || notificationHistoryId, subscriptionId: subscription.subscriptionId };
   }
 

--- a/packages/backend-services/src/subscription/SubscriptionRenewalUtil.ts
+++ b/packages/backend-services/src/subscription/SubscriptionRenewalUtil.ts
@@ -52,7 +52,7 @@ class SubscriptionRenewalUtil {
     const application: ConnectedApplication | undefined = await applicationDAO.getById(subscription.applicationId);
     if (!application || !application.gmailPubsubTopicName) return;
     const accessToken: string = await OAuth2AccessTokenService.getAccessToken(application.applicationId, _env);
-    const watch = await GmailProviderUtil.watchInbox(accessToken, application.gmailPubsubTopicName, application.watchedFolderIds ?? undefined);
+    const watch = await GmailProviderUtil.watchInbox(accessToken, application.gmailPubsubTopicName, application.watchedFolders?.map((f) => f.id) ?? undefined);
     await subscriptionDAO.upsertActive({
       applicationId: application.applicationId,
       providerId: application.providerId,

--- a/packages/backend-services/src/subscription/WatchService.ts
+++ b/packages/backend-services/src/subscription/WatchService.ts
@@ -70,7 +70,7 @@ class WatchService {
       throw new BadRequestError('Gmail Pub/Sub topic name is required before starting Gmail watch.');
     }
     const webhookSecret: string = WebhookSecurityUtil.generateSecret();
-    const watch = await GmailProviderUtil.watchInbox(accessToken, application.gmailPubsubTopicName, application.watchedFolderIds ?? undefined);
+    const watch = await GmailProviderUtil.watchInbox(accessToken, application.gmailPubsubTopicName, application.watchedFolders?.map((f) => f.id) ?? undefined);
     const subscription: ProviderSubscription = await subscriptionDAO.upsertActive({
       applicationId: application.applicationId,
       providerId: application.providerId,
@@ -105,7 +105,7 @@ class WatchService {
       lifecycleNotificationUrl,
       clientState,
       expiresAt,
-      application.watchedFolderIds?.[0] ?? undefined,
+      application.watchedFolders?.[0]?.id ?? undefined,
     );
     const subscription: ProviderSubscription = await subscriptionDAO.upsertActive({
       applicationId: application.applicationId,

--- a/packages/shared/src/model/ConnectedApplication.ts
+++ b/packages/shared/src/model/ConnectedApplication.ts
@@ -19,7 +19,7 @@ interface ConnectedApplicationMetadata {
   contextIndexingEnabled: boolean;
   maxContextDocuments?: number | null | undefined;
   gmailPubsubTopicName?: string | null | undefined;
-  watchedFolderIds?: string[] | null | undefined;
+  watchedFolders?: Array<{ id: string; name: string }> | null | undefined;
   oauth2RedirectUri?: string | undefined;
   webhookUrl?: string | undefined;
   watchStatus?: string | undefined;


### PR DESCRIPTION
Add folder_name column to application_watched_folders to persist human-readable folder display names alongside provider IDs.

- Add migration 0012 to add folder_name TEXT column
- Replace watchedFolderIds with watchedFolders: [{id, name}] in API response
- Frontend sends folder names from availableFolders when saving watched folders
- Backend consumers extract IDs via .map(f => f.id)
- Existing rows fall back to using folder_path as the display name