### PR TITLE
Fix Folder Display Name Showing As ID

### DIFF
--- a/packages/shared/src/schema/input.ts
+++ b/packages/shared/src/schema/input.ts
@@ -59,6 +59,7 @@ const ApplicationFoldersQuerySchema = z.object({
 const UpdateApplicationWatchSettingsBodySchema = z.object({
   applicationId: UuidSchema,
   folderIds: z.array(nonEmptyStringSchema('folderIds', 512)).nullable(),
+  folderNames: z.record(nonEmptyStringSchema('folderNames.key', 512), nonEmptyStringSchema('folderNames.value', 512)).optional(),
 });
 
 const WatchApplicationBodySchema = z.object({


### PR DESCRIPTION
The UpdateApplicationWatchSettingsBodySchema Zod schema was missing the folderNames field, causing Zod's default strip mode to silently remove it from the validated body. The DAO then fell back to using the folder ID as the display name since folderNames was undefined.

Added folderNames as an optional z.record to the schema so the field passes through validation and reaches the DAO.