### PR TITLE
Merge Available Actions Into Action Items Section

### DIFF
--- a/packages/backend-services/src/action/ActionService.ts
+++ b/packages/backend-services/src/action/ActionService.ts
@@ -82,23 +82,27 @@ class ActionService {
     return created;
   }
 
+  public static renderActionItems(actions: CreatedEmailAction[]): string[] {
+    return actions.map((item: CreatedEmailAction): string => {
+      const expires: string = new Date(item.action.expiresAt * 1000).toLocaleString('en-US', { timeZone: 'UTC', timeZoneName: 'short' });
+      return [
+        '<li>',
+        `<strong>${ActionService.escapeHtml(item.action.title)}</strong><br>`,
+        `${ActionService.escapeHtml(item.action.description)}<br>`,
+        `Review action: ${ActionService.escapeHtml(item.confirmationUrl)}<br>`,
+        ` <span style="color:#666;">Expires ${ActionService.escapeHtml(expires)}</span>`,
+        '</li>',
+      ].join('');
+    });
+  }
+
   public static renderEmailActionSection(actions: CreatedEmailAction[]): string {
     if (actions.length === 0) return '';
     return [
       '',
       '<p><strong>Available actions:</strong></p>',
       '<ul>',
-      ...actions.map((item: CreatedEmailAction): string => {
-        const expires: string = new Date(item.action.expiresAt * 1000).toLocaleString('en-US', { timeZone: 'UTC', timeZoneName: 'short' });
-        return [
-          '<li>',
-          `<strong>${ActionService.escapeHtml(item.action.title)}</strong><br>`,
-          `${ActionService.escapeHtml(item.action.description)}<br>`,
-          `Review action: ${ActionService.escapeHtml(item.confirmationUrl)}<br>`,
-          ` <span style="color:#666;">Expires ${ActionService.escapeHtml(expires)}</span>`,
-          '</li>',
-        ].join('');
-      }),
+      ...ActionService.renderActionItems(actions),
       '</ul>',
     ].join('\n');
   }

--- a/packages/backend-services/src/email/EmailProcessingUtil.ts
+++ b/packages/backend-services/src/email/EmailProcessingUtil.ts
@@ -303,8 +303,14 @@ class EmailProcessingUtil {
   }
 
   private static withActionSection(summaryHtml: string, actions: CreatedEmailAction[]): string {
-    const actionSection: string = ActionService.renderEmailActionSection(actions);
-    const body: string = actionSection ? [summaryHtml, actionSection].join('\n') : summaryHtml;
+    let body: string = summaryHtml;
+    if (actions.length > 0) {
+      const actionLiHtml: string = ActionService.renderActionItems(actions).join('\n');
+      const lastUlIndex: number = summaryHtml.lastIndexOf('</ul>');
+      if (lastUlIndex !== -1) {
+        body = summaryHtml.slice(0, lastUlIndex) + actionLiHtml + '\n' + summaryHtml.slice(lastUlIndex);
+      }
+    }
     return [body, '', '<p><em>Powered by Mail-Otter</em></p>'].join('\n');
   }
 


### PR DESCRIPTION
Available action proposals are now rendered as additional <li> items inside the existing Action items <ul> instead of a separate section with its own heading. The separate 'Available actions:' heading is removed from the email summary body.

- Added ActionService.renderActionItems() to return raw <li> strings
- Refactored ActionService.renderEmailActionSection() to reuse it
- Modified EmailProcessingUtil.withActionSection() to inject action <li> items before the last </ul> in the summary HTML