### PR TITLE
Replace Polynomial Regexes With Safe Alternatives

### DIFF
--- a/packages/backend-runtime/src/config/ConfigurationManager.ts
+++ b/packages/backend-runtime/src/config/ConfigurationManager.ts
@@ -178,7 +178,11 @@ class ConfigurationManager {
   }
 
   public static getActionCallbackBaseUrl(env: unknown): string {
-    return ConfigurationManager.getString(env, 'ACTION_CALLBACK_BASE_URL', DEFAULT_ACTION_CALLBACK_BASE_URL).replace(/\/+$/, '');
+    let url = ConfigurationManager.getString(env, 'ACTION_CALLBACK_BASE_URL', DEFAULT_ACTION_CALLBACK_BASE_URL);
+    while (url.endsWith('/')) {
+      url = url.slice(0, -1);
+    }
+    return url;
   }
 
   public static getActionDefaultExpiryHours(env: unknown): number {

--- a/packages/backend-services/src/action/ActionService.ts
+++ b/packages/backend-services/src/action/ActionService.ts
@@ -395,7 +395,11 @@ class ActionService {
   }
 
   private static resolveCallbackBaseUrl(callbackBaseUrl: string | undefined, env: ActionCreationEnv): string {
-    return (callbackBaseUrl?.trim() || ConfigurationManager.getActionCallbackBaseUrl(env)).replace(/\/+$/, '');
+    let url = callbackBaseUrl?.trim() || ConfigurationManager.getActionCallbackBaseUrl(env);
+    while (url.endsWith('/')) {
+      url = url.slice(0, -1);
+    }
+    return url;
   }
 
   private static resolveExpiresAt(expiresAt: string | undefined, now: number, env: ActionCreationEnv): number {
@@ -409,18 +413,24 @@ class ActionService {
   private static extractUrls(body: string): Set<string> {
     const urls = new Set<string>();
     for (const match of body.matchAll(/https?:\/\/[^\s<>"]+/gi)) {
-      const url: string = match[0].replace(/[),.;!?]+$/, '');
-      urls.add(url);
+      let raw = match[0];
+      while (raw.length > 0 && '),.;!?'.includes(raw[raw.length - 1])) raw = raw.slice(0, -1);
+      urls.add(raw);
     }
     return urls;
   }
 
   private static findAllowedUrl(url: string, allowedUrls: Set<string>): string | undefined {
-    const candidate: string = url.trim().replace(/[),.;!?]+$/, '');
+    let candidate = url.trim();
+    while (candidate.length > 0 && '),.;!?'.includes(candidate[candidate.length - 1])) candidate = candidate.slice(0, -1);
     if (!candidate.startsWith('http://') && !candidate.startsWith('https://')) return undefined;
     if (allowedUrls.has(candidate)) return candidate;
     for (const allowed of allowedUrls) {
-      if (allowed.replace(/\/+$/, '') === candidate.replace(/\/+$/, '')) return allowed;
+      let a = allowed;
+      let c = candidate;
+      while (a.endsWith('/')) a = a.slice(0, -1);
+      while (c.endsWith('/')) c = c.slice(0, -1);
+      if (a === c) return allowed;
     }
     return undefined;
   }


### PR DESCRIPTION
Replace all `/\\/+$/` and `/[),.;!?]+$/` regex patterns on uncontrolled data with equivalent while-loops using `endsWith`/`includes` and `slice`.

These regexes were anchored with `$` so not practically vulnerable to ReDoS, but static analysis flagged them as polynomial-time on uncontrolled input. The non-regex alternatives are provably O(n) and eliminate the alerts.

Affected methods:
- ConfigurationManager.getActionCallbackBaseUrl
- ActionService.resolveCallbackBaseUrl
- ActionService.extractUrls
- ActionService.findAllowedUrl