### PR TITLE
Use Json createReply For Outlook Summary Replies

### DIFF
--- a/packages/provider-clients/src/OutlookProviderUtil.ts
+++ b/packages/provider-clients/src/OutlookProviderUtil.ts
@@ -207,14 +207,30 @@ class OutlookProviderUtil {
     mailboxAddress: string,
     summary: string,
   ): Promise<void> {
-    const mimeMessage: string = OutlookProviderUtil.createSummaryReplyMimeMessage(originalMessage, mailboxAddress, summary);
     const draft = await OutlookProviderUtil.fetchJson<{ id?: string | undefined }>(
       `https://graph.microsoft.com/v1.0/me/messages/${encodeURIComponent(originalMessage.id)}/createReply`,
       accessToken,
       {
         method: 'POST',
-        headers: { 'Content-Type': 'text/plain' },
-        body: OutlookProviderUtil.base64EncodeString(mimeMessage),
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          message: {
+            body: {
+              contentType: 'html',
+              content: summary,
+            },
+            toRecipients: [
+              {
+                emailAddress: {
+                  address: mailboxAddress,
+                },
+              },
+            ],
+            internetMessageHeaders: [
+              { name: 'X-Mail-Otter-Summary', value: 'true' },
+            ],
+          },
+        }),
       },
     );
     if (!draft.id) {
@@ -260,43 +276,6 @@ class OutlookProviderUtil {
 
   private static isRetryableStatus(status: number): boolean {
     return status === 408 || status === 409 || status === 425 || status === 429 || status >= 500;
-  }
-
-  private static createSummaryReplyMimeMessage(originalMessage: OutlookMessage, mailboxAddress: string, summary: string): string {
-    const originalSubject: string = originalMessage.subject || '(no subject)';
-    const originalMessageId: string | undefined = EmailContentUtil.getHeader(originalMessage.internetMessageHeaders, 'Message-ID');
-    const originalReferences: string | undefined = EmailContentUtil.getHeader(originalMessage.internetMessageHeaders, 'References');
-    const replySubject: string = /^re:/i.test(originalSubject) ? originalSubject : `Re: ${originalSubject}`;
-    const references: string = [originalReferences, originalMessageId].filter(Boolean).join(' ');
-    const boundary: string = OutlookProviderUtil.createSummaryMimeBoundary(originalMessage.id);
-    const textSummary: string = EmailContentUtil.stripHtml(summary);
-
-    return [
-      `From: ${mailboxAddress}`,
-      `To: ${mailboxAddress}`,
-      `Subject: ${replySubject}`,
-      ...(originalMessageId ? [`In-Reply-To: ${originalMessageId}`] : []),
-      ...(references ? [`References: ${references}`] : []),
-      'X-Mail-Otter-Summary: true',
-      'MIME-Version: 1.0',
-      `Content-Type: multipart/alternative; boundary="${boundary}"`,
-      '',
-      EmailContentUtil.buildAlternativeMimeBody(textSummary, summary, boundary),
-    ].join('\r\n');
-  }
-
-  private static createSummaryMimeBoundary(seed: string): string {
-    const safeSeed: string = seed.replace(/[^A-Za-z0-9_-]/g, '').slice(0, 32) || 'message';
-    return `mail-otter-summary-${safeSeed}`;
-  }
-
-  private static base64EncodeString(value: string): string {
-    const bytes: Uint8Array = new TextEncoder().encode(value);
-    let binary = '';
-    bytes.forEach((byte: number): void => {
-      binary += String.fromCharCode(byte);
-    });
-    return btoa(binary);
   }
 
   private static async deleteSentCopy(accessToken: string, messageId: string): Promise<void> {

--- a/test/utils/OutlookProviderUtil.test.ts
+++ b/test/utils/OutlookProviderUtil.test.ts
@@ -20,14 +20,7 @@ describe('OutlookProviderUtil', () => {
 
       vi.stubGlobal('fetch', fetchMock);
 
-      const originalMessage = {
-        id: 'original-msg-id',
-        subject: 'Original subject',
-        internetMessageHeaders: [
-          { name: 'Message-ID', value: '<original@example.com>' },
-          { name: 'References', value: '<root@example.com>' },
-        ],
-      };
+      const originalMessage = { id: 'original-msg-id' };
 
       const htmlSummary =
         '<p><strong>Gist:</strong> Summary &lt;tag&gt; &amp; text</p>\n<p><strong>Key details:</strong></p>\n<ul>\n<li>Next line</li>\n</ul>';
@@ -47,22 +40,27 @@ describe('OutlookProviderUtil', () => {
 
       const createReplyCall = fetchMock.mock.calls[0];
       const createReplyHeaders = createReplyCall[1].headers as Headers;
-      const rawMessage: string = decodeBase64(createReplyCall[1].body as string);
-      const boundary: string = extractMimeBoundary(rawMessage);
+      const parsedBody: Record<string, unknown> = JSON.parse(createReplyCall[1].body as string);
 
-      expect(createReplyHeaders.get('Content-Type')).toBe('text/plain');
-      expect(rawMessage).toContain('From: sender@example.com');
-      expect(rawMessage).toContain('To: sender@example.com');
-      expect(rawMessage).toContain('Subject: Re: Original subject');
-      expect(rawMessage).toContain('In-Reply-To: <original@example.com>');
-      expect(rawMessage).toContain('References: <root@example.com> <original@example.com>');
-      expect(rawMessage).toContain('X-Mail-Otter-Summary: true');
-      expect(rawMessage).toContain(`Content-Type: multipart/alternative; boundary="${boundary}"`);
-      expect(rawMessage).toContain(`--${boundary}\r\nContent-Type: text/plain; charset=utf-8`);
-      expect(rawMessage).toContain('Gist: Summary <tag> & text');
-      expect(rawMessage).toContain(`--${boundary}\r\nContent-Type: text/html; charset=utf-8`);
-      expect(rawMessage).toContain('<p><strong>Gist:</strong> Summary &lt;tag&gt; &amp; text</p>');
-      expect(rawMessage).toContain(`--${boundary}--`);
+      expect(createReplyHeaders.get('Content-Type')).toBe('application/json');
+      expect(parsedBody).toEqual({
+        message: {
+          body: {
+            contentType: 'html',
+            content: htmlSummary,
+          },
+          toRecipients: [
+            {
+              emailAddress: {
+                address: 'sender@example.com',
+              },
+            },
+          ],
+          internetMessageHeaders: [
+            { name: 'X-Mail-Otter-Summary', value: 'true' },
+          ],
+        },
+      });
       expect(fetchMock).toHaveBeenNthCalledWith(
         2,
         'https://graph.microsoft.com/v1.0/me/messages/draft-id-123/send',
@@ -113,14 +111,4 @@ describe('OutlookProviderUtil', () => {
   });
 });
 
-function decodeBase64(value: string): string {
-  const binary: string = atob(value);
-  const bytes: Uint8Array = Uint8Array.from(binary, (char: string): number => char.charCodeAt(0));
-  return new TextDecoder().decode(bytes);
-}
 
-function extractMimeBoundary(rawMessage: string): string {
-  const match: RegExpMatchArray | null = rawMessage.match(/boundary="([^"]+)"/);
-  expect(match).not.toBeNull();
-  return match![1]!;
-}


### PR DESCRIPTION
Switch Outlook sendSelfSummaryReply from MIME-based createReply (Content-Type: text/plain with base64-encoded multipart MIME) to JSON-based createReply (Content-Type: application/json). The MIME approach silently mangles longer HTML bodies (with action section links), causing the reply to not appear in the conversation view for summaries that have actions — while shorter ones without actions happened to survive the parser.

The JSON body sets contentType: "html", toRecipients to the mailbox owner (self-reply), and includes the X-Mail-Otter-Summary header. The /send and deleteSentCopy steps are unchanged.

Removed unused helpers: createSummaryReplyMimeMessage, createSummaryMimeBoundary, base64EncodeString.