### PR TITLE
Replace Clickable Action Links With Plain Text URLs

### DIFF
--- a/packages/backend-services/src/action/ActionService.ts
+++ b/packages/backend-services/src/action/ActionService.ts
@@ -94,7 +94,7 @@ class ActionService {
           '<li>',
           `<strong>${ActionService.escapeHtml(item.action.title)}</strong><br>`,
           `${ActionService.escapeHtml(item.action.description)}<br>`,
-          `<a href="${ActionService.escapeHtml(item.confirmationUrl)}">Review action</a>`,
+          `Review action: ${ActionService.escapeHtml(item.confirmationUrl)}<br>`,
           ` <span style="color:#666;">Expires ${ActionService.escapeHtml(expires)}</span>`,
           '</li>',
         ].join('');


### PR DESCRIPTION
Exchange Online's anti-phishing protection suppresses delivery of self-addressed Outlook emails containing clickable <a> links to external domains. Action summaries rendered `<a href=https://mail-otter.550441.xyz/api/actions/...>Review action</a>` which triggered this filter, causing the email to appear in Sent Items but never arrive in the Inbox.

Replace the clickable anchor tag with a plain text URL so Exchange no longer flags the email as suspicious. Users can still copy-paste the URL to review and execute actions.