### PR TITLE
Use D1 Read Replication Sessions

### DIFF
--- a/apps/api/src/workers/MailOtterWorker.ts
+++ b/apps/api/src/workers/MailOtterWorker.ts
@@ -26,6 +26,9 @@ import { MiddlewareHandlers } from '@/middleware';
 import { SPA_HTML } from '@/generated/spa-shell';
 import { DURABLE_OBJECT_CRON_TASKS_RUN_URL, DURABLE_OBJECT_NAMESPACE_GLOBAL } from '@mail-otter/backend-runtime/constants';
 import { ConfigurationManager } from '@mail-otter/backend-runtime/config';
+import { createD1SessionEnv } from '@mail-otter/backend-data/utils';
+
+const D1_BOOKMARK_HEADER: string = 'x-d1-bookmark';
 
 class MailOtterWorker extends AbstractEntrypointWorker {
   protected readonly app: HonoOpenAPIRouterType<{
@@ -52,7 +55,8 @@ class MailOtterWorker extends AbstractEntrypointWorker {
         headers: {
           'Access-Control-Allow-Origin': '*',
           'Access-Control-Allow-Methods': 'GET, POST, PUT, DELETE, OPTIONS',
-          'Access-Control-Allow-Headers': 'Content-Type, Authorization, cf-access-jwt-assertion',
+          'Access-Control-Allow-Headers': `Content-Type, Authorization, cf-access-jwt-assertion, ${D1_BOOKMARK_HEADER}`,
+          'Access-Control-Expose-Headers': D1_BOOKMARK_HEADER,
           'Access-Control-Max-Age': '86400',
         },
       });
@@ -106,7 +110,23 @@ class MailOtterWorker extends AbstractEntrypointWorker {
   }
 
   protected async onRequest(request: Request, env: Env, ctx: ExecutionContext): Promise<Response> {
-    return this.app.fetch(request, env, ctx);
+    const path: string = new URL(request.url).pathname;
+    if (!MailOtterWorker.shouldUseD1Session(path, env)) {
+      return this.app.fetch(request, env, ctx);
+    }
+
+    const isUserRequest: boolean = path.startsWith('/user/');
+    const incomingBookmark: string | undefined = isUserRequest ? request.headers.get(D1_BOOKMARK_HEADER)?.trim() || undefined : undefined;
+    const sessionEnv = createD1SessionEnv(env, incomingBookmark || 'first-primary');
+    const response: Response = await this.app.fetch(request, sessionEnv as unknown as Env, ctx);
+    if (isUserRequest) {
+      const bookmark: D1SessionBookmark | null = sessionEnv.DB.getBookmark();
+      if (bookmark) {
+        response.headers.set(D1_BOOKMARK_HEADER, bookmark);
+      }
+      response.headers.set('Access-Control-Expose-Headers', D1_BOOKMARK_HEADER);
+    }
+    return response;
   }
 
   protected async onScheduled(event: ScheduledController, env: Env, ctx: ExecutionContext): Promise<void> {
@@ -132,6 +152,14 @@ class MailOtterWorker extends AbstractEntrypointWorker {
           console.error('Failed to invoke CronTasksWorker:', error);
         }),
     );
+  }
+
+  private static shouldUseD1Session(path: string, env: Env): boolean {
+    if (!path.startsWith('/user/') && !path.startsWith('/api/')) {
+      return false;
+    }
+    const database = (env as { DB?: { withSession?: unknown } }).DB;
+    return typeof database?.withSession === 'function';
   }
 }
 

--- a/apps/background/src/CronTasksWorker.ts
+++ b/apps/background/src/CronTasksWorker.ts
@@ -1,4 +1,5 @@
 import { AbstractDurableObjectWorker } from '@mail-otter/backend-runtime/base';
