### PR TITLE
Remove Confirmation Page Text From Email Action Section

### DIFF
--- a/packages/backend-services/src/action/ActionService.ts
+++ b/packages/backend-services/src/action/ActionService.ts
@@ -100,7 +100,6 @@ class ActionService {
         ].join('');
       }),
       '</ul>',
-      '<p><small>Mail-Otter will show a confirmation page before executing any action.</small></p>',
     ].join('\n');
   }
 


### PR DESCRIPTION
Remove the sentence 'Mail-Otter will show a confirmation page before executing any action.' from the rendered email action section in ActionService.ts.

The confirmation page behavior is inherent to the action flow and does not need to be called out in the email body.