### PR TITLE
Add Checkout Steps To Retry Step Jobs

### DIFF
--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -88,6 +88,9 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
+      - name: Checkout Repository
+        uses: actions/checkout@v6
+
       - name: Enable Auto-Merge
         uses: ./.github/actions/retry-step
         with:
@@ -108,6 +111,9 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
+      - name: Checkout Repository
+        uses: actions/checkout@v6
+
       - name: Dispatch Deployment
         uses: ./.github/actions/retry-step
         with:

--- a/.github/workflows/scheduled-version-update.yml
+++ b/.github/workflows/scheduled-version-update.yml
@@ -15,7 +15,7 @@ jobs:
 
     steps:
       - name: Checkout Repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           persist-credentials: true
 

--- a/.github/workflows/upstream-sync.yml
+++ b/.github/workflows/upstream-sync.yml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - name: Sync upstream changes
         id: sync


### PR DESCRIPTION
The dependabot-auto-merge and dispatch-upstream-sync-deployment jobs in continuous-integration.yml were failing with

    Error: Can't find 'action.yml', 'action.yaml' or 'Dockerfile' under
    '/home/runner/work/Mail-Otter/Mail-Otter/.github/actions/retry-step'.
    Did you forget to run actions/checkout before running your local action?

because they used the local composite action ./.github/actions/retry-step without first running actions/checkout, so the runner had no repository content to resolve the action definition from.

Added actions/checkout@v6 as the first step in both jobs.

Also standardized actions/checkout from @v4 to @v6 in upstream-sync.yml and scheduled-version-update.yml for consistency.