### PR TITLE
Rename Open Provider Button Label To Open

### DIFF
--- a/apps/web/src/SpaApp.tsx
+++ b/apps/web/src/SpaApp.tsx
@@ -1327,7 +1327,7 @@ function ContextDocumentRow({
             onClick={() => onOpenProviderDocument(document.contextDocumentId)}
             disabled={document.status === 'deleted'}
           >
-            Open Provider
+            Open
           </button>
           <span className={`px-2 py-1 rounded text-xs font-medium ${statusClass}`}>{document.status.toUpperCase()}</span>
         </div>


### PR DESCRIPTION
Change the "Open Provider" button label in the context document list to simply "Open" for brevity and clarity.