### PR TITLE
Track Workers AI Usage Accurately

### DIFF
--- a/packages/backend-errors/src/EmailProcessingError.ts
+++ b/packages/backend-errors/src/EmailProcessingError.ts
@@ -1,7 +1,16 @@
 import { NonRetryableError } from './NonRetryableError';
 import { RetryableError } from './RetryableError';
 
-class AiSummaryRetryableError extends RetryableError {}
+class AiSummaryRetryableError extends RetryableError {
+  public readonly aiUsage: unknown | undefined;
+  public readonly aiOutputText: string | undefined;
+
+  constructor(message: string, options: AiSummaryRetryableErrorOptions = {}) {
+    super(message);
+    this.aiUsage = options.aiUsage;
+    this.aiOutputText = options.aiOutputText;
+  }
+}
 
 class ProviderApiRetryableError extends RetryableError {}
 
@@ -18,3 +27,8 @@ export {
   ProviderApiNonRetryableError,
   ProviderApiRetryableError,
 };
+
+interface AiSummaryRetryableErrorOptions {
+  aiUsage?: unknown | undefined;
+  aiOutputText?: string | undefined;
+}

--- a/packages/backend-services/src/email/AiUsageUtil.ts
+++ b/packages/backend-services/src/email/AiUsageUtil.ts
@@ -32,9 +32,14 @@ class AiUsageUtil {
     fallbackInputText: string,
     fallbackOutputText: string,
   ): AiTextGenerationUsageEstimate {
-    const promptTokens: number = AiUsageUtil.toTokenCount(usage?.promptTokens) ?? AiUsageUtil.estimateTokensFromText(fallbackInputText);
+    const promptTokensFromUsage: number | undefined = AiUsageUtil.toTokenCount(usage?.promptTokens);
+    const promptTokens: number = promptTokensFromUsage ?? AiUsageUtil.estimateTokensFromText(fallbackInputText);
+    const completionTokensFromUsage: number | undefined = AiUsageUtil.toTokenCount(usage?.completionTokens);
+    const totalTokens: number | undefined = AiUsageUtil.toTokenCount(usage?.totalTokens);
+    const completionTokensFromTotal: number | undefined =
+      promptTokensFromUsage !== undefined && totalTokens !== undefined ? Math.max(0, totalTokens - promptTokens) : undefined;
     const completionTokens: number =
-      AiUsageUtil.toTokenCount(usage?.completionTokens) ?? AiUsageUtil.estimateTokensFromText(fallbackOutputText);
+      AiUsageUtil.maxTokenCount(completionTokensFromUsage, completionTokensFromTotal) ?? AiUsageUtil.estimateTokensFromText(fallbackOutputText);
     return AiUsageUtil.estimateTextGenerationUsageForTokenCounts(model, promptTokens, completionTokens);
   }
 
@@ -72,6 +77,12 @@ class AiUsageUtil {
   private static toTokenCount(value: number | undefined): number | undefined {
     if (typeof value !== 'number' || !Number.isFinite(value) || value < 0) return undefined;
     return Math.ceil(value);
+  }
+
+  private static maxTokenCount(first: number | undefined, second: number | undefined): number | undefined {
+    if (first === undefined) return second;
+    if (second === undefined) return first;
+    return Math.max(first, second);
   }
 }
 

--- a/packages/backend-services/src/email/EmailProcessingUtil.ts
+++ b/packages/backend-services/src/email/EmailProcessingUtil.ts
@@ -12,7 +12,7 @@ import { ConfigurationManager } from '@mail-otter/backend-runtime/config';
 import { CryptoUtil } from '@mail-otter/shared/utils';
 import type { ProviderId } from '@mail-otter/shared/constants';
 import { EmailContextUtil } from './EmailContextUtil';
-import { EmailSummaryUtil, type EmailSummaryResult } from './EmailSummaryUtil';
+import { EmailSummaryUtil, type AiTextGenerationUsage, type EmailSummaryResult } from './EmailSummaryUtil';
 import { AiUsageUtil, type AiTextGenerationUsageEstimate } from './AiUsageUtil';
 import { WorkersAiErrorUtil } from './WorkersAiErrorUtil';
 import { OAuth2AccessTokenService } from '../oauth2/OAuth2AccessTokenService';
