### PR TITLE
Move Powered By Mail-Otter Footer To Bottom Of Email Summary

### DIFF
--- a/packages/backend-services/src/email/EmailProcessingUtil.ts
+++ b/packages/backend-services/src/email/EmailProcessingUtil.ts
@@ -304,7 +304,8 @@ class EmailProcessingUtil {
 
   private static withActionSection(summaryHtml: string, actions: CreatedEmailAction[]): string {
     const actionSection: string = ActionService.renderEmailActionSection(actions);
-    return actionSection ? [summaryHtml, actionSection].join('\n') : summaryHtml;
+    const body: string = actionSection ? [summaryHtml, actionSection].join('\n') : summaryHtml;
+    return [body, '', '<p><em>Powered by Mail-Otter</em></p>'].join('\n');
   }
 
   private static async resolveSummaryModel(env: EmailProcessingEnv, estimatedPromptText: string): Promise<string> {

--- a/packages/backend-services/src/email/EmailSummaryUtil.ts
+++ b/packages/backend-services/src/email/EmailSummaryUtil.ts
@@ -271,8 +271,6 @@ class EmailSummaryUtil {
       '<ul>',
       ...EmailSummaryUtil.renderHtmlList(actionItems, '<li>None.</li>'),
       '</ul>',
-      '',
-      '<p><em>Powered by Mail-Otter</em></p>',
     ].join('\n');
   }
 

--- a/test/utils/EmailProcessingUtil.test.ts
+++ b/test/utils/EmailProcessingUtil.test.ts
@@ -124,7 +124,7 @@ describe('EmailProcessingUtil', () => {
       });
       expect(summarizeEmail).toHaveBeenCalledOnce();
       expect(sendSelfSummaryReply).toHaveBeenCalledOnce();
-      expect(sendSelfSummaryReply).toHaveBeenCalledWith('access-token', expect.anything(), 'owner@example.com', 'Summary text', false);
+      expect(sendSelfSummaryReply).toHaveBeenCalledWith('access-token', expect.anything(), 'owner@example.com', 'Summary text\n\n<p><em>Powered by Mail-Otter</em></p>', false);
       expect(markSummarized).toHaveBeenCalledWith('app-1', 'reply-message-2');
     });
 

--- a/test/utils/EmailSummaryUtil.test.ts
+++ b/test/utils/EmailSummaryUtil.test.ts
@@ -25,9 +25,7 @@ describe('EmailSummaryUtil', () => {
 <p><strong>Action items:</strong></p>
 <ul>
 <li>Approve or reject the budget by Friday.</li>
-</ul>
-
-<p><em>Powered by Mail-Otter</em></p>`);
+</ul>`);
     expect(ai.run).toHaveBeenCalledWith(
       '@cf/meta/llama-3.1-8b-instruct',
       expect.objectContaining({
@@ -60,9 +58,7 @@ describe('EmailSummaryUtil', () => {
 <p><strong>Action items:</strong></p>
 <ul>
 <li>None.</li>
-</ul>
-
-<p><em>Powered by Mail-Otter</em></p>`);
+</ul>`);
   });
 
   it('throws with usage details when the AI response cannot be parsed into the summary schema', async () => {
@@ -114,9 +110,7 @@ describe('EmailSummaryUtil', () => {
 <p><strong>Action items:</strong></p>
 <ul>
 <li>Approve the budget by Friday.</li>
-</ul>
-
-<p><em>Powered by Mail-Otter</em></p>`);
+</ul>`);
     expect(ai.run).toHaveBeenCalledWith(
       '@cf/openai/gpt-oss-120b',
       expect.objectContaining({
@@ -164,9 +158,7 @@ describe('EmailSummaryUtil', () => {
 <p><strong>Action items:</strong></p>
 <ul>
 <li>None.</li>
-</ul>
-
-<p><em>Powered by Mail-Otter</em></p>`);
+</ul>`);
   });
 
   it('returns token usage with summarized email output when available', async () => {


### PR DESCRIPTION
Previously the '\''Powered by Mail-Otter'\'' footer was embedded in EmailSummaryUtil.renderHtmlSummary() before any action section was appended, so it appeared above action buttons when actions existed.

Now the footer is removed from renderHtmlSummary() and instead appended at the end of EmailProcessingUtil.withActionSection() so it always appears as the very last element in every summary email, regardless of whether action buttons are present.