### PR TITLE
Fix Outlook Summary Reply Threading When Actions Are Present

### DIFF
--- a/packages/provider-clients/src/OutlookProviderUtil.ts
+++ b/packages/provider-clients/src/OutlookProviderUtil.ts
@@ -208,45 +208,71 @@ class OutlookProviderUtil {
     summary: string,
     disableDelete?: boolean,
   ): Promise<void> {
+    // Step 1: Create a draft reply without overriding body content to ensure
+    // proper conversation threading (avoiding sanitization issues with complex HTML).
     const draft = await OutlookProviderUtil.fetchJson<{ id?: string | undefined }>(
       `https://graph.microsoft.com/v1.0/me/messages/${encodeURIComponent(originalMessage.id)}/createReply`,
       accessToken,
       {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({
-          message: {
-            body: {
-              contentType: 'html',
-              content: summary,
-            },
-            toRecipients: [
-              {
-                emailAddress: {
-                  address: mailboxAddress,
-                },
-              },
-            ],
-            internetMessageHeaders: [
-              { name: 'X-Mail-Otter-Summary', value: 'true' },
-            ],
-          },
-        }),
+        body: JSON.stringify({}),
       },
     );
     if (!draft.id) {
       throw new ProviderApiRetryableError('Microsoft Graph createReply did not return a draft id.');
     }
-    const response = await fetch(`https://graph.microsoft.com/v1.0/me/messages/${encodeURIComponent(draft.id)}/send`, {
-      method: 'POST',
-      headers: {
-        Authorization: `Bearer ${accessToken}`,
-        'Content-Type': 'application/json',
+
+    // Step 2: PATCH the draft to set our custom HTML body, recipients, and headers.
+    // Using PATCH after createReply avoids HTML sanitization issues that occur
+    // when complex HTML (e.g. with <a> and <span> tags from action sections)
+    // is passed through the createReply message parameter.
+    const patchResponse: Response = await fetch(
+      `https://graph.microsoft.com/v1.0/me/messages/${encodeURIComponent(draft.id)}`,
+      {
+        method: 'PATCH',
+        headers: {
+          Authorization: `Bearer ${accessToken}`,
+          'Content-Type': 'application/json',
+        },
+        body: JSON.stringify({
+          body: {
+            contentType: 'html',
+            content: summary,
+          },
+          toRecipients: [
+            {
+              emailAddress: {
+                address: mailboxAddress,
+              },
+            },
+          ],
+          internetMessageHeaders: [
+            { name: 'X-Mail-Otter-Summary', value: 'true' },
+          ],
+        }),
       },
-    });
-    if (!response.ok) {
-      throw OutlookProviderUtil.createApiError('send summary', response, await response.text());
+    );
+    if (!patchResponse.ok) {
+      throw OutlookProviderUtil.createApiError('patch draft', patchResponse, await patchResponse.text());
     }
+
+    // Step 3: Send the draft
+    const sendResponse: Response = await fetch(
+      `https://graph.microsoft.com/v1.0/me/messages/${encodeURIComponent(draft.id)}/send`,
+      {
+        method: 'POST',
+        headers: {
+          Authorization: `Bearer ${accessToken}`,
+          'Content-Type': 'application/json',
+        },
+      },
+    );
+    if (!sendResponse.ok) {
+      throw OutlookProviderUtil.createApiError('send summary', sendResponse, await sendResponse.text());
+    }
+
+    // Step 4: Clean up the sent copy
     if (!disableDelete) {
       await OutlookProviderUtil.deleteSentCopy(accessToken, draft.id);
     }

--- a/test/utils/OutlookProviderUtil.test.ts
+++ b/test/utils/OutlookProviderUtil.test.ts
@@ -9,12 +9,14 @@ describe('OutlookProviderUtil', () => {
   describe('sendSelfSummaryReply', () => {
     it('sends a threaded reply and deletes the sent copy', async () => {
       const mockCreateReplyResponse = new Response(JSON.stringify({ id: 'draft-id-123' }), { status: 201 });
+      const mockPatchResponse = new Response('', { status: 200 });
       const mockSendResponse = new Response('', { status: 202 });
       const mockDeleteResponse = new Response(null, { status: 204 });
 
       const fetchMock = vi
         .fn()
         .mockResolvedValueOnce(mockCreateReplyResponse)
+        .mockResolvedValueOnce(mockPatchResponse)
         .mockResolvedValueOnce(mockSendResponse)
         .mockResolvedValueOnce(mockDeleteResponse);
 
@@ -31,55 +33,85 @@ describe('OutlookProviderUtil', () => {
         htmlSummary,
       );
 
-      expect(fetchMock).toHaveBeenCalledTimes(3);
+      expect(fetchMock).toHaveBeenCalledTimes(4);
+
+      // Step 1: createReply with empty body to get proper threading
       expect(fetchMock).toHaveBeenNthCalledWith(
         1,
         'https://graph.microsoft.com/v1.0/me/messages/original-msg-id/createReply',
         expect.objectContaining({ method: 'POST' }),
       );
-
       const createReplyCall = fetchMock.mock.calls[0];
       const createReplyHeaders = createReplyCall[1].headers as Headers;
-      const parsedBody: Record<string, unknown> = JSON.parse(createReplyCall[1].body as string);
-
+      const parsedCreateReplyBody: Record<string, unknown> = JSON.parse(createReplyCall[1].body as string);
       expect(createReplyHeaders.get('Content-Type')).toBe('application/json');
-      expect(parsedBody).toEqual({
-        message: {
-          body: {
-            contentType: 'html',
-            content: htmlSummary,
-          },
-          toRecipients: [
-            {
-              emailAddress: {
-                address: 'sender@example.com',
-              },
-            },
-          ],
-          internetMessageHeaders: [
-            { name: 'X-Mail-Otter-Summary', value: 'true' },
-          ],
-        },
-      });
+      expect(parsedCreateReplyBody).toEqual({});
+
+      // Step 2: PATCH the draft to set body, recipients, and headers
       expect(fetchMock).toHaveBeenNthCalledWith(
         2,
+        'https://graph.microsoft.com/v1.0/me/messages/draft-id-123',
+        expect.objectContaining({ method: 'PATCH' }),
+      );
+      const patchCall = fetchMock.mock.calls[1];
+      const patchBody: Record<string, unknown> = JSON.parse(patchCall[1].body as string);
+      expect(patchBody).toEqual({
+        body: {
+          contentType: 'html',
+          content: htmlSummary,
+        },
+        toRecipients: [
+          {
+            emailAddress: {
+              address: 'sender@example.com',
+            },
+          },
+        ],
+        internetMessageHeaders: [
+          { name: 'X-Mail-Otter-Summary', value: 'true' },
+        ],
+      });
+
+      // Step 3: Send the draft
+      expect(fetchMock).toHaveBeenNthCalledWith(
+        3,
         'https://graph.microsoft.com/v1.0/me/messages/draft-id-123/send',
         expect.objectContaining({ method: 'POST' }),
       );
+
+      // Step 4: Delete the sent copy
       expect(fetchMock).toHaveBeenNthCalledWith(
-        3,
+        4,
         'https://graph.microsoft.com/v1.0/me/messages/draft-id-123',
         expect.objectContaining({ method: 'DELETE' }),
       );
     });
 
+    it('throws when patch fails', async () => {
+      const mockCreateReplyResponse = new Response(JSON.stringify({ id: 'draft-id-123' }), { status: 201 });
+      const mockPatchResponse = new Response('Patch failed', { status: 400 });
+
+      const fetchMock = vi
+        .fn()
+        .mockResolvedValueOnce(mockCreateReplyResponse)
+        .mockResolvedValueOnce(mockPatchResponse);
+
+      vi.stubGlobal('fetch', fetchMock);
+
+      await expect(
+        OutlookProviderUtil.sendSelfSummaryReply('test-access-token', { id: 'original-msg-id' }, 'sender@example.com', 'Summary text'),
+      ).rejects.toThrow('Microsoft Graph patch draft failed (400): Patch failed');
+    });
+
     it('throws when send fails', async () => {
-      const mockCreateReplyResponse = new Response(JSON.stringify({ id: 'draft-id-123' }), { status: 200 });
+      const mockCreateReplyResponse = new Response(JSON.stringify({ id: 'draft-id-123' }), { status: 201 });
+      const mockPatchResponse = new Response('', { status: 200 });
       const mockSendResponse = new Response('Send failed', { status: 500 });
 
       const fetchMock = vi
         .fn()
         .mockResolvedValueOnce(mockCreateReplyResponse)
+        .mockResolvedValueOnce(mockPatchResponse)
         .mockResolvedValueOnce(mockSendResponse);
 
       vi.stubGlobal('fetch', fetchMock);


### PR DESCRIPTION
Outlook email summaries containing reply actions (with `<a href>` and `<span style>` HTML tags) were being sent successfully but never appearing in the inbox or conversation thread, while summaries without actions worked fine.

The root cause was that `sendSelfSummaryReply` passed the full HTML body inside the `message` parameter of Microsoft Graph's `createReply` action. When the HTML contained external links and inline styles (only present with actions), the Graph API's HTML sanitization pipeline disrupted proper threading and self-delivery during draft creation.

The fix decouples draft creation from body customization:
1. `createReply` with `{}` — creates a properly threaded draft
2. `PATCH` the draft — sets the custom HTML body, recipients, and headers
3. `send` — sends the patched draft
4. `delete` — cleanup (when not disabled)

FetchOrigin: https://github.com/anomalyco/opencode/issues