@@ -199,18 +199,34 @@ class EmailProcessingUtil {
     const maxChars: number = ConfigurationManager.getMaxEmailBodyChars(env);
     const bodyText: string = body || '(empty message body)';
     const input: string = EmailContentUtil.truncate(bodyText, maxChars);
-    let model: string = await EmailProcessingUtil.resolveSummaryModel(env, input);
+    const promptText: string = EmailSummaryUtil.buildEmailSummaryPromptText(subject, from, input, ragContext);
+    let model: string = await EmailProcessingUtil.resolveSummaryModel(env, promptText);
     let result: EmailSummaryResult;
     try {
       result = await EmailSummaryUtil.summarizeEmailWithUsage(env.AI, model, subject, from, input, ragContext);
     } catch (error: unknown) {
       if (!(error instanceof AiSummaryRetryableError)) throw error;
+      await EmailProcessingUtil.recordSummaryFailureUsage(env, model, error, promptText);
       const fallbackModel: string = ConfigurationManager.getEmailSummaryFallbackModel(env);
+      if (model === fallbackModel) throw error;
       console.warn(`AI summary failed with primary model ${model}, retrying with fallback ${fallbackModel}:`, error);
       model = fallbackModel;
-      result = await EmailSummaryUtil.summarizeEmailWithUsage(env.AI, model, subject, from, input, ragContext);
+      try {
+        result = await EmailSummaryUtil.summarizeEmailWithUsage(env.AI, model, subject, from, input, ragContext);
+      } catch (fallbackError: unknown) {
+        if (fallbackError instanceof AiSummaryRetryableError) {
+          await EmailProcessingUtil.recordSummaryFailureUsage(env, model, fallbackError, promptText);
+        }
+        throw fallbackError;
+      }
     }
-    const usageEstimate: AiTextGenerationUsageEstimate | undefined = await EmailProcessingUtil.recordSummaryUsage(env, model, result, input);
+    const usageEstimate: AiTextGenerationUsageEstimate | undefined = await EmailProcessingUtil.recordSummaryUsage(
+      env,
+      model,
+      result.usage,
+      promptText,
+      result.summary,
+    );
     if (!ConfigurationManager.getDebugMode(env)) return result.summary;
 
     const applicationName: string = application.displayName || application.applicationId;
@@ -235,7 +251,7 @@ class EmailProcessingUtil {
     ].join('\n');
   }
 