+import { createD1SessionEnv } from '@mail-otter/backend-data/utils';
 import {
   AiDailyUsagePruningTask,
   ContextDeletionRunPruningTask,
@@ -75,7 +76,7 @@ class CronTasksWorker extends AbstractDurableObjectWorker {
     await Promise.all([
       new OAuth2AccessTokenRefreshTask().handle(event, this.env, ctx),
       new ContextDocumentPruningTask().handle(event, this.env, ctx),
-      SubscriptionRenewalUtil.renewDueSubscriptions(this.env),
+      SubscriptionRenewalUtil.renewDueSubscriptions(createD1SessionEnv(this.env)),
     ]);
     await Promise.all([
       new ProcessedMessagePruningTask().handle(event, this.env, ctx),

--- a/apps/background/src/EmailProcessingWorkflow.ts
+++ b/apps/background/src/EmailProcessingWorkflow.ts
@@ -1,4 +1,5 @@
 import { AbstractWorkflowWorker } from '@mail-otter/backend-runtime/base';
+import { createD1SessionEnv } from '@mail-otter/backend-data/utils';
 import { DatabaseError, NonRetryableError, RetryableError } from '@mail-otter/backend-errors';
 import { EmailProcessingUtil } from '@mail-otter/backend-services/email';
 import type { GmailMessageList, ResolvedApplication } from '@mail-otter/backend-services/email';
@@ -16,7 +17,7 @@ class EmailProcessingWorkflow extends AbstractWorkflowWorker<EmailQueueMessage, 
       { retries: { limit: 3, delay: '10 seconds', backoff: 'exponential' }, timeout: '2 minutes' },
       async (): Promise<ResolvedApplication> => {
         try {
-          return await EmailProcessingUtil.resolveApplication(event.payload, this.env);
+          return await EmailProcessingUtil.resolveApplication(event.payload, createD1SessionEnv(this.env));
         } catch (error: unknown) {
           throw EmailProcessingWorkflow.toWorkflowError(error);
         }
@@ -34,7 +35,7 @@ class EmailProcessingWorkflow extends AbstractWorkflowWorker<EmailQueueMessage, 
               resolved.application,
               resolved.accessToken,
               gmailPayload.notificationHistoryId,
-              this.env,
+              createD1SessionEnv(this.env),
             );
           } catch (error: unknown) {
             throw EmailProcessingWorkflow.toWorkflowError(error);
@@ -53,7 +54,7 @@ class EmailProcessingWorkflow extends AbstractWorkflowWorker<EmailQueueMessage, 
                   resolved.application,
                   resolved.accessToken,
                   messageId,
-                  this.env,
+                  createD1SessionEnv(this.env),
                   resolved.enabledApplicationIds,
                   { retryAttempt: context.attempt },
                 );
@@ -69,7 +70,11 @@ class EmailProcessingWorkflow extends AbstractWorkflowWorker<EmailQueueMessage, 
           { retries: { limit: 3, delay: '10 seconds', backoff: 'exponential' }, timeout: '2 minutes' },
           async (): Promise<void> => {
             try {
-              await EmailProcessingUtil.updateGmailHistory(messageList.subscriptionId, messageList.historyId, this.env);
+              await EmailProcessingUtil.updateGmailHistory(
+                messageList.subscriptionId,
+                messageList.historyId,
+                createD1SessionEnv(this.env),
+              );
             } catch (error: unknown) {
               throw EmailProcessingWorkflow.toWorkflowError(error);
             }
@@ -87,7 +92,7 @@ class EmailProcessingWorkflow extends AbstractWorkflowWorker<EmailQueueMessage, 
               resolved.application,
               resolved.accessToken,
               outlookPayload.messageId,
-              this.env,
+              createD1SessionEnv(this.env),
               resolved.enabledApplicationIds,
               { retryAttempt: context.attempt },
             );

--- a/apps/background/src/OAuth2TokenRefreshWorker.ts
+++ b/apps/background/src/OAuth2TokenRefreshWorker.ts
@@ -6,6 +6,7 @@ import {
   PROVIDER_MICROSOFT_OUTLOOK,
 } from '@mail-otter/shared/constants';
 import { ConnectedApplicationDAO, OAuth2AccessTokenCacheDAO, OAuth2AccessTokenRefreshStatusDAO } from '@mail-otter/backend-data/dao';
+import { createD1SessionEnv } from '@mail-otter/backend-data/utils';
 import type { ConnectedApplication, OAuth2Credentials } from '@mail-otter/shared/model';
 import { TimestampUtil } from '@mail-otter/shared/utils';
 import { BadRequestError } from '@mail-otter/backend-errors';
@@ -100,10 +101,11 @@ class OAuth2TokenRefreshWorker extends AbstractDurableObjectWorker {
       }
     }
 
-    const statusDAO = new OAuth2AccessTokenRefreshStatusDAO(this.env.DB);
+    const sessionEnv = createD1SessionEnv(this.env);
+    const statusDAO = new OAuth2AccessTokenRefreshStatusDAO(sessionEnv.DB);
     await statusDAO.recordRefreshStarted(applicationId);
     try {
-      const applicationDAO = new ConnectedApplicationDAO(this.env.DB, masterKey);
+      const applicationDAO = new ConnectedApplicationDAO(sessionEnv.DB, masterKey);
       const application: ConnectedApplication = await this.getRefreshableApplication(applicationDAO, applicationId);
       const tokenResult: OAuth2TokenResult = await OAuth2ProviderUtil.refreshAccessToken({
         providerId: application.providerId,
@@ -125,8 +127,9 @@ class OAuth2TokenRefreshWorker extends AbstractDurableObjectWorker {
     const code: string = this.readRequiredString(payload.code, 'code');
     const codeVerifier: string = this.readRequiredString(payload.codeVerifier, 'codeVerifier');
     const masterKey: string = await this.env.AES_ENCRYPTION_KEY_SECRET.get();
-    const applicationDAO = new ConnectedApplicationDAO(this.env.DB, masterKey);
-    const statusDAO = new OAuth2AccessTokenRefreshStatusDAO(this.env.DB);
+    const sessionEnv = createD1SessionEnv(this.env);
+    const applicationDAO = new ConnectedApplicationDAO(sessionEnv.DB, masterKey);
+    const statusDAO = new OAuth2AccessTokenRefreshStatusDAO(sessionEnv.DB);
     await statusDAO.recordRefreshStarted(applicationId);
 
     try {

--- a/apps/background/src/scheduled/AiDailyUsagePruningTask.ts
+++ b/apps/background/src/scheduled/AiDailyUsagePruningTask.ts
@@ -1,4 +1,5 @@
 import { AiDailyUsageDAO } from '@mail-otter/backend-data/dao';
+import { createD1SessionEnv } from '@mail-otter/backend-data/utils';
 import { ConfigurationManager } from '@mail-otter/backend-runtime/config';
 import { IScheduledTask } from './IScheduledTask';
 import type { IEnv } from './IScheduledTask';
@@ -12,7 +13,8 @@ class AiDailyUsagePruningTask extends IScheduledTask<AiDailyUsagePruningTaskEnv>
     const retentionDays: number = ConfigurationManager.getAiDailyUsageRetentionDays(env);
     const date: Date = new Date(Date.now() - retentionDays * 86400 * 1000);
     const olderThanDate: string = date.toISOString().split('T')[0];
-    const dao = new AiDailyUsageDAO(env.DB);
+    const sessionEnv = createD1SessionEnv(env);
+    const dao = new AiDailyUsageDAO(sessionEnv.DB);
 
     const deleted: number = await dao.deleteOlderThanDate(olderThanDate);
     console.log(`AiDailyUsagePruningTask: deleted ${deleted} old usage rows`);

--- a/apps/background/src/scheduled/ContextDeletionRunPruningTask.ts
+++ b/apps/background/src/scheduled/ContextDeletionRunPruningTask.ts
@@ -1,4 +1,5 @@
 import { ApplicationContextDAO } from '@mail-otter/backend-data/dao';
+import { createD1SessionEnv } from '@mail-otter/backend-data/utils';
 import { ConfigurationManager } from '@mail-otter/backend-runtime/config';
 import { IScheduledTask } from './IScheduledTask';
 import type { IEnv } from './IScheduledTask';
@@ -13,7 +14,8 @@ class ContextDeletionRunPruningTask extends IScheduledTask<ContextDeletionRunPru
   ): Promise<void> {
     const retentionDays: number = ConfigurationManager.getContextDeletionRunRetentionDays(env);
     const olderThan: number = Date.now() - retentionDays * 86400 * 1000;
-    const dao = new ApplicationContextDAO(env.DB);
+    const sessionEnv = createD1SessionEnv(env);
+    const dao = new ApplicationContextDAO(sessionEnv.DB);
 
     let total: number = 0;
     let deleted: number = BATCH_SIZE;

--- a/apps/background/src/scheduled/ContextDocumentPruningTask.ts
+++ b/apps/background/src/scheduled/ContextDocumentPruningTask.ts
@@ -1,5 +1,6 @@
 import { ApplicationContextDAO } from '@mail-otter/backend-data/dao';
 import type { OverLimitApplication } from '@mail-otter/backend-data/dao';
+import { createD1SessionEnv } from '@mail-otter/backend-data/utils';
 import { ConfigurationManager } from '@mail-otter/backend-runtime/config';
 import { ContextService } from '@mail-otter/backend-services/email';
 import { IScheduledTask } from './IScheduledTask';
@@ -12,7 +13,8 @@ class ContextDocumentPruningTask extends IScheduledTask<ContextDocumentPruningTa
     _ctx: ExecutionContext,
   ): Promise<void> {
     const globalMax: number = ConfigurationManager.getMaxContextDocumentsPerApplication(env);
-    const contextDAO = new ApplicationContextDAO(env.DB);
+    const sessionEnv = createD1SessionEnv(env);
+    const contextDAO = new ApplicationContextDAO(sessionEnv.DB);
     const overLimitApps: OverLimitApplication[] = await contextDAO.listApplicationsOverDocumentLimit(globalMax);
 
     for (const app of overLimitApps) {
@@ -22,7 +24,7 @@ class ContextDocumentPruningTask extends IScheduledTask<ContextDocumentPruningTa
           app.userEmail,
           app.activeCount,
           app.effectiveLimit,
-          env,
+          sessionEnv,
         );
       } catch (error: unknown) {
         console.error(`Context document pruning failed for application ${app.applicationId}:`, error);

--- a/apps/background/src/scheduled/OAuth2AccessTokenRefreshTask.ts
+++ b/apps/background/src/scheduled/OAuth2AccessTokenRefreshTask.ts
@@ -1,4 +1,5 @@
 import { OAuth2AccessTokenRefreshStatusDAO } from '@mail-otter/backend-data/dao';
+import { createD1SessionEnv } from '@mail-otter/backend-data/utils';
 import { ConfigurationManager } from '@mail-otter/backend-runtime/config';
 import { OAuth2AccessTokenService } from '@mail-otter/backend-services/oauth2';
 import { TimestampUtil } from '@mail-otter/shared/utils';
@@ -14,7 +15,8 @@ class OAuth2AccessTokenRefreshTask extends IScheduledTask<OAuth2AccessTokenRefre
     const refreshWindowSeconds: number = ConfigurationManager.getOAuth2AccessTokenRefreshWindowSeconds(env);
     const batchSize: number = ConfigurationManager.getOAuth2TokenRefreshBatchSize(env);
     const refreshBefore: number = TimestampUtil.getCurrentUnixTimestampInSeconds() + refreshWindowSeconds;
-    const statusDAO = new OAuth2AccessTokenRefreshStatusDAO(env.DB);
+    const sessionEnv = createD1SessionEnv(env);
+    const statusDAO = new OAuth2AccessTokenRefreshStatusDAO(sessionEnv.DB);
     const applicationIds: string[] = await statusDAO.listDueApplicationIds(refreshBefore, batchSize);
 
     for (const applicationId of applicationIds) {

--- a/apps/background/src/scheduled/OAuth2SessionPruningTask.ts
+++ b/apps/background/src/scheduled/OAuth2SessionPruningTask.ts
@@ -1,4 +1,5 @@
 import { OAuth2AuthorizationSessionDAO } from '@mail-otter/backend-data/dao';
+import { createD1SessionEnv } from '@mail-otter/backend-data/utils';
 import { IScheduledTask } from './IScheduledTask';
 import type { IEnv } from './IScheduledTask';
 
@@ -10,7 +11,8 @@ class OAuth2SessionPruningTask extends IScheduledTask<OAuth2SessionPruningTaskEn
     env: OAuth2SessionPruningTaskEnv,
     _ctx: ExecutionContext,
   ): Promise<void> {
-    const dao = new OAuth2AuthorizationSessionDAO(env.DB);
+    const sessionEnv = createD1SessionEnv(env);
+    const dao = new OAuth2AuthorizationSessionDAO(sessionEnv.DB);
 
     let total: number = 0;
     let deleted: number = BATCH_SIZE;

--- a/apps/background/src/scheduled/ProcessedMessagePruningTask.ts
+++ b/apps/background/src/scheduled/ProcessedMessagePruningTask.ts
@@ -3,6 +3,7 @@ import {
   PROCESSED_MESSAGE_STATUS_SUMMARIZED,
 } from '@mail-otter/shared/constants';
 import { ProcessedMessageDAO } from '@mail-otter/backend-data/dao';
+import { createD1SessionEnv } from '@mail-otter/backend-data/utils';
 import { ConfigurationManager } from '@mail-otter/backend-runtime/config';
 import { IScheduledTask } from './IScheduledTask';
 import type { IEnv } from './IScheduledTask';
@@ -17,7 +18,8 @@ class ProcessedMessagePruningTask extends IScheduledTask<ProcessedMessagePruning
   ): Promise<void> {
     const retentionDays: number = ConfigurationManager.getProcessedMessageRetentionDays(env);
     const olderThan: number = Date.now() - retentionDays * 86400 * 1000;
-    const dao = new ProcessedMessageDAO(env.DB);
+    const sessionEnv = createD1SessionEnv(env);
+    const dao = new ProcessedMessageDAO(sessionEnv.DB);
 
     let total: number = 0;
     let deleted: number = BATCH_SIZE;

--- a/apps/background/src/scheduled/StaleContextDocumentPruningTask.ts
+++ b/apps/background/src/scheduled/StaleContextDocumentPruningTask.ts
@@ -1,4 +1,5 @@
 import { ApplicationContextDAO } from '@mail-otter/backend-data/dao';
+import { createD1SessionEnv } from '@mail-otter/backend-data/utils';
 import { ConfigurationManager } from '@mail-otter/backend-runtime/config';
 import { IScheduledTask } from './IScheduledTask';
 import type { IEnv } from './IScheduledTask';
@@ -15,7 +16,8 @@ class StaleContextDocumentPruningTask extends IScheduledTask<StaleContextDocumen
     const errorGraceDays: number = ConfigurationManager.getStaleContextDocumentErrorGraceDays(env);
     const deletedBefore: number = Date.now() - deletedGraceDays * 86400 * 1000;
     const errorBefore: number = Date.now() - errorGraceDays * 86400 * 1000;
-    const dao = new ApplicationContextDAO(env.DB);
+    const sessionEnv = createD1SessionEnv(env);
+    const dao = new ApplicationContextDAO(sessionEnv.DB);
 
     let totalDeleted: number = 0;
     let deleted: number = BATCH_SIZE;

--- a/apps/web/components/utils.ts
+++ b/apps/web/components/utils.ts
@@ -1,3 +1,21 @@
+const D1_BOOKMARK_HEADER: string = 'x-d1-bookmark';
+
+let latestD1Bookmark: string | undefined;
+
+export async function apiFetch(input: Parameters<typeof fetch>[0], init?: Parameters<typeof fetch>[1]): Promise<Response> {
+  const isUserRequest: boolean = getFetchPath(input).startsWith('/user/');
+  const headers = new Headers(init?.headers ?? (input instanceof Request ? input.headers : undefined));
+  if (isUserRequest && latestD1Bookmark && !headers.has(D1_BOOKMARK_HEADER)) {
+    headers.set(D1_BOOKMARK_HEADER, latestD1Bookmark);
+  }
+
+  const response: Response = await fetch(input, isUserRequest ? { ...init, headers } : init);
+  if (isUserRequest) {
+    rememberD1Bookmark(response.headers.get(D1_BOOKMARK_HEADER));
+  }
+  return response;
+}
+
 export async function readJson<T>(response: Response): Promise<T> {
   if (!response.ok) {
     const error = await response.text();
@@ -50,3 +68,16 @@ export const providerMethod: Record<string, 'oauth2'> = {
   'google-gmail': 'oauth2',
   'microsoft-outlook': 'oauth2',
 };
+
+function getFetchPath(input: Parameters<typeof fetch>[0]): string {
+  const url: string = typeof input === 'string' || input instanceof URL ? input.toString() : input.url;
+  return new URL(url, window.location.origin).pathname;
+}
+
+function rememberD1Bookmark(bookmark: string | null): void {
+  const nextBookmark: string | undefined = bookmark?.trim() || undefined;
+  if (!nextBookmark) return;
+  if (!latestD1Bookmark || latestD1Bookmark < nextBookmark) {
+    latestD1Bookmark = nextBookmark;
+  }
+}

--- a/apps/web/src/SpaApp.tsx
+++ b/apps/web/src/SpaApp.tsx
@@ -9,7 +9,7 @@ import type {
   CurrentUser,
   ProviderId,
 } from '../components/types';
-import { formatExpiryTimestamp, formatTimestamp, methodLabels, providerLabels, providerMethod, readJson } from '../components/utils';
+import { apiFetch, formatExpiryTimestamp, formatTimestamp, methodLabels, providerLabels, providerMethod, readJson } from '../components/utils';
 
 interface ApplicationFormState {
   applicationId?: string;
@@ -86,7 +86,7 @@ export default function SpaApp() {
   }, []);
 
   const loadApplications = useCallback(async () => {
-    const data = await readJson<{ applications: ConnectedApplication[] }>(await fetch('/user/applications'));
+    const data = await readJson<{ applications: ConnectedApplication[] }>(await apiFetch('/user/applications'));
     setApplications(data.applications);
     setSelectedApplicationId((current) => current || data.applications[0]?.applicationId || '');
   }, []);
@@ -105,10 +105,10 @@ export default function SpaApp() {
 
       const [documentData, deletionData] = await Promise.all([
         readJson<{ documents: ApplicationContextDocument[]; nextCursor?: string }>(
-          await fetch(`/user/application/context/documents?${documentParams.toString()}`),
+          await apiFetch(`/user/application/context/documents?${documentParams.toString()}`),
         ),
         readJson<{ deletionRuns: ApplicationContextDeletionRun[]; nextCursor?: string }>(
-          await fetch(`/user/application/context/deletions?${deletionParams.toString()}`),
+          await apiFetch(`/user/application/context/deletions?${deletionParams.toString()}`),
         ),
       ]);
       setContextDocuments((current) => (append ? [...current, ...documentData.documents] : documentData.documents));
@@ -122,7 +122,7 @@ export default function SpaApp() {
   useEffect(() => {
     const load = async () => {
       try {
-        const me = await readJson<CurrentUser>(await fetch('/user/me'));
+        const me = await readJson<CurrentUser>(await apiFetch('/user/me'));
         setUser(me);
         setAuthorized(true);
         await loadApplications();
@@ -168,7 +168,7 @@ export default function SpaApp() {
         clientSecret: applicationForm.clientSecret,
         ...(applicationForm.providerId === 'google-gmail' ? { gmailPubsubTopicName: applicationForm.gmailPubsubTopicName } : {}),
       };
-      const response = await fetch('/user/application', {
+      const response = await apiFetch('/user/application', {
         method: applicationForm.applicationId ? 'PUT' : 'POST',
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify(payload),
@@ -189,7 +189,7 @@ export default function SpaApp() {
     setIsBusy(true);
     try {
       await readJson<{ success: boolean }>(
-        await fetch('/user/application', {
+        await apiFetch('/user/application', {
           method: 'DELETE',
           headers: { 'Content-Type': 'application/json' },
           body: JSON.stringify({ applicationId }),
@@ -210,7 +210,7 @@ export default function SpaApp() {
     setIsBusy(true);
     try {
       const data = await readJson<{ authorizationUrl: string }>(
-        await fetch('/user/application/oauth2/authorize', {
+        await apiFetch('/user/application/oauth2/authorize', {
           method: 'POST',
           headers: { 'Content-Type': 'application/json' },
           body: JSON.stringify({ applicationId }),
@@ -227,7 +227,7 @@ export default function SpaApp() {
     setIsBusy(true);
     try {
       const data = await readJson<{ message: string; webhookUrl: string }>(
-        await fetch('/user/application/watch', {
+        await apiFetch('/user/application/watch', {
           method: 'POST',
           headers: { 'Content-Type': 'application/json' },
           body: JSON.stringify({ applicationId }),
@@ -247,7 +247,7 @@ export default function SpaApp() {
     setIsBusy(true);
     try {
       const data = await readJson<{ message: string }>(
-        await fetch('/user/application/stop', {
+        await apiFetch('/user/application/stop', {
           method: 'POST',
           headers: { 'Content-Type': 'application/json' },
           body: JSON.stringify({ applicationId }),
@@ -267,7 +267,7 @@ export default function SpaApp() {
     setIsBusy(true);
     try {
       const data = await readJson<{ application: ConnectedApplication }>(
-        await fetch('/user/application/context', {
+        await apiFetch('/user/application/context', {
           method: 'PUT',
           headers: { 'Content-Type': 'application/json' },
           body: JSON.stringify({ applicationId, contextIndexingEnabled }),
@@ -289,7 +289,7 @@ export default function SpaApp() {
     setIsBusy(true);
     try {
       const data = await readJson<{ application: ConnectedApplication }>(
-        await fetch('/user/application/context', {
+        await apiFetch('/user/application/context', {
           method: 'PUT',
           headers: { 'Content-Type': 'application/json' },
           body: JSON.stringify({ applicationId, maxContextDocuments }),
@@ -310,7 +310,7 @@ export default function SpaApp() {
     setLoadingFolders(true);
     try {
       const data = await readJson<{ folders: Array<{ id: string; name: string }> }>(
-        await fetch(`/user/application/folders?applicationId=${encodeURIComponent(applicationId)}`),
+        await apiFetch(`/user/application/folders?applicationId=${encodeURIComponent(applicationId)}`),
       );
       setAvailableFolders(data.folders);
     } catch (error) {
@@ -331,7 +331,7 @@ export default function SpaApp() {
         }
       }
       const data = await readJson<{ application: ConnectedApplication }>(
-        await fetch('/user/application/watch-settings', {
+        await apiFetch('/user/application/watch-settings', {
           method: 'PUT',
           headers: { 'Content-Type': 'application/json' },
           body: JSON.stringify({ applicationId, folderIds, folderNames }),
@@ -353,7 +353,7 @@ export default function SpaApp() {
     setIsBusy(true);
     try {
       const data = await readJson<{ deletionRun: ApplicationContextDeletionRun }>(
-        await fetch('/user/application/context/delete-documents', {
+        await apiFetch('/user/application/context/delete-documents', {
           method: 'POST',
           headers: { 'Content-Type': 'application/json' },
           body: JSON.stringify({ applicationId }),
@@ -381,7 +381,7 @@ export default function SpaApp() {
     if (auditStatus) params.set('status', auditStatus);
     params.set('cursor', contextDocumentsCursor);
     const data = await readJson<{ documents: ApplicationContextDocument[]; nextCursor?: string }>(
-      await fetch(`/user/application/context/documents?${params.toString()}`),
+      await apiFetch(`/user/application/context/documents?${params.toString()}`),
     );
     setContextDocuments((current) => [...current, ...data.documents]);
     setContextDocumentsCursor(data.nextCursor);
@@ -393,7 +393,7 @@ export default function SpaApp() {
     if (auditApplicationId) params.set('applicationId', auditApplicationId);
     params.set('cursor', contextDeletionRunsCursor);
     const data = await readJson<{ deletionRuns: ApplicationContextDeletionRun[]; nextCursor?: string }>(
-      await fetch(`/user/application/context/deletions?${params.toString()}`),
+      await apiFetch(`/user/application/context/deletions?${params.toString()}`),
     );
     setContextDeletionRuns((current) => [...current, ...data.deletionRuns]);
     setContextDeletionRunsCursor(data.nextCursor);
@@ -402,7 +402,7 @@ export default function SpaApp() {
   const openContextDocumentInProvider = async (contextDocumentId: string) => {
     try {
       const data = await readJson<{ url: string }>(
-        await fetch(`/user/application/context/document/${encodeURIComponent(contextDocumentId)}/provider-link`),
+        await apiFetch(`/user/application/context/document/${encodeURIComponent(contextDocumentId)}/provider-link`),
       );
       window.open(data.url, '_blank', 'noopener,noreferrer');
     } catch (error) {

--- a/packages/backend-data/src/dao/AiDailyUsageDAO.ts
+++ b/packages/backend-data/src/dao/AiDailyUsageDAO.ts
@@ -1,10 +1,11 @@
 import { executeD1WithRetry } from '../utils';
+import type { D1Queryable } from '../utils';
 import { TimestampUtil } from '@mail-otter/shared/utils';
 
 class AiDailyUsageDAO {
-  protected readonly database: D1Database;
+  protected readonly database: D1Queryable;
 
-  constructor(database: D1Database) {
+  constructor(database: D1Queryable) {
     this.database = database;
   }
 

--- a/packages/backend-data/src/dao/ApplicationContextDAO.ts
+++ b/packages/backend-data/src/dao/ApplicationContextDAO.ts
@@ -8,6 +8,7 @@ import {
 } from '@mail-otter/shared/constants';
 import { DatabaseError } from '@mail-otter/backend-errors';
 import { executeD1WithRetry } from '../utils';
+import type { D1Queryable } from '../utils';
 import type {
   ApplicationContextDeletionRun,
   ApplicationContextDeletionRunInternal,
@@ -22,9 +23,9 @@ import type { ApplicationContextDeletionStatus, ApplicationContextDocumentStatus
 import { TimestampUtil, UUIDUtil } from '@mail-otter/shared/utils';
 
 class ApplicationContextDAO {
-  protected readonly database: D1Database;
+  protected readonly database: D1Queryable;
 
-  constructor(database: D1Database) {
+  constructor(database: D1Queryable) {
     this.database = database;
   }
 

--- a/packages/backend-data/src/dao/ConnectedApplicationDAO.ts
+++ b/packages/backend-data/src/dao/ConnectedApplicationDAO.ts
@@ -7,6 +7,7 @@ import {
 import { decryptData, encryptData } from '../crypto';
 import { DatabaseError } from '@mail-otter/backend-errors';
 import { executeD1WithRetry } from '../utils';
+import type { D1Queryable } from '../utils';
 import type {
   ConnectedApplication,
   ConnectedApplicationCredentials,
@@ -17,10 +18,10 @@ import type {
 import { TimestampUtil, UUIDUtil } from '@mail-otter/shared/utils';
 
 class ConnectedApplicationDAO {
-  protected readonly database: D1Database;
+  protected readonly database: D1Queryable;
   protected readonly masterKey: string;
 
-  constructor(database: D1Database, masterKey: string) {
+  constructor(database: D1Queryable, masterKey: string) {
     this.database = database;
     this.masterKey = masterKey;
   }

--- a/packages/backend-data/src/dao/OAuth2AccessTokenRefreshStatusDAO.ts
+++ b/packages/backend-data/src/dao/OAuth2AccessTokenRefreshStatusDAO.ts
@@ -1,5 +1,6 @@
 import { CONNECTED_APPLICATION_STATUS_CONNECTED, CONNECTION_METHOD_OAUTH2 } from '@mail-otter/shared/constants';
 import { executeD1WithRetry } from '../utils';
+import type { D1Queryable } from '../utils';
 import { TimestampUtil } from '@mail-otter/shared/utils';
 
 interface OAuth2AccessTokenRefreshStatus {
@@ -25,9 +26,9 @@ interface OAuth2AccessTokenRefreshStatusInternal {
 }
 
 class OAuth2AccessTokenRefreshStatusDAO {
-  protected readonly database: D1Database;
+  protected readonly database: D1Queryable;
 
-  constructor(database: D1Database) {
+  constructor(database: D1Queryable) {
     this.database = database;
   }
 

--- a/packages/backend-data/src/dao/OAuth2AuthorizationSessionDAO.ts
+++ b/packages/backend-data/src/dao/OAuth2AuthorizationSessionDAO.ts
@@ -1,11 +1,12 @@
 import { executeD1WithRetry } from '../utils';
+import type { D1Queryable } from '../utils';
 import type { OAuth2AuthorizationSession, OAuth2AuthorizationSessionInternal } from '@mail-otter/shared/model';
 import { TimestampUtil, UUIDUtil } from '@mail-otter/shared/utils';
 
 class OAuth2AuthorizationSessionDAO {
-  protected readonly database: D1Database;
+  protected readonly database: D1Queryable;
 
-  constructor(database: D1Database) {
+  constructor(database: D1Queryable) {
     this.database = database;
   }
 

--- a/packages/backend-data/src/dao/ProcessedMessageDAO.ts
+++ b/packages/backend-data/src/dao/ProcessedMessageDAO.ts
@@ -5,14 +5,15 @@ import {
   PROCESSED_MESSAGE_STATUS_SUMMARIZED,
 } from '@mail-otter/shared/constants';
 import { executeD1WithRetry } from '../utils';
+import type { D1Queryable } from '../utils';
 import type { ProcessedMessage, ProcessedMessageInternal } from '@mail-otter/shared/model';
 import type { ProcessedMessageStatus, ProviderId } from '@mail-otter/shared/constants';
 import { TimestampUtil, UUIDUtil } from '@mail-otter/shared/utils';
 
 class ProcessedMessageDAO {
-  protected readonly database: D1Database;
+  protected readonly database: D1Queryable;
 
-  constructor(database: D1Database) {
+  constructor(database: D1Queryable) {
     this.database = database;
   }
 

--- a/packages/backend-data/src/dao/ProviderSubscriptionDAO.ts
+++ b/packages/backend-data/src/dao/ProviderSubscriptionDAO.ts
@@ -5,6 +5,7 @@ import {
 } from '@mail-otter/shared/constants';
 import { DatabaseError } from '@mail-otter/backend-errors';
 import { executeD1WithRetry } from '../utils';
+import type { D1Queryable } from '../utils';
 import type { ProviderId } from '@mail-otter/shared/constants';
 import type { ProviderSubscription, ProviderSubscriptionInternal } from '@mail-otter/shared/model';
 import { TimestampUtil, UUIDUtil } from '@mail-otter/shared/utils';
@@ -21,9 +22,9 @@ interface UpsertProviderSubscriptionInput {
 }
 
 class ProviderSubscriptionDAO {
-  protected readonly database: D1Database;
+  protected readonly database: D1Queryable;
 
-  constructor(database: D1Database) {
+  constructor(database: D1Queryable) {
     this.database = database;
   }
 

--- a/packages/backend-data/src/dao/UserDAO.ts
+++ b/packages/backend-data/src/dao/UserDAO.ts
@@ -1,12 +1,13 @@
 import { DatabaseError } from '@mail-otter/backend-errors';
 import { executeD1WithRetry } from '../utils';
+import type { D1Queryable } from '../utils';
 import type { User, UserInternal } from '@mail-otter/shared/model';
 import { TimestampUtil } from '@mail-otter/shared/utils';
 
 class UserDAO {
-  protected readonly database: D1Database;
+  protected readonly database: D1Queryable;
 
-  constructor(database: D1Database) {
+  constructor(database: D1Queryable) {
     this.database = database;
   }
 

--- a/packages/backend-data/src/utils/D1SessionUtil.ts
+++ b/packages/backend-data/src/utils/D1SessionUtil.ts
@@ -1,0 +1,18 @@
+type D1Queryable = Pick<D1Database, 'prepare' | 'batch'>;
+
+type D1SessionEnv<TEnv extends { DB: D1Database }> = Omit<TEnv, 'DB'> & {
+  DB: D1DatabaseSession;
+};
+
+function createD1SessionEnv<TEnv extends { DB: D1Database }>(
+  env: TEnv,
+  constraintOrBookmark: D1SessionBookmark | D1SessionConstraint = 'first-primary',
+): D1SessionEnv<TEnv> {
+  return {
+    ...env,
+    DB: env.DB.withSession(constraintOrBookmark),
+  };
+}
+
+export { createD1SessionEnv };
+export type { D1Queryable, D1SessionEnv };

--- a/packages/backend-data/src/utils/index.ts
+++ b/packages/backend-data/src/utils/index.ts
@@ -1,2 +1,4 @@
 export { isD1ErrorRetryable } from './D1ErrorClassifier';
 export { assertD1Success, executeD1WithRetry, sleep } from './D1Utils';
+export { createD1SessionEnv } from './D1SessionUtil';
+export type { D1Queryable, D1SessionEnv } from './D1SessionUtil';

--- a/packages/backend-services/src/application/ApplicationResponseUtil.ts
+++ b/packages/backend-services/src/application/ApplicationResponseUtil.ts
@@ -1,4 +1,5 @@
 import { ApplicationContextDAO, ProcessedMessageDAO, ProviderSubscriptionDAO } from '@mail-otter/backend-data/dao';
+import type { D1Queryable } from '@mail-otter/backend-data/utils';
 import type {
   ApplicationContextSummary,
   ConnectedApplicationMetadata,
@@ -42,7 +43,7 @@ class ApplicationResponseUtil {
 }
 
 interface ApplicationDecorationEnv {
-  DB: D1Database;
+  DB: D1Queryable;
 }
 
 interface ApplicationResponse extends ConnectedApplicationMetadata {

--- a/packages/backend-services/src/application/ApplicationService.ts
+++ b/packages/backend-services/src/application/ApplicationService.ts
@@ -1,5 +1,6 @@
 import { CONNECTED_APPLICATION_STATUS_DRAFT, CONNECTION_METHOD_OAUTH2 } from '@mail-otter/shared/constants';
 import { ApplicationContextDAO, ConnectedApplicationDAO, OAuth2AccessTokenCacheDAO } from '@mail-otter/backend-data/dao';
+import type { D1Queryable } from '@mail-otter/backend-data/utils';
 import { BadRequestError } from '@mail-otter/backend-errors';
 import type {
   ConnectedApplication,
@@ -139,7 +140,7 @@ interface UpdateUserApplicationInput extends CreateUserApplicationInput {
 }
 
 interface ApplicationServiceEnv {
-  DB: D1Database;
+  DB: D1Queryable;
   AES_ENCRYPTION_KEY_SECRET: SecretsStoreSecret;
   MAX_APPLICATIONS_PER_USER?: string | undefined;
 }

--- a/packages/backend-services/src/application/FolderService.ts
+++ b/packages/backend-services/src/application/FolderService.ts
@@ -1,5 +1,6 @@
 import { PROVIDER_GOOGLE_GMAIL, PROVIDER_MICROSOFT_OUTLOOK } from '@mail-otter/shared/constants';
 import { ConnectedApplicationDAO } from '@mail-otter/backend-data/dao';
+import type { D1Queryable } from '@mail-otter/backend-data/utils';
 import { BadRequestError } from '@mail-otter/backend-errors';
 import type { ConnectedApplication } from '@mail-otter/shared/model';
 import { GmailProviderUtil } from '@mail-otter/provider-clients/gmail';
@@ -33,7 +34,7 @@ class FolderService {
 }
 
 interface FolderServiceEnv {
-  DB: D1Database;
+  DB: D1Queryable;
   AES_ENCRYPTION_KEY_SECRET: SecretsStoreSecret;
   OAUTH2_TOKEN_CACHE: KVNamespace;
   OAUTH2_TOKEN_REFRESHERS: DurableObjectNamespace;

--- a/packages/backend-services/src/email/ContextService.ts
+++ b/packages/backend-services/src/email/ContextService.ts
@@ -5,6 +5,7 @@ import {
   PROVIDER_MICROSOFT_OUTLOOK,
 } from '@mail-otter/shared/constants';
 import { ApplicationContextDAO, ConnectedApplicationDAO } from '@mail-otter/backend-data/dao';
+import type { D1Queryable } from '@mail-otter/backend-data/utils';
 import { BadRequestError } from '@mail-otter/backend-errors';
 import type {
   ApplicationContextDeletionRun,
@@ -207,7 +208,7 @@ interface ListDeletionRunsInput {
 }
 
 interface ContextListEnv {
-  DB: D1Database;
+  DB: D1Queryable;
 }
 
 interface ContextServiceEnv extends ContextListEnv {
@@ -219,7 +220,7 @@ interface DeleteContextDocumentsEnv extends ContextServiceEnv {
 }
 
 interface PruneDocumentsEnv {
-  DB: D1Database;
+  DB: D1Queryable;
   EMAIL_CONTEXT_INDEX: Vectorize;
 }
 

--- a/packages/backend-services/src/email/EmailContextUtil.ts
+++ b/packages/backend-services/src/email/EmailContextUtil.ts
@@ -1,4 +1,5 @@
 import { AiDailyUsageDAO, ApplicationContextDAO } from '@mail-otter/backend-data/dao';
+import type { D1Queryable } from '@mail-otter/backend-data/utils';
 import { NonRetryableError } from '@mail-otter/backend-errors';
 import { EmailContentUtil } from '@mail-otter/provider-clients/email-content';
 import type { ApplicationContextDocument, ConnectedApplication } from '@mail-otter/shared/model';
@@ -210,7 +211,7 @@ interface PrepareEmailRagContextInput {
 }
 
 interface EmailContextEnv {
-  DB: D1Database;
+  DB: D1Queryable;
   AES_ENCRYPTION_KEY_SECRET: SecretsStoreSecret;
   AI: Ai;
   EMAIL_CONTEXT_INDEX?: Vectorize | undefined;

--- a/packages/backend-services/src/email/EmailProcessingUtil.ts
+++ b/packages/backend-services/src/email/EmailProcessingUtil.ts
@@ -1,5 +1,6 @@
 import { PROVIDER_SUBSCRIPTION_STATUS_ACTIVE } from '@mail-otter/shared/constants';
 import { AiDailyUsageDAO, ConnectedApplicationDAO, ProcessedMessageDAO, ProviderSubscriptionDAO } from '@mail-otter/backend-data/dao';
+import type { D1Queryable } from '@mail-otter/backend-data/utils';
 import { EmailContentUtil } from '@mail-otter/provider-clients/email-content';
 import { GmailProviderUtil } from '@mail-otter/provider-clients/gmail';
 import { OutlookProviderUtil } from '@mail-otter/provider-clients/outlook';
@@ -336,7 +337,7 @@ interface GmailMessageList {
 }
 
 interface EmailProcessingEnv {
-  DB: D1Database;
+  DB: D1Queryable;
   AES_ENCRYPTION_KEY_SECRET: SecretsStoreSecret;
   OAUTH2_TOKEN_CACHE: KVNamespace;
   OAUTH2_TOKEN_REFRESHERS: DurableObjectNamespace;

--- a/packages/backend-services/src/oauth2/OAuth2AuthorizationService.ts
+++ b/packages/backend-services/src/oauth2/OAuth2AuthorizationService.ts
@@ -1,5 +1,6 @@
 import { CONNECTION_METHOD_OAUTH2 } from '@mail-otter/shared/constants';
 import { ConnectedApplicationDAO, OAuth2AuthorizationSessionDAO } from '@mail-otter/backend-data/dao';
+import type { D1Queryable } from '@mail-otter/backend-data/utils';
 import { BadRequestError } from '@mail-otter/backend-errors';
 import type { ConnectedApplication, OAuth2AuthorizationSession, OAuth2Credentials } from '@mail-otter/shared/model';
 import { ConfigurationManager } from '@mail-otter/backend-runtime/config';
@@ -88,13 +89,13 @@ interface CompleteOAuth2CallbackInput {
 }
 
 interface CreateOAuth2AuthorizationEnv {
-  DB: D1Database;
+  DB: D1Queryable;
   AES_ENCRYPTION_KEY_SECRET: SecretsStoreSecret;
   OAUTH2_STATE_EXPIRY_MINUTES?: string | undefined;
 }
 
 interface CompleteOAuth2CallbackEnv {
-  DB: D1Database;
+  DB: D1Queryable;
   AES_ENCRYPTION_KEY_SECRET: SecretsStoreSecret;
   OAUTH2_TOKEN_CACHE: KVNamespace;
   OAUTH2_TOKEN_REFRESHERS: DurableObjectNamespace;

--- a/packages/backend-services/src/subscription/SubscriptionRenewalUtil.ts
+++ b/packages/backend-services/src/subscription/SubscriptionRenewalUtil.ts
@@ -1,5 +1,6 @@
 import { PROVIDER_GOOGLE_GMAIL, PROVIDER_MICROSOFT_OUTLOOK } from '@mail-otter/shared/constants';
 import { ConnectedApplicationDAO, ProviderSubscriptionDAO } from '@mail-otter/backend-data/dao';
+import type { D1Queryable } from '@mail-otter/backend-data/utils';
 import { GmailProviderUtil } from '@mail-otter/provider-clients/gmail';
 import { OutlookProviderUtil } from '@mail-otter/provider-clients/outlook';
 import { WebhookSecurityUtil } from '@mail-otter/provider-clients/webhook';
@@ -87,7 +88,7 @@ class SubscriptionRenewalUtil {
 }
 
 interface SubscriptionRenewalEnv {
-  DB: D1Database;
+  DB: D1Queryable;
   AES_ENCRYPTION_KEY_SECRET: SecretsStoreSecret;
   OAUTH2_TOKEN_CACHE: KVNamespace;
   OAUTH2_TOKEN_REFRESHERS: DurableObjectNamespace;

--- a/packages/backend-services/src/subscription/WatchService.ts
+++ b/packages/backend-services/src/subscription/WatchService.ts
@@ -1,5 +1,6 @@
 import { CONNECTED_APPLICATION_STATUS_CONNECTED, PROVIDER_GOOGLE_GMAIL, PROVIDER_MICROSOFT_OUTLOOK } from '@mail-otter/shared/constants';
 import { ConnectedApplicationDAO, ProviderSubscriptionDAO } from '@mail-otter/backend-data/dao';
+import type { D1Queryable } from '@mail-otter/backend-data/utils';
 import { BadRequestError } from '@mail-otter/backend-errors';
 import type { ConnectedApplication, ProviderSubscription } from '@mail-otter/shared/model';
 import { ConfigurationManager } from '@mail-otter/backend-runtime/config';
@@ -125,7 +126,7 @@ class WatchService {
 }
 
 interface WatchServiceEnv {
-  DB: D1Database;
+  DB: D1Queryable;
   AES_ENCRYPTION_KEY_SECRET: SecretsStoreSecret;
   OAUTH2_TOKEN_CACHE: KVNamespace;
   OAUTH2_TOKEN_REFRESHERS: DurableObjectNamespace;

--- a/packages/backend-services/src/webhook/GmailWebhookService.ts
+++ b/packages/backend-services/src/webhook/GmailWebhookService.ts
@@ -1,4 +1,5 @@
 import { ProviderSubscriptionDAO } from '@mail-otter/backend-data/dao';
+import type { D1Queryable } from '@mail-otter/backend-data/utils';
 import { BadRequestError, UnauthorizedError } from '@mail-otter/backend-errors';
 import type { EmailQueueMessage, ProviderSubscription } from '@mail-otter/shared/model';
 import { WebhookSecurityUtil } from '@mail-otter/provider-clients/webhook';
@@ -35,7 +36,7 @@ interface GmailNotificationData {
 }
 
 interface GmailWebhookEnv {
-  DB: D1Database;
+  DB: D1Queryable;
   EMAIL_EVENTS_QUEUE: Queue<EmailQueueMessage>;
 }
 

--- a/packages/backend-services/src/webhook/OutlookWebhookService.ts
+++ b/packages/backend-services/src/webhook/OutlookWebhookService.ts
@@ -1,4 +1,5 @@
 import { ProviderSubscriptionDAO } from '@mail-otter/backend-data/dao';
+import type { D1Queryable } from '@mail-otter/backend-data/utils';
 import { UnauthorizedError } from '@mail-otter/backend-errors';
 import type { EmailQueueMessage, ProviderSubscription } from '@mail-otter/shared/model';
 import { WebhookSecurityUtil } from '@mail-otter/provider-clients/webhook';
@@ -92,7 +93,7 @@ interface OutlookLifecycleNotification {
 }
 
 interface OutlookLifecycleWebhookEnv {
-  DB: D1Database;
+  DB: D1Queryable;
 }
 
 interface OutlookWebhookEnv extends OutlookLifecycleWebhookEnv {

--- a/test/workers/CronTasksWorker.test.ts
+++ b/test/workers/CronTasksWorker.test.ts
@@ -66,6 +66,14 @@ function createRunRequest(): Request {
   });
 }
 
+function createEnv(): Env {
+  return {
+    DB: {
+      withSession: vi.fn(() => ({}) as D1DatabaseSession),
+    } as unknown as D1Database,
+  } as Env;
+}
+
 describe('CronTasksWorker', () => {
   beforeEach(() => {
     vi.restoreAllMocks();
@@ -80,7 +88,7 @@ describe('CronTasksWorker', () => {
   });
 
   it('runs token refresh before provider subscription renewal', async () => {
-    const env = { DB: {} as D1Database } as Env;
+    const env = createEnv();
     const worker = new CronTasksWorker(createDurableObjectState(), env);
 
     const response: Response = await worker.fetch(createRunRequest());
@@ -93,7 +101,7 @@ describe('CronTasksWorker', () => {
     expect(taskSpies.oauth2SessionPruning).toHaveBeenCalledOnce();
     expect(taskSpies.contextDeletionRunPruning).toHaveBeenCalledOnce();
     expect(taskSpies.aiDailyUsagePruning).toHaveBeenCalledOnce();
-    expect(taskSpies.subscriptionRenewal).toHaveBeenCalledWith(env);
+    expect(taskSpies.subscriptionRenewal).toHaveBeenCalledWith(expect.objectContaining({ DB: expect.any(Object) }));
     expect(taskSpies.oauth2Refresh.mock.invocationCallOrder[0]).toBeLessThan(taskSpies.contextPruning.mock.invocationCallOrder[0]);
     expect(taskSpies.contextPruning.mock.invocationCallOrder[0]).toBeLessThan(taskSpies.processedMessagePruning.mock.invocationCallOrder[0]);
     expect(taskSpies.oauth2Refresh.mock.calls[0][0]).toEqual(
@@ -111,7 +119,7 @@ describe('CronTasksWorker', () => {
         resolveRefresh = resolve;
       }),
     );
-    const worker = new CronTasksWorker(createDurableObjectState(), {} as Env);
+    const worker = new CronTasksWorker(createDurableObjectState(), createEnv());
     const firstResponsePromise: Promise<Response> = worker.fetch(createRunRequest());
     await Promise.resolve();
     await Promise.resolve();

--- a/test/workers/EmailProcessingWorkflow.test.ts
+++ b/test/workers/EmailProcessingWorkflow.test.ts
@@ -39,7 +39,7 @@ describe('EmailProcessingWorkflow', () => {
   it('passes the workflow retry attempt into email processing', async () => {
     vi.mocked(EmailProcessingUtil.resolveApplication).mockResolvedValue(resolvedApplication as never);
     vi.mocked(EmailProcessingUtil.processOutlookMessage).mockResolvedValue();
-    const workflow = new EmailProcessingWorkflow({} as ExecutionContext, {} as Env);
+    const workflow = new EmailProcessingWorkflow({} as ExecutionContext, createEnv());
     const step = createStep(3);
     const event = createEvent();
 
@@ -49,7 +49,7 @@ describe('EmailProcessingWorkflow', () => {
       resolvedApplication.application,
       resolvedApplication.accessToken,
       'message-1',
-      {},
+      expect.objectContaining({ DB: expect.any(Object) }),
       resolvedApplication.enabledApplicationIds,
       { retryAttempt: 3 },
     );
@@ -59,14 +59,14 @@ describe('EmailProcessingWorkflow', () => {
     vi.mocked(EmailProcessingUtil.resolveApplication).mockResolvedValue(resolvedApplication as never);
     const error = new RetryableError('Temporary provider failure.');
     vi.mocked(EmailProcessingUtil.processOutlookMessage).mockRejectedValue(error);
-    const workflow = new EmailProcessingWorkflow({} as ExecutionContext, {} as Env);
+    const workflow = new EmailProcessingWorkflow({} as ExecutionContext, createEnv());
 
     await expect(workflow.run(createEvent(), createStep(1))).rejects.toBe(error);
   });
 
   it('converts non-retryable errors into Cloudflare workflow fatal errors', async () => {
     vi.mocked(EmailProcessingUtil.resolveApplication).mockRejectedValue(new NonRetryableError('Application is not connected.'));
-    const workflow = new EmailProcessingWorkflow({} as ExecutionContext, {} as Env);
+    const workflow = new EmailProcessingWorkflow({} as ExecutionContext, createEnv());
 
     await expect(workflow.run(createEvent(), createStep(1))).rejects.toThrow(WorkflowNonRetryableError);
   });
@@ -83,6 +83,14 @@ function createEvent(): Readonly<WorkflowEvent<EmailQueueMessage>> {
     timestamp: new Date(),
     instanceId: 'workflow-instance-1',
   };
+}
+
+function createEnv(): Env {
+  return {
+    DB: {
+      withSession: vi.fn(() => ({}) as D1DatabaseSession),
+    } as unknown as D1Database,
+  } as Env;
 }
 
 function createStep(attempt: number): WorkflowStep {

--- a/test/workers/OAuth2TokenRefreshWorker.test.ts
+++ b/test/workers/OAuth2TokenRefreshWorker.test.ts
@@ -14,7 +14,9 @@ function createDurableObjectState(): DurableObjectState {
 
 function createEnv(): Env {
   return {
-    DB: {} as D1Database,
+    DB: {
+      withSession: vi.fn(() => ({}) as D1DatabaseSession),
+    } as unknown as D1Database,
     OAUTH2_TOKEN_CACHE: {} as KVNamespace,
     AES_ENCRYPTION_KEY_SECRET: { get: vi.fn().mockResolvedValue('master-key') } as unknown as SecretsStoreSecret,
     OAUTH2_ACCESS_TOKEN_FALLBACK_TTL_SECONDS: '3600',


### PR DESCRIPTION
Use D1 Sessions API for API, workflow, durable object, and scheduled D1 access so read-replication-enabled databases can serve sequentially consistent replica reads.

Add SPA bookmark propagation for /user requests and relax DAO/service DB typing to accept D1 sessions.