### PR TITLE
Add Retries To GitHub Workflow Steps

### DIFF
--- a/.github/actions/retry-step/action.yml
+++ b/.github/actions/retry-step/action.yml
@@ -1,0 +1,39 @@
+name: Retry Step
+description: Retry a bash command on failure
+
+inputs:
+  command:
+    description: The bash command to run
+    required: true
+  max_attempts:
+    description: Maximum number of attempts
+    required: false
+    default: '3'
+  delay:
+    description: Seconds to wait between attempts
+    required: false
+    default: '10'
+
+runs:
+  using: composite
+  steps:
+    - shell: bash
+      run: |
+        attempt=0
+        max=${{ inputs.max_attempts }}
+        delay=${{ inputs.delay }}
+        while true; do
+          attempt=$(( attempt + 1 ))
+          printf '::notice title=Retry Step::Attempt %d of %d\n' "$attempt" "$max"
+          if eval "$RETRY_COMMAND"; then
+            exit 0
+          fi
+          if [ "$attempt" -ge "$max" ]; then
+            printf '::error title=Retry Step::Command failed after %d attempts\n' "$max"
+            exit 1
+          fi
+          printf '::warning title=Retry Step::Command failed, retrying in %ds...\n' "$delay"
+          sleep "$delay"
+        done
+      env:
+        RETRY_COMMAND: ${{ inputs.command }}

--- a/.github/workflows/azure-devops-backup.yml
+++ b/.github/workflows/azure-devops-backup.yml
@@ -37,9 +37,13 @@ jobs:
           eval "$(ssh-agent -s)"
           ssh-add ~/.ssh/id_rsa
 
-      - name: Add SSH Remote and Push main Branch
+      - name: Add SSH Remote
+        run: git remote add backup "${REMOTE_REPO_URL}"
         env:
           REMOTE_REPO_URL: ${{ secrets.BACKUP_REPO_AZURE_DEVOPS_REPO_URL }}
-        run: |
-          git remote add backup "${REMOTE_REPO_URL}"
-          git push --force backup main:main
+
+      - name: Push main Branch
+        uses: ./.github/actions/retry-step
+        with:
+          command: git push --force backup main:main
+          max_attempts: '3'

--- a/.github/workflows/continuous-deployment.yml
+++ b/.github/workflows/continuous-deployment.yml
@@ -42,10 +42,16 @@ jobs:
           cache: pnpm
 
       - name: Install Dependencies
-        run: pnpm install
+        uses: ./.github/actions/retry-step
+        with:
+          command: pnpm install
+          max_attempts: '3'
 
       - name: Prepare Wrangler Configuration
-        run: pnpm exec tsx scripts/prepare-wrangler-config.ts
+        uses: ./.github/actions/retry-step
+        with:
+          command: pnpm exec tsx scripts/prepare-wrangler-config.ts
+          max_attempts: '3'
         env:
           WRANGLER_JSONC: ${{ vars.WRANGLER_JSONC }}
           WRANGLER_VARS_PATCH_JSON: ${{ vars.WRANGLER_VARS_PATCH_JSON }}
@@ -63,13 +69,19 @@ jobs:
           fi
 
       - name: Initialize Cloudflare Secrets
-        run: pnpm exec tsx scripts/init-secrets.ts
+        uses: ./.github/actions/retry-step
+        with:
+          command: pnpm exec tsx scripts/init-secrets.ts
+          max_attempts: '3'
         env:
           CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
           CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
 
       - name: Apply Database Migration
-        run: pnpm exec wrangler d1 migrations apply --remote mail-otter-db
+        uses: ./.github/actions/retry-step
+        with:
+          command: pnpm exec wrangler d1 migrations apply --remote mail-otter-db
+          max_attempts: '3'
         env:
           CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
           CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
@@ -93,7 +105,10 @@ jobs:
           CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
 
       - name: Deploy with Wrangler
-        run: pnpm exec wrangler deploy
+        uses: ./.github/actions/retry-step
+        with:
+          command: pnpm exec wrangler deploy
+          max_attempts: '3'
         env:
           CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
           CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
@@ -119,7 +134,10 @@ jobs:
           cache: pnpm
 
       - name: Install Dependencies
-        run: pnpm install
+        uses: ./.github/actions/retry-step
+        with:
+          command: pnpm install
+          max_attempts: '3'
 
       - name: Build Frontend
         run: pnpm --filter @mail-otter/web build
@@ -135,12 +153,15 @@ jobs:
           CLOUDFLARE_PAGES_PROJECT_NAME: ${{ vars.CLOUDFLARE_PAGES_PROJECT_NAME }}
 
       - name: Deploy with Wrangler Pages
