### PR TITLE
Classify D1 Errors As Retryable And Retry Transient Failures

### DIFF
--- a/apps/api/src/endpoints/IBaseRoute.ts
+++ b/apps/api/src/endpoints/IBaseRoute.ts
@@ -1,7 +1,7 @@
 import { OpenAPIRoute } from 'chanfana';
 import { Context } from 'hono';
 import type { StatusCode } from 'hono/utils/http-status';
-import { BadRequestError, DefaultInternalServerError, InternalServerError, IServiceError } from '@mail-otter/backend-errors';
+import { BadRequestError, DatabaseError, DefaultInternalServerError, InternalServerError, IServiceError } from '@mail-otter/backend-errors';
 import { validateRequestInput } from '@mail-otter/shared/schema';
 
 abstract class IBaseRoute<TRequest extends IRequest, TResponse extends IResponse, TEnv extends IEnv> extends OpenAPIRoute {
@@ -54,6 +54,10 @@ abstract class IBaseRoute<TRequest extends IRequest, TResponse extends IResponse
   protected toErrorResponse(error: unknown, c: RouteContext<TEnv>) {
     if (error instanceof IServiceError && !(error instanceof InternalServerError)) {
       console.warn(`Responding with ${error.getErrorType()}Error:`, error.stack);
+      return c.json({ Exception: { Type: error.getErrorType(), Message: error.getErrorMessage() } }, error.getErrorCode());
+    }
+    if (error instanceof DatabaseError) {
+      console.error('Caught database error during execution:', error);
       return c.json({ Exception: { Type: error.getErrorType(), Message: error.getErrorMessage() } }, error.getErrorCode());
     }
     console.error('Caught service error during execution:', error);

--- a/apps/background/src/EmailProcessingWorkflow.ts
+++ b/apps/background/src/EmailProcessingWorkflow.ts
@@ -1,5 +1,5 @@
 import { AbstractWorkflowWorker } from '@mail-otter/backend-runtime/base';
-import { NonRetryableError, RetryableError } from '@mail-otter/backend-errors';
+import { DatabaseError, NonRetryableError, RetryableError } from '@mail-otter/backend-errors';
 import { EmailProcessingUtil } from '@mail-otter/backend-services/email';
 import type { GmailMessageList, ResolvedApplication } from '@mail-otter/backend-services/email';
 import type { EmailQueueMessage } from '@mail-otter/shared/model';
@@ -110,6 +110,12 @@ class EmailProcessingWorkflow extends AbstractWorkflowWorker<EmailQueueMessage, 
     }
     if (error instanceof RetryableError) {
       return error;
+    }
+    if (error instanceof DatabaseError) {
+      if (!error.retryable) {
+        return new WorkflowNonRetryableError(error.message, 'DatabaseError');
+      }
+      return new RetryableError(error.message);
     }
     if (error instanceof Error) {
       return new RetryableError(error.message);

--- a/packages/backend-data/package.json
+++ b/packages/backend-data/package.json
@@ -11,7 +11,9 @@
     "./crypto": "./src/crypto/index.ts",
     "./crypto/*": "./src/crypto/*.ts",
     "./dao": "./src/dao/index.ts",
-    "./dao/*": "./src/dao/*.ts"
+    "./dao/*": "./src/dao/*.ts",
+    "./utils": "./src/utils/index.ts",
+    "./utils/*": "./src/utils/*.ts"
   },
   "scripts": {
     "typecheck": "tsc --noEmit"

--- a/packages/backend-data/src/dao/AiDailyUsageDAO.ts
+++ b/packages/backend-data/src/dao/AiDailyUsageDAO.ts
@@ -1,4 +1,4 @@
-import { DatabaseError } from '@mail-otter/backend-errors';
+import { executeD1WithRetry } from '../utils';
 import { TimestampUtil } from '@mail-otter/shared/utils';
 
 class AiDailyUsageDAO {
@@ -25,13 +25,14 @@ class AiDailyUsageDAO {
   }
 
   public async deleteOlderThanDate(olderThanDate: string): Promise<number> {
-    const result: D1Result = await this.database
-      .prepare('DELETE FROM ai_daily_usage WHERE usage_date < ?')
-      .bind(olderThanDate)
-      .run();
-    if (!result.success) {
-      throw new DatabaseError(`Failed to delete old AI daily usage: ${result.error}`);
-    }
+    const result: D1Result = await executeD1WithRetry(
+      (): Promise<D1Result> =>
+        this.database
+          .prepare('DELETE FROM ai_daily_usage WHERE usage_date < ?')
+          .bind(olderThanDate)
+          .run(),
+      'delete old AI daily usage',
+    );
     return (result.meta as { changes?: number } | undefined)?.changes ?? 0;
   }
 
@@ -58,26 +59,27 @@ class AiDailyUsageDAO {
     const embeddingTokens: number = AiDailyUsageDAO.toNonNegativeInteger(input.embeddingTokens ?? 0);
     const requestCount: number = AiDailyUsageDAO.toNonNegativeInteger(input.requestCount ?? 1);
 
-    const result: D1Result = await this.database
-      .prepare(
-        `
-          INSERT INTO ai_daily_usage
-            (usage_date, estimated_neurons, prompt_tokens, completion_tokens, embedding_tokens, request_count, created_at, updated_at)
-          VALUES (?, ?, ?, ?, ?, ?, ?, ?)
-          ON CONFLICT(usage_date) DO UPDATE SET
-            estimated_neurons = ai_daily_usage.estimated_neurons + excluded.estimated_neurons,
-            prompt_tokens = ai_daily_usage.prompt_tokens + excluded.prompt_tokens,
-            completion_tokens = ai_daily_usage.completion_tokens + excluded.completion_tokens,
-            embedding_tokens = ai_daily_usage.embedding_tokens + excluded.embedding_tokens,
-            request_count = ai_daily_usage.request_count + excluded.request_count,
-            updated_at = excluded.updated_at
-        `,
-      )
-      .bind(input.usageDate, estimatedNeurons, promptTokens, completionTokens, embeddingTokens, requestCount, now, now)
-      .run();
-    if (!result.success) {
-      throw new DatabaseError(`Failed to increment AI daily usage: ${result.error}`);
-    }
+    await executeD1WithRetry(
+      (): Promise<D1Result> =>
+        this.database
+          .prepare(
+            `
+              INSERT INTO ai_daily_usage
+                (usage_date, estimated_neurons, prompt_tokens, completion_tokens, embedding_tokens, request_count, created_at, updated_at)
+              VALUES (?, ?, ?, ?, ?, ?, ?, ?)
+              ON CONFLICT(usage_date) DO UPDATE SET
+                estimated_neurons = ai_daily_usage.estimated_neurons + excluded.estimated_neurons,
+                prompt_tokens = ai_daily_usage.prompt_tokens + excluded.prompt_tokens,
+                completion_tokens = ai_daily_usage.completion_tokens + excluded.completion_tokens,
+                embedding_tokens = ai_daily_usage.embedding_tokens + excluded.embedding_tokens,
+                request_count = ai_daily_usage.request_count + excluded.request_count,
+                updated_at = excluded.updated_at
+            `,
+          )
+          .bind(input.usageDate, estimatedNeurons, promptTokens, completionTokens, embeddingTokens, requestCount, now, now)
+          .run(),
+      'increment AI daily usage',
+    );
   }
 
   private toUsage(row: AiDailyUsageInternal): AiDailyUsage {

--- a/packages/backend-data/src/dao/ApplicationContextDAO.ts
+++ b/packages/backend-data/src/dao/ApplicationContextDAO.ts
@@ -7,6 +7,7 @@ import {
   SOURCE_TYPE_EMAIL,
 } from '@mail-otter/shared/constants';
 import { DatabaseError } from '@mail-otter/backend-errors';
+import { executeD1WithRetry } from '../utils';
 import type {
   ApplicationContextDeletionRun,
   ApplicationContextDeletionRunInternal,
@@ -42,35 +43,36 @@ class ApplicationContextDAO {
       .first<ApplicationContextDocumentInternal>();
 
     if (existing) {
-      const result: D1Result = await this.database
-        .prepare(
-          `
-            UPDATE application_context_documents
-            SET user_email = ?, source_provider_id = ?, source_thread_id = ?, vector_namespace = ?,
-                source_document_fingerprint = ?, source_thread_fingerprint = ?, title_fingerprint = ?, sender_fingerprint = ?,
-                content_fingerprint = ?, indexed_text_chars = ?, status = ?, deleted_at = NULL, last_error = NULL, updated_at = ?
-            WHERE context_document_id = ?
-          `,
-        )
-        .bind(
-          input.userEmail,
-          input.sourceProviderId,
-          input.sourceThreadId || null,
-          input.vectorNamespace,
-          input.sourceDocumentFingerprint,
-          input.sourceThreadFingerprint || null,
-          input.titleFingerprint || null,
-          input.senderFingerprint || null,
-          input.contentFingerprint,
-          input.indexedTextChars,
-          APPLICATION_CONTEXT_DOCUMENT_STATUS_ACTIVE,
-          now,
-          existing.context_document_id,
-        )
-        .run();
-      if (!result.success) {
-        throw new DatabaseError(`Failed to update application context document: ${result.error}`);
-      }
+      await executeD1WithRetry(
+        (): Promise<D1Result> =>
+          this.database
+            .prepare(
+              `
+                UPDATE application_context_documents
+                SET user_email = ?, source_provider_id = ?, source_thread_id = ?, vector_namespace = ?,
+                    source_document_fingerprint = ?, source_thread_fingerprint = ?, title_fingerprint = ?, sender_fingerprint = ?,
+                    content_fingerprint = ?, indexed_text_chars = ?, status = ?, deleted_at = NULL, last_error = NULL, updated_at = ?
+                WHERE context_document_id = ?
+              `,
+            )
+            .bind(
+              input.userEmail,
+              input.sourceProviderId,
+              input.sourceThreadId || null,
+              input.vectorNamespace,
+              input.sourceDocumentFingerprint,
+              input.sourceThreadFingerprint || null,
+              input.titleFingerprint || null,
+              input.senderFingerprint || null,
+              input.contentFingerprint,
+              input.indexedTextChars,
+              APPLICATION_CONTEXT_DOCUMENT_STATUS_ACTIVE,
+              now,
+              existing.context_document_id,
+            )
+            .run(),
+        'update application context document',
+      );
       const updated: ApplicationContextDocument | undefined = await this.getDocumentById(existing.context_document_id);
       if (!updated) throw new DatabaseError('Failed to load application context document after update.');
       return updated;
@@ -78,40 +80,41 @@ class ApplicationContextDAO {
 
     const contextDocumentId: string = UUIDUtil.getRandomUUID();
     const vectorId: string = `cd_${contextDocumentId}`;
-    const result: D1Result = await this.database
-      .prepare(
-        `
-          INSERT INTO application_context_documents
-            (context_document_id, application_id, user_email, source_type, source_provider_id, source_document_id, source_thread_id,
-             vector_namespace, vector_id, source_document_fingerprint, source_thread_fingerprint, title_fingerprint, sender_fingerprint,
-             content_fingerprint, indexed_text_chars, status, indexed_at, deleted_at, last_error, created_at, updated_at)
-          VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, NULL, NULL, NULL, ?, ?)
-        `,
-      )
-      .bind(
-        contextDocumentId,
-        input.applicationId,
-        input.userEmail,
-        SOURCE_TYPE_EMAIL,
-        input.sourceProviderId,
-        input.sourceDocumentId,
-        input.sourceThreadId || null,
-        input.vectorNamespace,
-        vectorId,
-        input.sourceDocumentFingerprint,
-        input.sourceThreadFingerprint || null,
-        input.titleFingerprint || null,
-        input.senderFingerprint || null,
-        input.contentFingerprint,
-        input.indexedTextChars,
-        APPLICATION_CONTEXT_DOCUMENT_STATUS_ACTIVE,
-        now,
-        now,
-      )
-      .run();
-    if (!result.success) {
-      throw new DatabaseError(`Failed to create application context document: ${result.error}`);
-    }
+    await executeD1WithRetry(
+      (): Promise<D1Result> =>
+        this.database
+          .prepare(
+            `
+              INSERT INTO application_context_documents
+                (context_document_id, application_id, user_email, source_type, source_provider_id, source_document_id, source_thread_id,
+                 vector_namespace, vector_id, source_document_fingerprint, source_thread_fingerprint, title_fingerprint, sender_fingerprint,
+                 content_fingerprint, indexed_text_chars, status, indexed_at, deleted_at, last_error, created_at, updated_at)
+              VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, NULL, NULL, NULL, ?, ?)
+            `,
+          )
+          .bind(
+            contextDocumentId,
+            input.applicationId,
+            input.userEmail,
+            SOURCE_TYPE_EMAIL,
+            input.sourceProviderId,
+            input.sourceDocumentId,
+            input.sourceThreadId || null,
+            input.vectorNamespace,
+            vectorId,
+            input.sourceDocumentFingerprint,
+            input.sourceThreadFingerprint || null,
+            input.titleFingerprint || null,
+            input.senderFingerprint || null,
+            input.contentFingerprint,
+            input.indexedTextChars,
+            APPLICATION_CONTEXT_DOCUMENT_STATUS_ACTIVE,
+            now,
+            now,
+          )
+          .run(),
+      'create application context document',
+    );
     const document: ApplicationContextDocument | undefined = await this.getDocumentById(contextDocumentId);
     if (!document) throw new DatabaseError('Failed to load application context document after create.');
     return document;
@@ -119,36 +122,38 @@ class ApplicationContextDAO {
 
   public async markDocumentIndexed(contextDocumentId: string): Promise<void> {
     const now: number = TimestampUtil.getCurrentUnixTimestampInSeconds();
-    const result: D1Result = await this.database
-      .prepare(
-        `
-          UPDATE application_context_documents
-          SET status = ?, indexed_at = ?, last_error = NULL, updated_at = ?
-          WHERE context_document_id = ?
-        `,
-      )
-      .bind(APPLICATION_CONTEXT_DOCUMENT_STATUS_ACTIVE, now, now, contextDocumentId)
-      .run();
-    if (!result.success) {
-      throw new DatabaseError(`Failed to mark application context document indexed: ${result.error}`);
-    }
+    await executeD1WithRetry(
+      (): Promise<D1Result> =>
+        this.database
+          .prepare(
+            `
+              UPDATE application_context_documents
+              SET status = ?, indexed_at = ?, last_error = NULL, updated_at = ?
+              WHERE context_document_id = ?
+            `,
+          )
+          .bind(APPLICATION_CONTEXT_DOCUMENT_STATUS_ACTIVE, now, now, contextDocumentId)
+          .run(),
+      'mark application context document indexed',
+    );
   }
 
   public async markDocumentError(contextDocumentId: string, errorMessage: string): Promise<void> {
     const now: number = TimestampUtil.getCurrentUnixTimestampInSeconds();
-    const result: D1Result = await this.database
-      .prepare(
-        `
-          UPDATE application_context_documents
-          SET status = ?, last_error = ?, updated_at = ?
-          WHERE context_document_id = ?
-        `,
-      )
-      .bind(APPLICATION_CONTEXT_DOCUMENT_STATUS_ERROR, errorMessage.slice(0, 1024), now, contextDocumentId)
-      .run();
-    if (!result.success) {
-      throw new DatabaseError(`Failed to mark application context document error: ${result.error}`);
-    }
+    await executeD1WithRetry(
+      (): Promise<D1Result> =>
+        this.database
+          .prepare(
+            `
+              UPDATE application_context_documents
+              SET status = ?, last_error = ?, updated_at = ?
+              WHERE context_document_id = ?
+            `,
+          )
+          .bind(APPLICATION_CONTEXT_DOCUMENT_STATUS_ERROR, errorMessage.slice(0, 1024), now, contextDocumentId)
+          .run(),
+      'mark application context document error',
+    );
   }
 
   public async getSummaryByApplication(applicationId: string): Promise<ApplicationContextSummary> {
@@ -338,85 +343,89 @@ class ApplicationContextDAO {
   public async recordDeletionRun(input: RecordDeletionRunInput): Promise<ApplicationContextDeletionRun> {
     const now: number = TimestampUtil.getCurrentUnixTimestampInSeconds();
     const deletionRunId: string = UUIDUtil.getRandomUUID();
-    const result: D1Result = await this.database
-      .prepare(
-        `
-          INSERT INTO application_context_deletion_runs
-            (deletion_run_id, application_id, user_email, vector_namespace, requested_vector_count, deleted_vector_count,
-             mutation_ids, status, error_message, created_at, updated_at)
-          VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
-        `,
-      )
-      .bind(
-        deletionRunId,
-        input.applicationId,
-        input.userEmail,
-        input.vectorNamespace,
-        input.requestedVectorCount,
-        input.deletedVectorCount,
-        JSON.stringify(input.mutationIds),
-        input.status,
-        input.errorMessage ? input.errorMessage.slice(0, 1024) : null,
-        now,
-        now,
-      )
-      .run();
-    if (!result.success) {
-      throw new DatabaseError(`Failed to record context deletion run: ${result.error}`);
-    }
+    await executeD1WithRetry(
+      (): Promise<D1Result> =>
+        this.database
+          .prepare(
+            `
+              INSERT INTO application_context_deletion_runs
+                (deletion_run_id, application_id, user_email, vector_namespace, requested_vector_count, deleted_vector_count,
+                 mutation_ids, status, error_message, created_at, updated_at)
+              VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+            `,
+          )
+          .bind(
+            deletionRunId,
+            input.applicationId,
+            input.userEmail,
+            input.vectorNamespace,
+            input.requestedVectorCount,
+            input.deletedVectorCount,
+            JSON.stringify(input.mutationIds),
+            input.status,
+            input.errorMessage ? input.errorMessage.slice(0, 1024) : null,
+            now,
+            now,
+          )
+          .run(),
+      'record context deletion run',
+    );
     const run: ApplicationContextDeletionRun | undefined = await this.getDeletionRunById(deletionRunId);
     if (!run) throw new DatabaseError('Failed to load context deletion run after create.');
     return run;
   }
 
   public async deleteStaleDeletedDocuments(deletedBefore: number, limit: number): Promise<number> {
-    const result: D1Result = await this.database
-      .prepare(
-        `
-          DELETE FROM application_context_documents
-          WHERE status = ? AND deleted_at IS NOT NULL AND deleted_at < ?
-          LIMIT ?
-        `,
-      )
-      .bind(APPLICATION_CONTEXT_DOCUMENT_STATUS_DELETED, deletedBefore, limit)
-      .run();
-    if (!result.success) {
-      throw new DatabaseError(`Failed to delete stale deleted context documents: ${result.error}`);
-    }
+    const result: D1Result = await executeD1WithRetry(
+      (): Promise<D1Result> =>
+        this.database
+          .prepare(
+            `
+              DELETE FROM application_context_documents
+              WHERE status = ? AND deleted_at IS NOT NULL AND deleted_at < ?
+              LIMIT ?
+            `,
+          )
+          .bind(APPLICATION_CONTEXT_DOCUMENT_STATUS_DELETED, deletedBefore, limit)
+          .run(),
+      'delete stale deleted context documents',
+    );
     return (result.meta as { changes?: number } | undefined)?.changes ?? 0;
   }
 
   public async deleteStaleErrorDocuments(errorBefore: number, limit: number): Promise<number> {
-    const result: D1Result = await this.database
-      .prepare(
-        `
-          DELETE FROM application_context_documents
-          WHERE status = ? AND updated_at < ?
-          LIMIT ?
-        `,
-      )
-      .bind(APPLICATION_CONTEXT_DOCUMENT_STATUS_ERROR, errorBefore, limit)
-      .run();
-    if (!result.success) {
-      throw new DatabaseError(`Failed to delete stale error context documents: ${result.error}`);
-    }
+    const result: D1Result = await executeD1WithRetry(
+      (): Promise<D1Result> =>
+        this.database
+          .prepare(
+            `
+              DELETE FROM application_context_documents
+              WHERE status = ? AND updated_at < ?
+              LIMIT ?
+            `,
+          )
+          .bind(APPLICATION_CONTEXT_DOCUMENT_STATUS_ERROR, errorBefore, limit)
+          .run(),
+      'delete stale error context documents',
+    );
     return (result.meta as { changes?: number } | undefined)?.changes ?? 0;
   }
 
   public async deleteOldDeletionRuns(olderThan: number, limit: number): Promise<number> {
-    const result: D1Result = await this.database
-      .prepare(
-        `
-          DELETE FROM application_context_deletion_runs
-          WHERE created_at < ?
-          LIMIT ?
-        `,
-      )
-      .bind(olderThan, limit)
-      .run();
-    if (!result.success) {
-      throw new DatabaseError(`Failed to delete old context deletion runs: ${result.error}`);
-    }
+    const result: D1Result = await executeD1WithRetry(
+      (): Promise<D1Result> =>
+        this.database
+          .prepare(
+            `
+              DELETE FROM application_context_deletion_runs
+              WHERE created_at < ?
+              LIMIT ?
+            `,
+          )
+          .bind(olderThan, limit)
+          .run(),
+      'delete old context deletion runs',
+    );
     return (result.meta as { changes?: number } | undefined)?.changes ?? 0;
   }
 
@@ -470,19 +479,20 @@ class ApplicationContextDAO {
     const now: number = TimestampUtil.getCurrentUnixTimestampInSeconds();
     for (const chunk of ApplicationContextDAO.chunk(vectorIds, 100)) {
       const placeholders: string = chunk.map((): string => '?').join(', ');
-      const result: D1Result = await this.database
-        .prepare(
-          `
-            UPDATE application_context_documents
-            SET status = ?, deleted_at = ?, updated_at = ?
-            WHERE application_id = ? AND user_email = ? AND vector_id IN (${placeholders})
-          `,
-        )
-        .bind(APPLICATION_CONTEXT_DOCUMENT_STATUS_DELETED, now, now, applicationId, userEmail, ...chunk)
-        .run();
-      if (!result.success) {
-        throw new DatabaseError(`Failed to mark context documents deleted: ${result.error}`);
-      }
+      await executeD1WithRetry(
+        (): Promise<D1Result> =>
+          this.database
+            .prepare(
+              `
+                UPDATE application_context_documents
+                SET status = ?, deleted_at = ?, updated_at = ?
+                WHERE application_id = ? AND user_email = ? AND vector_id IN (${placeholders})
+              `,
+            )
+            .bind(APPLICATION_CONTEXT_DOCUMENT_STATUS_DELETED, now, now, applicationId, userEmail, ...chunk)
+            .run(),
+        'mark context documents deleted',
+      );
     }
   }
 

--- a/packages/backend-data/src/dao/ConnectedApplicationDAO.ts
+++ b/packages/backend-data/src/dao/ConnectedApplicationDAO.ts
@@ -6,6 +6,7 @@ import {
 } from '@mail-otter/shared/constants';
 import { decryptData, encryptData } from '../crypto';
 import { DatabaseError } from '@mail-otter/backend-errors';
+import { executeD1WithRetry } from '../utils';
 import type {
   ConnectedApplication,
   ConnectedApplicationCredentials,
@@ -36,32 +37,33 @@ class ConnectedApplicationDAO {
     const now: number = TimestampUtil.getCurrentUnixTimestampInSeconds();
     const applicationId: string = UUIDUtil.getRandomUUID();
     const encrypted = await encryptData(JSON.stringify(credentials), this.masterKey);
-    const result: D1Result = await this.database
-      .prepare(
-        `
-          INSERT INTO connected_applications
-            (application_id, user_email, provider_email, display_name, provider_id, connection_method, encrypted_credentials, credentials_iv, status, context_indexing_enabled, created_at, updated_at)
-          VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
-        `,
-      )
-      .bind(
-        applicationId,
-        userEmail,
-        null,
-        displayName,
-        providerId,
-        connectionMethod,
-        encrypted.encrypted,
-        encrypted.iv,
-        status,
-        1,
-        now,
-        now,
-      )
-      .run();
-    if (!result.success) {
-      throw new DatabaseError(`Failed to create connected application: ${result.error}`);
-    }
+    await executeD1WithRetry(
+      (): Promise<D1Result> =>
+        this.database
+          .prepare(
+            `
+              INSERT INTO connected_applications
+                (application_id, user_email, provider_email, display_name, provider_id, connection_method, encrypted_credentials, credentials_iv, status, context_indexing_enabled, created_at, updated_at)
+              VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+            `,
+          )
+          .bind(
+            applicationId,
+            userEmail,
+            null,
+            displayName,
+            providerId,
+            connectionMethod,
+            encrypted.encrypted,
+            encrypted.iv,
+            status,
+            1,
+            now,
+            now,
+          )
+          .run(),
+      'create connected application',
+    );
     if (gmailPubsubTopicName) {
       await this.setProviderConfig(applicationId, 'gmail_pubsub_topic_name', gmailPubsubTopicName, now);
     }
@@ -136,19 +138,20 @@ class ConnectedApplicationDAO {
   ): Promise<ConnectedApplicationMetadata | undefined> {
     const now: number = TimestampUtil.getCurrentUnixTimestampInSeconds();
     const encrypted = await encryptData(JSON.stringify(credentials), this.masterKey);
-    const result: D1Result = await this.database
-      .prepare(
-        `
-          UPDATE connected_applications
-          SET display_name = ?, encrypted_credentials = ?, credentials_iv = ?, status = ?, updated_at = ?
-          WHERE application_id = ? AND user_email = ?
-        `,
-      )
-      .bind(displayName, encrypted.encrypted, encrypted.iv, status, now, applicationId, userEmail)
-      .run();
-    if (!result.success) {
-      throw new DatabaseError(`Failed to update connected application: ${result.error}`);
-    }
+    await executeD1WithRetry(
+      (): Promise<D1Result> =>
+        this.database
+          .prepare(
+            `
+              UPDATE connected_applications
+              SET display_name = ?, encrypted_credentials = ?, credentials_iv = ?, status = ?, updated_at = ?
+              WHERE application_id = ? AND user_email = ?
+            `,
+          )
+          .bind(displayName, encrypted.encrypted, encrypted.iv, status, now, applicationId, userEmail)
+          .run(),
+      'update connected application',
+    );
     if (gmailPubsubTopicName) {
       await this.setProviderConfig(applicationId, 'gmail_pubsub_topic_name', gmailPubsubTopicName, now);
     } else if (gmailPubsubTopicName === null) {
@@ -169,19 +172,20 @@ class ConnectedApplicationDAO {
     };
     const encrypted = await encryptData(JSON.stringify(credentials), this.masterKey);
     const now: number = TimestampUtil.getCurrentUnixTimestampInSeconds();
-    const result: D1Result = await this.database
-      .prepare(
-        `
-          UPDATE connected_applications
-          SET encrypted_credentials = ?, credentials_iv = ?, provider_email = ?, status = ?, updated_at = ?
-          WHERE application_id = ?
-        `,
-      )
-      .bind(encrypted.encrypted, encrypted.iv, providerEmail, CONNECTED_APPLICATION_STATUS_CONNECTED, now, applicationId)
-      .run();
-    if (!result.success) {
-      throw new DatabaseError(`Failed to mark OAuth2 application connected: ${result.error}`);
-    }
+    await executeD1WithRetry(
+      (): Promise<D1Result> =>
+        this.database
+          .prepare(
+            `
+              UPDATE connected_applications
+              SET encrypted_credentials = ?, credentials_iv = ?, provider_email = ?, status = ?, updated_at = ?
+              WHERE application_id = ?
+            `,
+          )
+          .bind(encrypted.encrypted, encrypted.iv, providerEmail, CONNECTED_APPLICATION_STATUS_CONNECTED, now, applicationId)
+          .run(),
+      'mark OAuth2 application connected',
+    );
   }
 
   public async updateOAuth2RefreshToken(applicationId: string, refreshToken: string): Promise<void> {
@@ -192,24 +196,26 @@ class ConnectedApplicationDAO {
       refreshToken,
     };
     const encrypted = await encryptData(JSON.stringify(credentials), this.masterKey);
-    const result: D1Result = await this.database
-      .prepare('UPDATE connected_applications SET encrypted_credentials = ?, credentials_iv = ? WHERE application_id = ?')
-      .bind(encrypted.encrypted, encrypted.iv, applicationId)
-      .run();
-    if (!result.success) {
-      throw new DatabaseError(`Failed to update OAuth2 refresh token: ${result.error}`);
-    }
+    await executeD1WithRetry(
+      (): Promise<D1Result> =>
+        this.database
+          .prepare('UPDATE connected_applications SET encrypted_credentials = ?, credentials_iv = ? WHERE application_id = ?')
+          .bind(encrypted.encrypted, encrypted.iv, applicationId)
+          .run(),
+      'update OAuth2 refresh token',
+    );
   }
 
-  public async markError(applicationId: string, message: string): Promise<void> {
+  public async markError(applicationId: string, _message: string): Promise<void> {
     const now: number = TimestampUtil.getCurrentUnixTimestampInSeconds();
-    const result: D1Result = await this.database
-      .prepare('UPDATE connected_applications SET status = ?, updated_at = ? WHERE application_id = ?')
-      .bind(CONNECTED_APPLICATION_STATUS_ERROR, now, applicationId)
-      .run();
-    if (!result.success) {
-      throw new DatabaseError(`Failed to mark connected application error: ${result.error || message}`);
-    }
+    await executeD1WithRetry(
+      (): Promise<D1Result> =>
+        this.database
+          .prepare('UPDATE connected_applications SET status = ?, updated_at = ? WHERE application_id = ?')
+          .bind(CONNECTED_APPLICATION_STATUS_ERROR, now, applicationId)
+          .run(),
+      'mark connected application error',
+    );
   }
 
   public async updateContextIndexingForUser(
@@ -218,19 +224,20 @@ class ConnectedApplicationDAO {
     contextIndexingEnabled: boolean,
   ): Promise<ConnectedApplicationMetadata | undefined> {
     const now: number = TimestampUtil.getCurrentUnixTimestampInSeconds();
-    const result: D1Result = await this.database
-      .prepare(
-        `
-          UPDATE connected_applications
-          SET context_indexing_enabled = ?, updated_at = ?
-          WHERE application_id = ? AND user_email = ?
-        `,
-      )
-      .bind(contextIndexingEnabled ? 1 : 0, now, applicationId, userEmail)
-      .run();
-    if (!result.success) {
-      throw new DatabaseError(`Failed to update context indexing setting: ${result.error}`);
-    }
+    await executeD1WithRetry(
+      (): Promise<D1Result> =>
+        this.database
+          .prepare(
+            `
+              UPDATE connected_applications
+              SET context_indexing_enabled = ?, updated_at = ?
+              WHERE application_id = ? AND user_email = ?
+            `,
+          )
+          .bind(contextIndexingEnabled ? 1 : 0, now, applicationId, userEmail)
+          .run(),
+      'update context indexing setting',
+    );
     return this.getMetadataByIdForUser(applicationId, userEmail);
   }
 
@@ -242,22 +249,33 @@ class ConnectedApplicationDAO {
   ): Promise<ConnectedApplicationMetadata | undefined> {
     const now: number = TimestampUtil.getCurrentUnixTimestampInSeconds();
     if (folderIds && folderIds.length > 0) {
-      await this.database
-        .prepare('DELETE FROM application_watched_folders WHERE application_id = ?')
-        .bind(applicationId)
-        .run();
+      await executeD1WithRetry(
+        (): Promise<D1Result> =>
+          this.database
+            .prepare('DELETE FROM application_watched_folders WHERE application_id = ?')
+            .bind(applicationId)
+            .run(),
+        'clear watched folders',
+      );
       const stmt = this.database.prepare(
         'INSERT INTO application_watched_folders (application_id, folder_path, folder_name, created_at) VALUES (?, ?, ?, ?)',
       );
       for (const folderPath of folderIds) {
         const folderName: string = folderNames?.[folderPath] || folderPath;
-        await stmt.bind(applicationId, folderPath, folderName, now).run();
+        await executeD1WithRetry(
+          (): Promise<D1Result> => stmt.bind(applicationId, folderPath, folderName, now).run(),
+          'insert watched folder',
+        );
       }
     } else {
-      await this.database
-        .prepare('DELETE FROM application_watched_folders WHERE application_id = ?')
-        .bind(applicationId)
-        .run();
+      await executeD1WithRetry(
+        (): Promise<D1Result> =>
+          this.database
+            .prepare('DELETE FROM application_watched_folders WHERE application_id = ?')
+            .bind(applicationId)
+            .run(),
+        'clear watched folders',
+      );
     }
     return this.getMetadataByIdForUser(applicationId, userEmail);
   }
@@ -268,30 +286,32 @@ class ConnectedApplicationDAO {
     maxContextDocuments: number | null,
   ): Promise<ConnectedApplicationMetadata | undefined> {
     const now: number = TimestampUtil.getCurrentUnixTimestampInSeconds();
-    const result: D1Result = await this.database
-      .prepare(
-        `
-          UPDATE connected_applications
-          SET max_context_documents = ?, updated_at = ?
-          WHERE application_id = ? AND user_email = ?
-        `,
-      )
-      .bind(maxContextDocuments, now, applicationId, userEmail)
-      .run();
-    if (!result.success) {
-      throw new DatabaseError(`Failed to update max context documents: ${result.error}`);
-    }
+    await executeD1WithRetry(
+      (): Promise<D1Result> =>
+        this.database
+          .prepare(
+            `
+              UPDATE connected_applications
+              SET max_context_documents = ?, updated_at = ?
+              WHERE application_id = ? AND user_email = ?
+            `,
+          )
+          .bind(maxContextDocuments, now, applicationId, userEmail)
+          .run(),
+      'update max context documents',
+    );
     return this.getMetadataByIdForUser(applicationId, userEmail);
   }
 
   public async deleteForUser(applicationId: string, userEmail: string): Promise<void> {
-    const result: D1Result = await this.database
-      .prepare('DELETE FROM connected_applications WHERE application_id = ? AND user_email = ?')
-      .bind(applicationId, userEmail)
-      .run();
-    if (!result.success) {
-      throw new DatabaseError(`Failed to delete connected application: ${result.error}`);
-    }
+    await executeD1WithRetry(
+      (): Promise<D1Result> =>
+        this.database
+          .prepare('DELETE FROM connected_applications WHERE application_id = ? AND user_email = ?')
+          .bind(applicationId, userEmail)
+          .run(),
+      'delete connected application',
+    );
   }
 
   public async getProviderConfig(applicationId: string, configKey: string): Promise<string | null> {
@@ -304,26 +324,31 @@ class ConnectedApplicationDAO {
 
   public async setProviderConfig(applicationId: string, configKey: string, configValue: string, now?: number): Promise<void> {
     const timestamp: number = now ?? TimestampUtil.getCurrentUnixTimestampInSeconds();
-    const result: D1Result = await this.database
-      .prepare(
-        `
-          INSERT INTO provider_application_configs (application_id, config_key, config_value, created_at, updated_at)
-          VALUES (?, ?, ?, ?, ?)
-          ON CONFLICT(application_id, config_key) DO UPDATE SET config_value = excluded.config_value, updated_at = excluded.updated_at
-        `,
-      )
-      .bind(applicationId, configKey, configValue, timestamp, timestamp)
-      .run();
-    if (!result.success) {
-      throw new DatabaseError(`Failed to set provider config: ${result.error}`);
-    }
+    await executeD1WithRetry(
+      (): Promise<D1Result> =>
+        this.database
+          .prepare(
+            `
+              INSERT INTO provider_application_configs (application_id, config_key, config_value, created_at, updated_at)
+              VALUES (?, ?, ?, ?, ?)
+              ON CONFLICT(application_id, config_key) DO UPDATE SET config_value = excluded.config_value, updated_at = excluded.updated_at
+            `,
+          )
+          .bind(applicationId, configKey, configValue, timestamp, timestamp)
+          .run(),
+      'set provider config',
+    );
   }
 
   public async deleteProviderConfig(applicationId: string, configKey: string): Promise<void> {
-    await this.database
-      .prepare('DELETE FROM provider_application_configs WHERE application_id = ? AND config_key = ?')
-      .bind(applicationId, configKey)
-      .run();
+    await executeD1WithRetry(
+      (): Promise<D1Result> =>
+        this.database
+          .prepare('DELETE FROM provider_application_configs WHERE application_id = ? AND config_key = ?')
+          .bind(applicationId, configKey)
+          .run(),
+      'delete provider config',
+    );
   }
 
   public async getWatchedFolders(applicationId: string): Promise<Array<{ folderPath: string; folderName: string }>> {

--- a/packages/backend-data/src/dao/OAuth2AccessTokenRefreshStatusDAO.ts
+++ b/packages/backend-data/src/dao/OAuth2AccessTokenRefreshStatusDAO.ts
@@ -1,5 +1,5 @@
 import { CONNECTED_APPLICATION_STATUS_CONNECTED, CONNECTION_METHOD_OAUTH2 } from '@mail-otter/shared/constants';
-import { DatabaseError } from '@mail-otter/backend-errors';
+import { executeD1WithRetry } from '../utils';
 import { TimestampUtil } from '@mail-otter/shared/utils';
 
 interface OAuth2AccessTokenRefreshStatus {
@@ -49,68 +49,71 @@ class OAuth2AccessTokenRefreshStatusDAO {
 
   public async recordRefreshStarted(applicationId: string): Promise<void> {
     const now: number = TimestampUtil.getCurrentUnixTimestampInSeconds();
-    const result: D1Result = await this.database
-      .prepare(
-        `
-          INSERT INTO oauth2_access_token_refresh_status
-            (application_id, access_token_expires_at, last_refresh_started_at, last_refresh_succeeded_at,
-             last_refresh_failed_at, last_error, created_at, updated_at)
-          VALUES (?, NULL, ?, NULL, NULL, NULL, ?, ?)
-          ON CONFLICT(application_id) DO UPDATE SET
-            last_refresh_started_at = excluded.last_refresh_started_at,
-            updated_at = excluded.updated_at
-        `,
-      )
-      .bind(applicationId, now, now, now)
-      .run();
-    if (!result.success) {
-      throw new DatabaseError(`Failed to record OAuth2 token refresh start: ${result.error}`);
-    }
+    await executeD1WithRetry(
+      (): Promise<D1Result> =>
+        this.database
+          .prepare(
+            `
+              INSERT INTO oauth2_access_token_refresh_status
+                (application_id, access_token_expires_at, last_refresh_started_at, last_refresh_succeeded_at,
+                 last_refresh_failed_at, last_error, created_at, updated_at)
+              VALUES (?, NULL, ?, NULL, NULL, NULL, ?, ?)
+              ON CONFLICT(application_id) DO UPDATE SET
+                last_refresh_started_at = excluded.last_refresh_started_at,
+                updated_at = excluded.updated_at
+            `,
+          )
+          .bind(applicationId, now, now, now)
+          .run(),
+      'record OAuth2 token refresh start',
+    );
   }
 
   public async recordRefreshSuccess(applicationId: string, accessTokenExpiresAt: number): Promise<void> {
     const now: number = TimestampUtil.getCurrentUnixTimestampInSeconds();
-    const result: D1Result = await this.database
-      .prepare(
-        `
-          INSERT INTO oauth2_access_token_refresh_status
-            (application_id, access_token_expires_at, last_refresh_started_at, last_refresh_succeeded_at,
-             last_refresh_failed_at, last_error, created_at, updated_at)
-          VALUES (?, ?, NULL, ?, NULL, NULL, ?, ?)
-          ON CONFLICT(application_id) DO UPDATE SET
-            access_token_expires_at = excluded.access_token_expires_at,
-            last_refresh_succeeded_at = excluded.last_refresh_succeeded_at,
-            last_error = NULL,
-            updated_at = excluded.updated_at
-        `,
-      )
-      .bind(applicationId, accessTokenExpiresAt, now, now, now)
-      .run();
-    if (!result.success) {
-      throw new DatabaseError(`Failed to record OAuth2 token refresh success: ${result.error}`);
-    }
+    await executeD1WithRetry(
+      (): Promise<D1Result> =>
+        this.database
+          .prepare(
+            `
+              INSERT INTO oauth2_access_token_refresh_status
+                (application_id, access_token_expires_at, last_refresh_started_at, last_refresh_succeeded_at,
+                 last_refresh_failed_at, last_error, created_at, updated_at)
+              VALUES (?, ?, NULL, ?, NULL, NULL, ?, ?)
+              ON CONFLICT(application_id) DO UPDATE SET
+                access_token_expires_at = excluded.access_token_expires_at,
+                last_refresh_succeeded_at = excluded.last_refresh_succeeded_at,
+                last_error = NULL,
+                updated_at = excluded.updated_at
+            `,
+          )
+          .bind(applicationId, accessTokenExpiresAt, now, now, now)
+          .run(),
+      'record OAuth2 token refresh success',
+    );
   }
 
   public async recordRefreshFailure(applicationId: string, errorMessage: string): Promise<void> {
     const now: number = TimestampUtil.getCurrentUnixTimestampInSeconds();
-    const result: D1Result = await this.database
-      .prepare(
-        `
-          INSERT INTO oauth2_access_token_refresh_status
-            (application_id, access_token_expires_at, last_refresh_started_at, last_refresh_succeeded_at,
-             last_refresh_failed_at, last_error, created_at, updated_at)
-          VALUES (?, NULL, NULL, NULL, ?, ?, ?, ?)
-          ON CONFLICT(application_id) DO UPDATE SET
-            last_refresh_failed_at = excluded.last_refresh_failed_at,
-            last_error = excluded.last_error,
-            updated_at = excluded.updated_at
-        `,
-      )
-      .bind(applicationId, now, errorMessage.slice(0, 1024), now, now)
-      .run();
-    if (!result.success) {
-      throw new DatabaseError(`Failed to record OAuth2 token refresh failure: ${result.error}`);
-    }
+    await executeD1WithRetry(
+      (): Promise<D1Result> =>
+        this.database
+          .prepare(
+            `
+              INSERT INTO oauth2_access_token_refresh_status
+                (application_id, access_token_expires_at, last_refresh_started_at, last_refresh_succeeded_at,
+                 last_refresh_failed_at, last_error, created_at, updated_at)
+              VALUES (?, NULL, NULL, NULL, ?, ?, ?, ?)
+              ON CONFLICT(application_id) DO UPDATE SET
+                last_refresh_failed_at = excluded.last_refresh_failed_at,
+                last_error = excluded.last_error,
+                updated_at = excluded.updated_at
+            `,
+          )
+          .bind(applicationId, now, errorMessage.slice(0, 1024), now, now)
+          .run(),
+      'record OAuth2 token refresh failure',
+    );
   }
 
   public async listDueApplicationIds(refreshBefore: number, limit: number): Promise<string[]> {

--- a/packages/backend-data/src/dao/OAuth2AuthorizationSessionDAO.ts
+++ b/packages/backend-data/src/dao/OAuth2AuthorizationSessionDAO.ts
@@ -1,4 +1,4 @@
-import { DatabaseError } from '@mail-otter/backend-errors';
+import { executeD1WithRetry } from '../utils';
 import type { OAuth2AuthorizationSession, OAuth2AuthorizationSessionInternal } from '@mail-otter/shared/model';
 import { TimestampUtil, UUIDUtil } from '@mail-otter/shared/utils';
 
@@ -18,19 +18,20 @@ class OAuth2AuthorizationSessionDAO {
   ): Promise<void> {
     const now: number = TimestampUtil.getCurrentUnixTimestampInSeconds();
     const sessionId: string = UUIDUtil.getRandomUUID();
-    const result: D1Result = await this.database
-      .prepare(
-        `
-          INSERT INTO oauth2_authorization_sessions
-            (session_id, application_id, state_hash, code_verifier, redirect_uri, created_at, expires_at)
-          VALUES (?, ?, ?, ?, ?, ?, ?)
-        `,
-      )
-      .bind(sessionId, applicationId, stateHash, codeVerifier, redirectUri, now, expiresAt)
-      .run();
-    if (!result.success) {
-      throw new DatabaseError(`Failed to create OAuth2 authorization session: ${result.error}`);
-    }
+    await executeD1WithRetry(
+      (): Promise<D1Result> =>
+        this.database
+          .prepare(
+            `
+              INSERT INTO oauth2_authorization_sessions
+                (session_id, application_id, state_hash, code_verifier, redirect_uri, created_at, expires_at)
+              VALUES (?, ?, ?, ?, ?, ?, ?)
+            `,
+          )
+          .bind(sessionId, applicationId, stateHash, codeVerifier, redirectUri, now, expiresAt)
+          .run(),
+      'create OAuth2 authorization session',
+    );
   }
 
   public async getActive(applicationId: string, stateHash: string): Promise<OAuth2AuthorizationSession | undefined> {
@@ -51,31 +52,33 @@ class OAuth2AuthorizationSessionDAO {
 
   public async deleteExpiredSessions(limit: number): Promise<number> {
     const now: number = TimestampUtil.getCurrentUnixTimestampInSeconds();
-    const result: D1Result = await this.database
-      .prepare(
-        `
-          DELETE FROM oauth2_authorization_sessions
-          WHERE expires_at < ? OR consumed_at IS NOT NULL
-          LIMIT ?
-        `,
-      )
-      .bind(now, limit)
-      .run();
-    if (!result.success) {
-      throw new DatabaseError(`Failed to delete expired OAuth2 sessions: ${result.error}`);
-    }
+    const result: D1Result = await executeD1WithRetry(
+      (): Promise<D1Result> =>
+        this.database
+          .prepare(
+            `
+              DELETE FROM oauth2_authorization_sessions
+              WHERE expires_at < ? OR consumed_at IS NOT NULL
+              LIMIT ?
+            `,
+          )
+          .bind(now, limit)
+          .run(),
+      'delete expired OAuth2 sessions',
+    );
     return (result.meta as { changes?: number } | undefined)?.changes ?? 0;
   }
 
   public async consume(sessionId: string): Promise<void> {
     const consumedAt: number = TimestampUtil.getCurrentUnixTimestampInSeconds();
-    const result: D1Result = await this.database
-      .prepare('UPDATE oauth2_authorization_sessions SET consumed_at = ? WHERE session_id = ? AND consumed_at IS NULL')
-      .bind(consumedAt, sessionId)
-      .run();
-    if (!result.success) {
-      throw new DatabaseError(`Failed to consume OAuth2 authorization session: ${result.error}`);
-    }
+    await executeD1WithRetry(
+      (): Promise<D1Result> =>
+        this.database
+          .prepare('UPDATE oauth2_authorization_sessions SET consumed_at = ? WHERE session_id = ? AND consumed_at IS NULL')
+          .bind(consumedAt, sessionId)
+          .run(),
+      'consume OAuth2 authorization session',
+    );
   }
 
   private toSession(row: OAuth2AuthorizationSessionInternal): OAuth2AuthorizationSession {

--- a/packages/backend-data/src/dao/ProcessedMessageDAO.ts
+++ b/packages/backend-data/src/dao/ProcessedMessageDAO.ts
@@ -4,7 +4,7 @@ import {
   PROCESSED_MESSAGE_STATUS_SKIPPED,
   PROCESSED_MESSAGE_STATUS_SUMMARIZED,
 } from '@mail-otter/shared/constants';
-import { DatabaseError } from '@mail-otter/backend-errors';
+import { executeD1WithRetry } from '../utils';
 import type { ProcessedMessage, ProcessedMessageInternal } from '@mail-otter/shared/model';
 import type { ProcessedMessageStatus, ProviderId } from '@mail-otter/shared/constants';
 import { TimestampUtil, UUIDUtil } from '@mail-otter/shared/utils';
@@ -25,29 +25,30 @@ class ProcessedMessageDAO {
   ): Promise<boolean> {
     const now: number = TimestampUtil.getCurrentUnixTimestampInSeconds();
     const processedMessageId: string = UUIDUtil.getRandomUUID();
-    const result: D1Result = await this.database
-      .prepare(
-        `
-          INSERT OR IGNORE INTO processed_messages
-            (processed_message_id, application_id, provider_id, provider_message_id, provider_thread_id, provider_stable_message_fingerprint, status, summary_sent_at, error_message, created_at, updated_at)
-          VALUES (?, ?, ?, ?, ?, ?, ?, NULL, NULL, ?, ?)
-        `,
-      )
-      .bind(
-        processedMessageId,
-        applicationId,
-        providerId,
-        providerMessageId,
-        providerThreadId || null,
-        options.providerStableMessageFingerprint || null,
-        PROCESSED_MESSAGE_STATUS_PROCESSING,
-        now,
-        now,
-      )
-      .run();
-    if (!result.success) {
-      throw new DatabaseError(`Failed to create processed message row: ${result.error}`);
-    }
+    const result: D1Result = await executeD1WithRetry(
+      (): Promise<D1Result> =>
+        this.database
+          .prepare(
+            `
+              INSERT OR IGNORE INTO processed_messages
+                (processed_message_id, application_id, provider_id, provider_message_id, provider_thread_id, provider_stable_message_fingerprint, status, summary_sent_at, error_message, created_at, updated_at)
+              VALUES (?, ?, ?, ?, ?, ?, ?, NULL, NULL, ?, ?)
+            `,
+          )
+          .bind(
+            processedMessageId,
+            applicationId,
+            providerId,
+            providerMessageId,
+            providerThreadId || null,
+            options.providerStableMessageFingerprint || null,
+            PROCESSED_MESSAGE_STATUS_PROCESSING,
+            now,
+            now,
+          )
+          .run(),
+      'create processed message row',
+    );
     const inserted: boolean = ((result.meta as { changes?: number } | undefined)?.changes ?? 0) > 0;
     if (inserted || !options.allowExistingForRetry) {
       return inserted;
@@ -84,19 +85,20 @@ class ProcessedMessageDAO {
 
   public async deleteOlderThan(olderThan: number, statuses: string[], limit: number): Promise<number> {
     const placeholders: string = statuses.map((): string => '?').join(', ');
-    const result: D1Result = await this.database
-      .prepare(
-        `
-          DELETE FROM processed_messages
-          WHERE updated_at < ? AND status IN (${placeholders})
-          LIMIT ?
-        `,
-      )
-      .bind(olderThan, ...statuses, limit)
-      .run();
-    if (!result.success) {
-      throw new DatabaseError(`Failed to delete old processed messages: ${result.error}`);
-    }
+    const result: D1Result = await executeD1WithRetry(
+      (): Promise<D1Result> =>
+        this.database
+          .prepare(
+            `
+              DELETE FROM processed_messages
+              WHERE updated_at < ? AND status IN (${placeholders})
+              LIMIT ?
+            `,
+          )
+          .bind(olderThan, ...statuses, limit)
+          .run(),
+      'delete old processed messages',
+    );
     return (result.meta as { changes?: number } | undefined)?.changes ?? 0;
   }
 
@@ -140,19 +142,20 @@ class ProcessedMessageDAO {
     setSummarySentAt: boolean,
   ): Promise<void> {
     const now: number = TimestampUtil.getCurrentUnixTimestampInSeconds();
-    const result: D1Result = await this.database
-      .prepare(
-        `
-          UPDATE processed_messages
-          SET status = ?, summary_sent_at = CASE WHEN ? THEN ? ELSE summary_sent_at END, error_message = ?, updated_at = ?
-          WHERE application_id = ? AND provider_message_id = ?
-        `,
-      )
-      .bind(status, setSummarySentAt ? 1 : 0, now, errorMessage ? errorMessage.slice(0, 1024) : null, now, applicationId, providerMessageId)
-      .run();
-    if (!result.success) {
-      throw new DatabaseError(`Failed to update processed message: ${result.error}`);
-    }
+    await executeD1WithRetry(
+      (): Promise<D1Result> =>
+        this.database
+          .prepare(
+            `
+              UPDATE processed_messages
+              SET status = ?, summary_sent_at = CASE WHEN ? THEN ? ELSE summary_sent_at END, error_message = ?, updated_at = ?
+              WHERE application_id = ? AND provider_message_id = ?
+            `,
+          )
+          .bind(status, setSummarySentAt ? 1 : 0, now, errorMessage ? errorMessage.slice(0, 1024) : null, now, applicationId, providerMessageId)
+          .run(),
+      'update processed message',
+    );
   }
 
   private async getInternalByMessageId(applicationId: string, providerMessageId: string): Promise<ProcessedMessageInternal | null> {
@@ -194,21 +197,22 @@ class ProcessedMessageDAO {
     providerStableMessageFingerprint: string | null | undefined,
   ): Promise<void> {
     const now: number = TimestampUtil.getCurrentUnixTimestampInSeconds();
-    const result: D1Result = await this.database
-      .prepare(
-        `
-          UPDATE processed_messages
-          SET provider_thread_id = COALESCE(?, provider_thread_id),
-              provider_stable_message_fingerprint = COALESCE(?, provider_stable_message_fingerprint),
-              updated_at = ?
-          WHERE application_id = ? AND provider_message_id = ?
-        `,
-      )
-      .bind(providerThreadId || null, providerStableMessageFingerprint || null, now, applicationId, providerMessageId)
-      .run();
-    if (!result.success) {
-      throw new DatabaseError(`Failed to update processed message retry metadata: ${result.error}`);
-    }
+    await executeD1WithRetry(
+      (): Promise<D1Result> =>
+        this.database
+          .prepare(
+            `
+              UPDATE processed_messages
+              SET provider_thread_id = COALESCE(?, provider_thread_id),
+                  provider_stable_message_fingerprint = COALESCE(?, provider_stable_message_fingerprint),
+                  updated_at = ?
+              WHERE application_id = ? AND provider_message_id = ?
+            `,
+          )
+          .bind(providerThreadId || null, providerStableMessageFingerprint || null, now, applicationId, providerMessageId)
+          .run(),
+      'update processed message retry metadata',
+    );
   }
 
   private toProcessedMessage(row: ProcessedMessageInternal): ProcessedMessage {

--- a/packages/backend-data/src/dao/ProviderSubscriptionDAO.ts
+++ b/packages/backend-data/src/dao/ProviderSubscriptionDAO.ts
@@ -4,6 +4,7 @@ import {
   PROVIDER_SUBSCRIPTION_STATUS_STOPPED,
 } from '@mail-otter/shared/constants';
 import { DatabaseError } from '@mail-otter/backend-errors';
+import { executeD1WithRetry } from '../utils';
 import type { ProviderId } from '@mail-otter/shared/constants';
 import type { ProviderSubscription, ProviderSubscriptionInternal } from '@mail-otter/shared/model';
 import { TimestampUtil, UUIDUtil } from '@mail-otter/shared/utils';
@@ -30,65 +31,67 @@ class ProviderSubscriptionDAO {
     const existing: ProviderSubscription | undefined = await this.getByApplication(input.applicationId);
     const now: number = TimestampUtil.getCurrentUnixTimestampInSeconds();
     if (existing) {
-      const result: D1Result = await this.database
-        .prepare(
-          `
-            UPDATE provider_subscriptions
-            SET external_subscription_id = ?, webhook_secret_hash = ?, client_state_hash = ?, gmail_history_id = ?,
-                resource = ?, status = ?, expires_at = ?, last_error = NULL, last_renewed_at = ?,
-                renewal_retry_count = 0, renewal_next_retry_at = NULL, updated_at = ?
-            WHERE subscription_id = ?
-          `,
-        )
-        .bind(
-          input.externalSubscriptionId || null,
-          input.webhookSecretHash || existing.webhookSecretHash || null,
-          input.clientStateHash || null,
-          input.gmailHistoryId || existing.gmailHistoryId || null,
-          input.resource || null,
-          PROVIDER_SUBSCRIPTION_STATUS_ACTIVE,
-          input.expiresAt ?? null,
-          now,
-          now,
-          existing.subscriptionId,
-        )
-        .run();
-      if (!result.success) {
-        throw new DatabaseError(`Failed to update provider subscription: ${result.error}`);
-      }
+      await executeD1WithRetry(
+        (): Promise<D1Result> =>
+          this.database
+            .prepare(
+              `
+                UPDATE provider_subscriptions
+                SET external_subscription_id = ?, webhook_secret_hash = ?, client_state_hash = ?, gmail_history_id = ?,
+                    resource = ?, status = ?, expires_at = ?, last_error = NULL, last_renewed_at = ?,
+                    renewal_retry_count = 0, renewal_next_retry_at = NULL, updated_at = ?
+                WHERE subscription_id = ?
+              `,
+            )
+            .bind(
+              input.externalSubscriptionId || null,
+              input.webhookSecretHash || existing.webhookSecretHash || null,
+              input.clientStateHash || null,
+              input.gmailHistoryId || existing.gmailHistoryId || null,
+              input.resource || null,
+              PROVIDER_SUBSCRIPTION_STATUS_ACTIVE,
+              input.expiresAt ?? null,
+              now,
+              now,
+              existing.subscriptionId,
+            )
+            .run(),
+        'update provider subscription',
+      );
       const updated: ProviderSubscription | undefined = await this.getById(existing.subscriptionId);
       if (!updated) throw new DatabaseError('Failed to load provider subscription after update.');
       return updated;
     }
 
     const subscriptionId: string = UUIDUtil.getRandomUUID();
-    const result: D1Result = await this.database
-      .prepare(
-        `
-          INSERT INTO provider_subscriptions
-            (subscription_id, application_id, provider_id, external_subscription_id, webhook_secret_hash, client_state_hash, gmail_history_id, resource, status, expires_at, last_notification_at, last_renewed_at, last_error, created_at, updated_at)
-          VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, NULL, ?, NULL, ?, ?)
-        `,
-      )
-      .bind(
-        subscriptionId,
-        input.applicationId,
-        input.providerId,
-        input.externalSubscriptionId || null,
-        input.webhookSecretHash || null,
-        input.clientStateHash || null,
-        input.gmailHistoryId || null,
-        input.resource || null,
-        PROVIDER_SUBSCRIPTION_STATUS_ACTIVE,
-        input.expiresAt ?? null,
-        now,
-        now,
-        now,
-      )
-      .run();
-    if (!result.success) {
-      throw new DatabaseError(`Failed to create provider subscription: ${result.error}`);
-    }
+    await executeD1WithRetry(
+      (): Promise<D1Result> =>
+        this.database
+          .prepare(
+            `
+              INSERT INTO provider_subscriptions
+                (subscription_id, application_id, provider_id, external_subscription_id, webhook_secret_hash, client_state_hash, gmail_history_id, resource, status, expires_at, last_notification_at, last_renewed_at, last_error, created_at, updated_at)
+              VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, NULL, ?, NULL, ?, ?)
+            `,
+          )
+          .bind(
+            subscriptionId,
+            input.applicationId,
+            input.providerId,
+            input.externalSubscriptionId || null,
+            input.webhookSecretHash || null,
+            input.clientStateHash || null,
+            input.gmailHistoryId || null,
+            input.resource || null,
+            PROVIDER_SUBSCRIPTION_STATUS_ACTIVE,
+            input.expiresAt ?? null,
+            now,
+            now,
+            now,
+          )
+          .run(),
+      'create provider subscription',
+    );
     const created: ProviderSubscription | undefined = await this.getById(subscriptionId);
     if (!created) throw new DatabaseError('Failed to load provider subscription after create.');
     return created;
@@ -143,63 +146,68 @@ class ProviderSubscriptionDAO {
 
   public async updateGmailHistory(subscriptionId: string, gmailHistoryId: string, lastNotificationAt?: number): Promise<void> {
     const now: number = TimestampUtil.getCurrentUnixTimestampInSeconds();
-    const result: D1Result = await this.database
-      .prepare(
-        'UPDATE provider_subscriptions SET gmail_history_id = ?, last_notification_at = COALESCE(?, last_notification_at), updated_at = ? WHERE subscription_id = ?',
-      )
-      .bind(gmailHistoryId, lastNotificationAt ?? null, now, subscriptionId)
-      .run();
-    if (!result.success) {
-      throw new DatabaseError(`Failed to update Gmail history cursor: ${result.error}`);
-    }
+    await executeD1WithRetry(
+      (): Promise<D1Result> =>
+        this.database
+          .prepare(
+            'UPDATE provider_subscriptions SET gmail_history_id = ?, last_notification_at = COALESCE(?, last_notification_at), updated_at = ? WHERE subscription_id = ?',
+          )
+          .bind(gmailHistoryId, lastNotificationAt ?? null, now, subscriptionId)
+          .run(),
+      'update Gmail history cursor',
+    );
   }
 
   public async touchNotification(subscriptionId: string): Promise<void> {
     const now: number = TimestampUtil.getCurrentUnixTimestampInSeconds();
-    const result: D1Result = await this.database
-      .prepare('UPDATE provider_subscriptions SET last_notification_at = ?, updated_at = ? WHERE subscription_id = ?')
-      .bind(now, now, subscriptionId)
-      .run();
-    if (!result.success) {
-      throw new DatabaseError(`Failed to update provider subscription notification timestamp: ${result.error}`);
-    }
+    await executeD1WithRetry(
+      (): Promise<D1Result> =>
+        this.database
+          .prepare('UPDATE provider_subscriptions SET last_notification_at = ?, updated_at = ? WHERE subscription_id = ?')
+          .bind(now, now, subscriptionId)
+          .run(),
+      'update provider subscription notification timestamp',
+    );
   }
 
   public async markStopped(applicationId: string): Promise<void> {
     const now: number = TimestampUtil.getCurrentUnixTimestampInSeconds();
-    const result: D1Result = await this.database
-      .prepare('UPDATE provider_subscriptions SET status = ?, updated_at = ? WHERE application_id = ?')
-      .bind(PROVIDER_SUBSCRIPTION_STATUS_STOPPED, now, applicationId)
-      .run();
-    if (!result.success) {
-      throw new DatabaseError(`Failed to stop provider subscription: ${result.error}`);
-    }
+    await executeD1WithRetry(
+      (): Promise<D1Result> =>
+        this.database
+          .prepare('UPDATE provider_subscriptions SET status = ?, updated_at = ? WHERE application_id = ?')
+          .bind(PROVIDER_SUBSCRIPTION_STATUS_STOPPED, now, applicationId)
+          .run(),
+      'stop provider subscription',
+    );
   }
 
   public async markError(subscriptionId: string, errorMessage: string, nextRetryAt?: number): Promise<void> {
     const now: number = TimestampUtil.getCurrentUnixTimestampInSeconds();
-    const result: D1Result = await this.database
-      .prepare(
-        'UPDATE provider_subscriptions SET status = ?, last_error = ?, renewal_retry_count = renewal_retry_count + 1, renewal_next_retry_at = ?, updated_at = ? WHERE subscription_id = ?',
-      )
-      .bind(PROVIDER_SUBSCRIPTION_STATUS_ERROR, errorMessage.slice(0, 1024), nextRetryAt ?? null, now, subscriptionId)
-      .run();
-    if (!result.success) {
-      throw new DatabaseError(`Failed to mark provider subscription error: ${result.error}`);
-    }
+    await executeD1WithRetry(
+      (): Promise<D1Result> =>
+        this.database
+          .prepare(
+            'UPDATE provider_subscriptions SET status = ?, last_error = ?, renewal_retry_count = renewal_retry_count + 1, renewal_next_retry_at = ?, updated_at = ? WHERE subscription_id = ?',
+          )
+          .bind(PROVIDER_SUBSCRIPTION_STATUS_ERROR, errorMessage.slice(0, 1024), nextRetryAt ?? null, now, subscriptionId)
+          .run(),
+      'mark provider subscription error',
+    );
   }
 
   public async recordTransientError(subscriptionId: string, errorMessage: string, nextRetryAt: number): Promise<void> {
     const now: number = TimestampUtil.getCurrentUnixTimestampInSeconds();
-    const result: D1Result = await this.database
-      .prepare(
-        'UPDATE provider_subscriptions SET last_error = ?, renewal_retry_count = renewal_retry_count + 1, renewal_next_retry_at = ?, updated_at = ? WHERE subscription_id = ?',
-      )
-      .bind(errorMessage.slice(0, 1024), nextRetryAt, now, subscriptionId)
-      .run();
-    if (!result.success) {
-      throw new DatabaseError(`Failed to record transient error on provider subscription: ${result.error}`);
-    }
+    await executeD1WithRetry(
+      (): Promise<D1Result> =>
+        this.database
+          .prepare(
+            'UPDATE provider_subscriptions SET last_error = ?, renewal_retry_count = renewal_retry_count + 1, renewal_next_retry_at = ?, updated_at = ? WHERE subscription_id = ?',
+          )
+          .bind(errorMessage.slice(0, 1024), nextRetryAt, now, subscriptionId)
+          .run(),
+      'record transient error on provider subscription',
+    );
   }
 
   private async getById(subscriptionId: string): Promise<ProviderSubscription | undefined> {

--- a/packages/backend-data/src/dao/UserDAO.ts
+++ b/packages/backend-data/src/dao/UserDAO.ts
@@ -1,4 +1,5 @@
 import { DatabaseError } from '@mail-otter/backend-errors';
+import { executeD1WithRetry } from '../utils';
 import type { User, UserInternal } from '@mail-otter/shared/model';
 import { TimestampUtil } from '@mail-otter/shared/utils';
 
@@ -11,19 +12,20 @@ class UserDAO {
 
   public async upsertByEmail(email: string): Promise<User> {
     const now: number = TimestampUtil.getCurrentUnixTimestampInSeconds();
-    const result: D1Result = await this.database
-      .prepare(
-        `
-          INSERT INTO users (email, created_at, updated_at)
-          VALUES (?, ?, ?)
-          ON CONFLICT(email) DO UPDATE SET updated_at = excluded.updated_at
-        `,
-      )
-      .bind(email, now, now)
-      .run();
-    if (!result.success) {
-      throw new DatabaseError(`Failed to upsert user: ${result.error}`);
-    }
+    await executeD1WithRetry(
+      (): Promise<D1Result> =>
+        this.database
+          .prepare(
+            `
+              INSERT INTO users (email, created_at, updated_at)
+              VALUES (?, ?, ?)
+              ON CONFLICT(email) DO UPDATE SET updated_at = excluded.updated_at
+            `,
+          )
+          .bind(email, now, now)
+          .run(),
+      'upsert user',
+    );
     const user: User | undefined = await this.getByEmail(email);
     if (!user) {
       throw new DatabaseError('Failed to load user after upsert.');

--- a/packages/backend-data/src/utils/D1ErrorClassifier.ts
+++ b/packages/backend-data/src/utils/D1ErrorClassifier.ts
@@ -1,0 +1,48 @@
+const RETRYABLE_PATTERNS: RegExp[] = [
+  /busy/i,
+  /locked/i,
+  /timeout/i,
+  /timed?\s*out/i,
+  /internal\s+(server\s+)?error/i,
+  /connection/i,
+  /network/i,
+  /unavailable/i,
+  /throttl/i,
+  /too\s+many/i,
+  /retry/i,
+  /deadlock/i,
+  /serialization/i,
+];
+
+const NON_RETRYABLE_PATTERNS: RegExp[] = [
+  /constraint/i,
+  /unique/i,
+  /primary\s+key/i,
+  /foreign\s+key/i,
+  /not\s+found/i,
+  /syntax/i,
+  /parse\s+error/i,
+  /no\s+such\s+(table|column|index)/i,
+  /type\s+mismatch/i,
+  /range/i,
+  /permission/i,
+  /authorization/i,
+  /authentication/i,
+  /invalid\s+argument/i,
+];
+
+function isD1ErrorRetryable(errorMessage: string): boolean {
+  if (!errorMessage) return false;
+
+  for (const pattern of NON_RETRYABLE_PATTERNS) {
+    if (pattern.test(errorMessage)) return false;
+  }
+
+  for (const pattern of RETRYABLE_PATTERNS) {
+    if (pattern.test(errorMessage)) return true;
+  }
+
+  return false;
+}
+
+export { isD1ErrorRetryable };

--- a/packages/backend-data/src/utils/D1Utils.ts
+++ b/packages/backend-data/src/utils/D1Utils.ts
@@ -1,0 +1,66 @@
+import { DatabaseError } from '@mail-otter/backend-errors';
+import { isD1ErrorRetryable } from './D1ErrorClassifier';
+
+const DEFAULT_MAX_RETRIES = 3;
+const DEFAULT_BASE_DELAY_MS = 100;
+
+function sleep(ms: number): Promise<void> {
+  return new Promise((resolve: (value: void) => void): unknown => setTimeout(resolve, ms));
+}
+
+function assertD1Success(result: D1Result, context: string): void {
+  if (!result.success) {
+    const errorMessage: string = result.error ?? 'Unknown database error';
+    const retryable: boolean = isD1ErrorRetryable(errorMessage);
+    throw new DatabaseError(`Failed to ${context}: ${errorMessage}`, retryable);
+  }
+}
+
+async function executeD1WithRetry(
+  operation: () => Promise<D1Result>,
+  context: string,
+  options?: { maxRetries?: number; baseDelayMs?: number },
+): Promise<D1Result> {
+  const maxRetries: number = options?.maxRetries ?? DEFAULT_MAX_RETRIES;
+  const baseDelayMs: number = options?.baseDelayMs ?? DEFAULT_BASE_DELAY_MS;
+  let lastError: Error | undefined;
+
+  for (let attempt = 0; attempt <= maxRetries; attempt++) {
+    try {
+      const result: D1Result = await operation();
+      if (!result.success) {
+        const errorMessage: string = result.error ?? 'Unknown database error';
+        const retryable: boolean = isD1ErrorRetryable(errorMessage);
+        if (retryable && attempt < maxRetries) {
+          await sleep(baseDelayMs * Math.pow(2, attempt));
+          continue;
+        }
+        throw new DatabaseError(`Failed to ${context}: ${errorMessage}`, retryable);
+      }
+      return result;
+    } catch (error: unknown) {
+      if (error instanceof DatabaseError) {
+        if (error.retryable && attempt < maxRetries) {
+          await sleep(baseDelayMs * Math.pow(2, attempt));
+          lastError = error;
+          continue;
+        }
+        throw error;
+      }
+      if (error instanceof Error) {
+        const retryable: boolean = isD1ErrorRetryable(error.message);
+        if (retryable && attempt < maxRetries) {
+          await sleep(baseDelayMs * Math.pow(2, attempt));
+          lastError = error;
+          continue;
+        }
+        throw new DatabaseError(`Failed to ${context}: ${error.message}`, retryable);
+      }
+      throw error;
+    }
+  }
+
+  throw lastError ?? new DatabaseError(`Failed to ${context} after ${maxRetries + 1} attempts`);
+}
+
+export { assertD1Success, executeD1WithRetry, sleep };

--- a/packages/backend-data/src/utils/index.ts
+++ b/packages/backend-data/src/utils/index.ts
@@ -1,0 +1,2 @@
+export { isD1ErrorRetryable } from './D1ErrorClassifier';
+export { assertD1Success, executeD1WithRetry, sleep } from './D1Utils';

--- a/packages/backend-errors/src/DatabaseError.ts
+++ b/packages/backend-errors/src/DatabaseError.ts
@@ -1,8 +1,11 @@
 import { InternalServerError } from './InternalServerError';
 
 class DatabaseError extends InternalServerError {
-  constructor(message?: string | undefined) {
+  public readonly retryable: boolean;
+
+  constructor(message?: string | undefined, retryable: boolean = false) {
     super(message ?? 'The system encountered an unexpected problem while accessing the database.');
+    this.retryable = retryable;
   }
 
   public getErrorType(): string {


### PR DESCRIPTION
D1 operations can fail transiently (SQLITE_BUSY, SQLITE_LOCKED, timeouts, network issues) or permanently (constraint violations, syntax errors, permission errors). Previously all D1 write failures threw a generic DatabaseError with no retry distinction, causing transient errors to immediately fail API requests and be incorrectly treated as retryable in background workflows.

Changes:
- Add retryable boolean property to DatabaseError (default false)
- Create D1ErrorClassifier to detect transient vs permanent D1 error strings
- Create executeD1WithRetry utility that retries transient D1 failures with exponential backoff (max 3 attempts, 100ms base delay)
- Update all 8 DAO files to use executeD1WithRetry instead of inline if result.success checks
- Add missing D1 success checks in ConnectedApplicationDAO (updateWatchedFolderIdsForUser, deleteProviderConfig)
- Update EmailProcessingWorkflow.toWorkflowError to respect DatabaseError retryable flag (transient becomes RetryableError, permanent becomes NonRetryableError)
- Update IBaseRoute.toErrorResponse to surface DatabaseError details instead of generic InternalServerError message
- Export utils from @mail-otter/backend-data package