-  private static async resolveSummaryModel(env: EmailProcessingEnv, fallbackInputText: string): Promise<string> {
+  private static async resolveSummaryModel(env: EmailProcessingEnv, estimatedPromptText: string): Promise<string> {
     const primaryModel: string = ConfigurationManager.getEmailSummaryModel(env);
     const fallbackThreshold: number = ConfigurationManager.getAiDailyNeuronFallbackThreshold(env);
     if (fallbackThreshold <= 0) return primaryModel;
@@ -245,7 +261,7 @@ class EmailProcessingUtil {
       const estimatedNeurons: number = await new AiDailyUsageDAO(env.DB).getEstimatedNeuronsForDate(usageDate);
       const projectedPrimaryUsage: AiTextGenerationUsageEstimate = AiUsageUtil.estimateTextGenerationUsageForTokenCounts(
         primaryModel,
-        AiUsageUtil.estimateTokensFromText(fallbackInputText),
+        AiUsageUtil.estimateTokensFromText(estimatedPromptText),
         EMAIL_SUMMARY_MAX_COMPLETION_TOKENS,
       );
       return estimatedNeurons + projectedPrimaryUsage.estimatedNeurons >= fallbackThreshold
@@ -260,16 +276,17 @@ class EmailProcessingUtil {
   private static async recordSummaryUsage(
     env: EmailProcessingEnv,
     model: string,
-    result: EmailSummaryResult,
+    usage: AiTextGenerationUsage | undefined,
     fallbackInputText: string,
+    fallbackOutputText: string,
   ): Promise<AiTextGenerationUsageEstimate | undefined> {
     let estimate: AiTextGenerationUsageEstimate | undefined;
     try {
       estimate = AiUsageUtil.estimateTextGenerationUsage(
         model,
-        result.usage,
+        usage,
         fallbackInputText,
-        result.summary,
+        fallbackOutputText,
       );
       await new AiDailyUsageDAO(env.DB).incrementUsage({
         usageDate: AiUsageUtil.getCurrentUtcUsageDate(),
@@ -281,6 +298,25 @@ class EmailProcessingUtil {
       console.warn('Failed to record Workers AI summary usage estimate:', error);
     }
     return estimate;
+  }
+
+  private static async recordSummaryFailureUsage(
+    env: EmailProcessingEnv,
+    model: string,
+    error: AiSummaryRetryableError,
+    fallbackInputText: string,
+  ): Promise<void> {
+    await EmailProcessingUtil.recordSummaryUsage(
+      env,
+      model,
+      EmailProcessingUtil.getAiSummaryErrorUsage(error),
+      fallbackInputText,
+      error.aiOutputText ?? '',
+    );
+  }
+
+  private static getAiSummaryErrorUsage(error: AiSummaryRetryableError): AiTextGenerationUsage | undefined {
+    return error.aiUsage && typeof error.aiUsage === 'object' ? (error.aiUsage as AiTextGenerationUsage) : undefined;
   }
 
   private static formatDebugNumber(value: number | undefined): string {

--- a/packages/backend-services/src/email/EmailSummaryUtil.ts
+++ b/packages/backend-services/src/email/EmailSummaryUtil.ts
@@ -21,6 +21,8 @@ const SUMMARY_JSON_SCHEMA = {
 } as const;
 
 const JSON_MODE_SUPPORTED_MODELS: ReadonlySet<string> = new Set<string>([
+  '@cf/openai/gpt-oss-120b',
+  '@cf/openai/gpt-oss-20b',
   '@cf/meta/llama-3.1-8b-instruct-fast',
   '@cf/meta/llama-3.1-70b-instruct',
   '@cf/meta/llama-3.3-70b-instruct-fp8-fast',
@@ -31,6 +33,8 @@ const JSON_MODE_SUPPORTED_MODELS: ReadonlySet<string> = new Set<string>([
   '@hf/thebloke/deepseek-coder-6.7b-instruct-awq',
   '@cf/deepseek-ai/deepseek-r1-distill-qwen-32b',
 ]);
+
+const GPT_OSS_MODELS: ReadonlySet<string> = new Set<string>(['@cf/openai/gpt-oss-120b', '@cf/openai/gpt-oss-20b']);
 
 class EmailSummaryUtil {
   public static async summarizeEmail(
@@ -53,28 +57,8 @@ class EmailSummaryUtil {
     body: string,
     ragContext?: string | undefined,
   ): Promise<EmailSummaryResult> {
-    const instructions = [
-      'You are a helpful assistant that summarizes emails for a mailbox owner.',
-      'Return only JSON with this exact shape: {"gist":"one sentence","keyDetails":["short fact"],"actionItems":["owner deadline or request"]}.',
-      'Keep the gist to one sentence.',
-      'Key details must be short factual bullets copied from the email when possible.',
-      'Action items must include deadlines or owners when present.',
-      'If there are no action items, return an empty array.',
-      'Do not invent facts. Do not include a greeting.',
-      'You may use <a href="URL">text</a> to create clickable links in gist, key details, or action items.',
-      'Only use the href attribute; no other HTML tags or attributes are allowed.',
-    ].join(' ');
-
-    const input = [
-      'Summarize this email for the mailbox owner.',
-      'Use the PRIOR CONTEXT (if any) only as background, not as the email to summarize.',
-      '',
-      `Subject: ${subject || '(no subject)'}`,
-      `From: ${from || '(unknown)'}`,
-      '',
-      body,
-      ...(ragContext ? ['', '--- PRIOR CONTEXT (for background only, do not summarize) ---', ragContext] : []),
-    ].join('\n');
+    const instructions: string = EmailSummaryUtil.buildSummaryInstructions();
+    const input: string = EmailSummaryUtil.buildSummaryInput(subject, from, body, ragContext);
 
     const request: AiTextGenerationRequest = {
       messages: [
@@ -88,8 +72,17 @@ class EmailSummaryUtil {
     if (EmailSummaryUtil.supportsJsonMode(model)) {
       request.response_format = {
         type: 'json_schema',
-        json_schema: SUMMARY_JSON_SCHEMA,
+        json_schema: {
+          name: 'email_summary',
+          schema: SUMMARY_JSON_SCHEMA,
+          strict: true,
+        },
       };
+    }
+
+    if (EmailSummaryUtil.isGptOssModel(model)) {
+      request.reasoning_effort = 'low';
+      request.chat_template_kwargs = { enable_thinking: false };
     }
 
     const result = await (ai as unknown as { run: (...args: unknown[]) => Promise<unknown> }).run(model, request);
@@ -97,18 +90,53 @@ class EmailSummaryUtil {
 
     const summaryText = EmailSummaryUtil.extractResponseText(result);
     if (!summaryText) {
-      throw new AiSummaryRetryableError('Workers AI did not return a summary.');
+      throw new AiSummaryRetryableError('Workers AI did not return a summary.', { aiUsage: usage });
     }
 
     const summary = EmailSummaryUtil.parseAiSummaryResult(summaryText);
     if (!summary) {
-      throw new AiSummaryRetryableError('Workers AI did not return a valid summary.');
+      throw new AiSummaryRetryableError('Workers AI did not return a valid summary.', { aiUsage: usage, aiOutputText: summaryText });
     }
     return { summary: EmailSummaryUtil.renderHtmlSummary(summary), usage };
   }
 
+  public static buildEmailSummaryPromptText(subject: string, from: string, body: string, ragContext?: string | undefined): string {
+    return [EmailSummaryUtil.buildSummaryInstructions(), EmailSummaryUtil.buildSummaryInput(subject, from, body, ragContext)].join('\n\n');
+  }
+
+  private static buildSummaryInstructions(): string {
+    return [
+      'You are a helpful assistant that summarizes emails for a mailbox owner.',
+      'Return only JSON with this exact shape: {"gist":"one sentence","keyDetails":["short fact"],"actionItems":["owner deadline or request"]}.',
+      'Keep the gist to one sentence.',
+      'Key details must be short factual bullets copied from the email when possible.',
+      'Action items must include deadlines or owners when present.',
+      'If there are no action items, return an empty array.',
+      'Do not invent facts. Do not include a greeting.',
+      'You may use <a href="URL">text</a> to create clickable links in gist, key details, or action items.',
+      'Only use the href attribute; no other HTML tags or attributes are allowed.',
+    ].join(' ');
+  }
+
+  private static buildSummaryInput(subject: string, from: string, body: string, ragContext?: string | undefined): string {
+    return [
+      'Summarize this email for the mailbox owner.',
+      'Use the PRIOR CONTEXT (if any) only as background, not as the email to summarize.',
+      '',
+      `Subject: ${subject || '(no subject)'}`,
+      `From: ${from || '(unknown)'}`,
+      '',
+      body,
+      ...(ragContext ? ['', '--- PRIOR CONTEXT (for background only, do not summarize) ---', ragContext] : []),
+    ].join('\n');
+  }
+
   private static supportsJsonMode(model: string): boolean {
     return JSON_MODE_SUPPORTED_MODELS.has(model);
+  }
+
+  private static isGptOssModel(model: string): boolean {
+    return GPT_OSS_MODELS.has(model);
   }
 
   private static extractResponseText(result: unknown): string | undefined {
@@ -153,12 +181,33 @@ class EmailSummaryUtil {
     if (!EmailSummaryUtil.isRecord(result) || !EmailSummaryUtil.isRecord(result.usage)) return undefined;
 
     const promptTokens: number | undefined = EmailSummaryUtil.getOptionalNumber(result.usage.prompt_tokens ?? result.usage.input_tokens);
-    const completionTokens: number | undefined = EmailSummaryUtil.getOptionalNumber(
-      result.usage.completion_tokens ?? result.usage.output_tokens,
-    );
+    const outputTokens: number | undefined = EmailSummaryUtil.getOptionalNumber(result.usage.completion_tokens ?? result.usage.output_tokens);
     const totalTokens: number | undefined = EmailSummaryUtil.getOptionalNumber(result.usage.total_tokens);
+    const completionTokens: number | undefined = EmailSummaryUtil.resolveBilledOutputTokens(promptTokens, outputTokens, totalTokens);
+    const reasoningTokens: number | undefined = EmailSummaryUtil.extractReasoningTokens(result.usage);
     if (promptTokens === undefined && completionTokens === undefined && totalTokens === undefined) return undefined;
-    return { promptTokens, completionTokens, totalTokens };
+    return { promptTokens, completionTokens, totalTokens, reasoningTokens };
+  }
+
+  private static resolveBilledOutputTokens(
+    promptTokens: number | undefined,
+    outputTokens: number | undefined,
+    totalTokens: number | undefined,
+  ): number | undefined {
+    const outputTokensFromTotal: number | undefined =
+      promptTokens !== undefined && totalTokens !== undefined ? Math.max(0, totalTokens - promptTokens) : undefined;
+    if (outputTokens === undefined) return outputTokensFromTotal;
+    if (outputTokensFromTotal === undefined) return outputTokens;
+    return Math.max(outputTokens, outputTokensFromTotal);
+  }
+
+  private static extractReasoningTokens(usage: Record<string, unknown>): number | undefined {
+    const directReasoningTokens: number | undefined = EmailSummaryUtil.getOptionalNumber(usage.reasoning_tokens);
+    if (directReasoningTokens !== undefined) return directReasoningTokens;
+
+    const completionTokenDetails: unknown = usage.completion_tokens_details ?? usage.output_tokens_details;
+    if (!EmailSummaryUtil.isRecord(completionTokenDetails)) return undefined;
+    return EmailSummaryUtil.getOptionalNumber(completionTokenDetails.reasoning_tokens);
   }
 
   static parseAiSummaryResult(result: string): EmailSummary | undefined {
@@ -374,6 +423,7 @@ interface AiTextGenerationUsage {
   promptTokens?: number | undefined;
   completionTokens?: number | undefined;
   totalTokens?: number | undefined;
+  reasoningTokens?: number | undefined;
 }
 
 interface AiTextGenerationRequest {
@@ -383,9 +433,15 @@ interface AiTextGenerationRequest {
   response_format?:
     | {
         type: 'json_schema';
-        json_schema: typeof SUMMARY_JSON_SCHEMA;
+        json_schema: {
+          name: string;
+          schema: typeof SUMMARY_JSON_SCHEMA;
+          strict: boolean;
+        };
       }
     | undefined;
+  reasoning_effort?: 'low' | 'medium' | 'high' | undefined;
+  chat_template_kwargs?: { enable_thinking?: boolean | undefined } | undefined;
 }
 
 export { EmailSummaryUtil };

--- a/test/utils/EmailProcessingUtil.test.ts
+++ b/test/utils/EmailProcessingUtil.test.ts
@@ -4,7 +4,7 @@ import type { EmailProcessingEnv } from '@mail-otter/backend-services/email';
 import { AiDailyUsageDAO, ConnectedApplicationDAO, ProcessedMessageDAO } from '@mail-otter/backend-data/dao';
 import { OutlookProviderUtil } from '@mail-otter/provider-clients/outlook';
 import type { OutlookMessage } from '@mail-otter/provider-clients/outlook';
-import { NonRetryableError, RetryableError } from '@mail-otter/backend-errors';
+import { AiSummaryRetryableError, NonRetryableError, RetryableError } from '@mail-otter/backend-errors';
 
 describe('EmailProcessingUtil', () => {
   beforeEach(() => {
@@ -232,6 +232,60 @@ describe('EmailProcessingUtil', () => {
         estimatedNeurons: 21,
         promptTokens: 1000,
         completionTokens: 100,
+      });
+    });
+
+    it('records failed primary summary usage before retrying with the fallback model', async () => {
+      vi.spyOn(ProcessedMessageDAO.prototype, 'tryStart').mockResolvedValue(true);
+      vi.spyOn(ProcessedMessageDAO.prototype, 'markSummarized').mockResolvedValue();
+      vi.spyOn(ProcessedMessageDAO.prototype, 'markError').mockResolvedValue();
+      vi.spyOn(OutlookProviderUtil, 'sendSelfSummaryReply').mockResolvedValue();
+      vi.spyOn(OutlookProviderUtil, 'getMessage').mockResolvedValue(createOutlookMessage());
+      const incrementUsage = vi.spyOn(AiDailyUsageDAO.prototype, 'incrementUsage').mockResolvedValue();
+      const summarizeEmail = vi
+        .spyOn(EmailSummaryUtil, 'summarizeEmailWithUsage')
+        .mockRejectedValueOnce(
+          new AiSummaryRetryableError('Workers AI did not return a valid summary.', {
+            aiUsage: { promptTokens: 1000, completionTokens: 700, totalTokens: 1700 },
+            aiOutputText: '{"wrong":true}',
+          }),
+        )
+        .mockResolvedValueOnce({
+          summary: 'Summary text',
+          usage: { promptTokens: 500, completionTokens: 50 },
+        });
+
+      await EmailProcessingUtil.processOutlookMessage(createApplication(), 'access-token', 'message-1', createEnv(), []);
+
+      expect(summarizeEmail).toHaveBeenNthCalledWith(
+        1,
+        expect.anything(),
+        '@cf/openai/gpt-oss-120b',
+        'Project update',
+        'sender@example.com',
+        'Please review the project update.',
+        undefined,
+      );
+      expect(summarizeEmail).toHaveBeenNthCalledWith(
+        2,
+        expect.anything(),
+        '@cf/openai/gpt-oss-20b',
+        'Project update',
+        'sender@example.com',
+        'Please review the project update.',
+        undefined,
+      );
+      expect(incrementUsage).toHaveBeenNthCalledWith(1, {
+        usageDate: expect.any(String),
+        estimatedNeurons: 80,
+        promptTokens: 1000,
+        completionTokens: 700,
+      });
+      expect(incrementUsage).toHaveBeenNthCalledWith(2, {
+        usageDate: expect.any(String),
+        estimatedNeurons: 11,
+        promptTokens: 500,
+        completionTokens: 50,
       });
     });
 

--- a/test/utils/EmailSummaryUtil.test.ts
+++ b/test/utils/EmailSummaryUtil.test.ts
@@ -65,19 +65,30 @@ describe('EmailSummaryUtil', () => {
 <p><em>Powered by Mail-Otter</em></p>`);
   });
 
-  it('throws when the AI response cannot be parsed into the summary schema', async () => {
+  it('throws with usage details when the AI response cannot be parsed into the summary schema', async () => {
     const ai = {
       run: vi.fn().mockResolvedValue({
         response: '{"wrong":true}',
+        usage: {
+          prompt_tokens: 1000,
+          completion_tokens: 12,
+          total_tokens: 1012,
+        },
       }),
     } as unknown as Ai;
 
-    await expect(EmailSummaryUtil.summarizeEmail(ai, 'model', 'Status', 'sam@example.com', 'body')).rejects.toThrow(
-      new AiSummaryRetryableError('Workers AI did not return a valid summary.'),
-    );
+    await expect(EmailSummaryUtil.summarizeEmail(ai, 'model', 'Status', 'sam@example.com', 'body')).rejects.toMatchObject({
+      message: 'Workers AI did not return a valid summary.',
+      aiOutputText: '{"wrong":true}',
+      aiUsage: {
+        promptTokens: 1000,
+        completionTokens: 12,
+        totalTokens: 1012,
+      },
+    } satisfies Partial<AiSummaryRetryableError>);
   });
 
-  it('does not request JSON mode from gpt-oss-120b and parses fenced JSON output', async () => {
+  it('requests JSON mode and low reasoning from gpt-oss-120b', async () => {
     const ai = {
       run: vi.fn().mockResolvedValue({
         response: `Here is the summary:
@@ -108,8 +119,16 @@ describe('EmailSummaryUtil', () => {
 <p><em>Powered by Mail-Otter</em></p>`);
     expect(ai.run).toHaveBeenCalledWith(
       '@cf/openai/gpt-oss-120b',
-      expect.not.objectContaining({
-        response_format: expect.anything(),
+      expect.objectContaining({
+        response_format: {
+          type: 'json_schema',
+          json_schema: expect.objectContaining({
+            name: 'email_summary',
+            strict: true,
+          }),
+        },
+        reasoning_effort: 'low',
+        chat_template_kwargs: { enable_thinking: false },
       }),
     );
   });
@@ -173,6 +192,74 @@ describe('EmailSummaryUtil', () => {
           promptTokens: 1000,
           completionTokens: 100,
           totalTokens: 1100,
+        },
+      });
+  });
+
+  it('uses Responses API totals as billed output tokens when they exceed visible output tokens', async () => {
+    const ai = {
+      run: vi.fn().mockResolvedValue({
+        output_text: JSON.stringify({
+          gist: 'The email asks for feedback.',
+          keyDetails: ['Review is due Tuesday.'],
+          actionItems: ['Send feedback by Tuesday.'],
+        }),
+        usage: {
+          input_tokens: 1000,
+          output_tokens: 100,
+          total_tokens: 1800,
+          output_tokens_details: {
+            reasoning_tokens: 700,
+          },
+        },
+      }),
+    } as unknown as Ai;
+
+    await expect(EmailSummaryUtil.summarizeEmailWithUsage(ai, '@cf/openai/gpt-oss-120b', 'Review', 'sam@example.com', 'body')).resolves
+      .toMatchObject({
+        summary: expect.stringContaining('<strong>Gist:</strong> The email asks for feedback.'),
+        usage: {
+          promptTokens: 1000,
+          completionTokens: 800,
+          totalTokens: 1800,
+          reasoningTokens: 700,
+        },
+      });
+  });
+
+  it('uses Chat Completions totals as billed output tokens when reasoning details are present', async () => {
+    const ai = {
+      run: vi.fn().mockResolvedValue({
+        choices: [
+          {
+            message: {
+              content: JSON.stringify({
+                gist: 'The email asks for feedback.',
+                keyDetails: ['Review is due Tuesday.'],
+                actionItems: ['Send feedback by Tuesday.'],
+              }),
+            },
+          },
+        ],
+        usage: {
+          prompt_tokens: 1000,
+          completion_tokens: 100,
+          total_tokens: 1800,
+          completion_tokens_details: {
+            reasoning_tokens: 700,
+          },
+        },
+      }),
+    } as unknown as Ai;
+
+    await expect(EmailSummaryUtil.summarizeEmailWithUsage(ai, '@cf/openai/gpt-oss-120b', 'Review', 'sam@example.com', 'body')).resolves
+      .toMatchObject({
+        summary: expect.stringContaining('<strong>Gist:</strong> The email asks for feedback.'),
+        usage: {
+          promptTokens: 1000,
+          completionTokens: 800,
+          totalTokens: 1800,
+          reasoningTokens: 700,
         },
       });
   });


### PR DESCRIPTION
Records usage returned on retryable summary parse failures before retrying the fallback model.

Normalizes Responses API and Chat Completions usage so billed output tokens include total-token deltas and reasoning-token details.

Enables JSON schema mode and low reasoning options for gpt-oss summaries.

Tests:
- source ~/.customrc && NODE_OPTIONS=--max-old-space-size=4096 volta run pnpm run lint
- source ~/.customrc && NODE_OPTIONS=--max-old-space-size=4096 volta run pnpm run typecheck
- source ~/.customrc && NODE_OPTIONS=--max-old-space-size=4096 volta run pnpm run test