-        run: |
-          pnpm exec wrangler pages deploy \
-            --project-name "${CLOUDFLARE_PAGES_PROJECT_NAME}" \
-            --branch "${DEPLOY_BRANCH}" \
-            --commit-hash "${DEPLOY_SHA}" \
+        uses: ./.github/actions/retry-step
+        with:
+          command: >
+            pnpm exec wrangler pages deploy
+            --project-name "${CLOUDFLARE_PAGES_PROJECT_NAME}"
+            --branch "${DEPLOY_BRANCH}"
+            --commit-hash "${DEPLOY_SHA}"
             --commit-message "$(git log -1 --pretty=%s)"
+          max_attempts: '3'
         env:
           CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
           CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}

--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -36,10 +36,16 @@ jobs:
           cache: pnpm
 
       - name: Install Dependencies
-        run: pnpm install
+        uses: ./.github/actions/retry-step
+        with:
+          command: pnpm install
+          max_attempts: '3'
 
       - name: Run Tests and Checks
-        run: pnpm run checks
+        uses: ./.github/actions/retry-step
+        with:
+          command: pnpm run checks
+          max_attempts: '2'
 
   build:
     name: Build
@@ -59,7 +65,10 @@ jobs:
           cache: pnpm
 
       - name: Install Dependencies
-        run: pnpm install
+        uses: ./.github/actions/retry-step
+        with:
+          command: pnpm install
+          max_attempts: '3'
 
       - name: Build Web App
         run: pnpm --filter @mail-otter/web build
@@ -80,7 +89,10 @@ jobs:
 
     steps:
       - name: Enable Auto-Merge
-        run: gh pr merge --auto --merge "$PR_URL"
+        uses: ./.github/actions/retry-step
+        with:
+          command: gh pr merge --auto --merge "$PR_URL"
+          max_attempts: '2'
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           PR_URL: ${{ github.event.pull_request.html_url }}
@@ -97,15 +109,14 @@ jobs:
 
     steps:
       - name: Dispatch Deployment
-        uses: actions/github-script@v7
+        uses: ./.github/actions/retry-step
         with:
-          script: |
-            await github.rest.repos.createDispatchEvent({
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              event_type: 'Upstream Sync Deployment',
-              client_payload: {
-                branch: context.payload.client_payload?.branch || 'main',
-                sha: context.payload.client_payload?.sha || context.sha,
-              },
-            });
+          command: >
+            printf '{"event_type":"Upstream Sync Deployment","client_payload":{"branch":"%s","sha":"%s"}}\n'
+            "$PAYLOAD_BRANCH" "$PAYLOAD_SHA"
+            | gh api repos/${{ github.repository }}/dispatches --method POST --input -
+          max_attempts: '2'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PAYLOAD_BRANCH: ${{ github.event.client_payload.branch || 'main' }}
+          PAYLOAD_SHA: ${{ github.event.client_payload.sha || github.sha }}

--- a/.github/workflows/scheduled-version-update.yml
+++ b/.github/workflows/scheduled-version-update.yml
@@ -35,4 +35,10 @@ jobs:
           fi
 
           git commit -m "CHORE: version update"
-          git push
+
+          for i in {1..3}; do
+            if git push; then
+              break
+            fi
+            if [ $i -lt 3 ]; then sleep 10; else exit 1; fi
+          done

--- a/.github/workflows/upstream-sync.yml
+++ b/.github/workflows/upstream-sync.yml
@@ -28,11 +28,9 @@ jobs:
 
       - name: Trigger CI for synced commits
         if: steps.sync.outputs.has_new_commits == 'true'
-        uses: actions/github-script@v7
+        uses: ./.github/actions/retry-step
         with:
-          script: |
-            await github.rest.repos.createDispatchEvent({
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              event_type: 'Upstream Sync',
-            });
+          command: gh api repos/${{ github.repository }}/dispatches --method POST -f event_type='Upstream Sync'
+          max_attempts: '2'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Introduce a reusable local composite action (retry-step) that wraps bash commands with configurable retry logic (max_attempts, delay).

Apply retries to network-dependent and flaky steps across all five workflows:

- continuous-integration.yml: pnpm install (3x), pnpm run checks (2x), gh pr merge (2x), dispatch API via gh api (2x)
- continuous-deployment.yml: pnpm install (3x), Wrangler/tsx CLI calls to Cloudflare API (3x), wrangler deploy (3x), wrangler pages deploy (3x)
- scheduled-version-update.yml: git push (3x inline)
- upstream-sync.yml: dispatch API via gh api (2x)
- azure-devops-backup.yml: git push --force (3x); separated remote add from push to avoid retry failure from duplicate remote

The composite action uses eval with environment variable passing for safe command execution and emits workflow commands for visibility in GitHub Actions output.