### PR TITLE
Merge Callback Link As Title Hyperlink In Email Summary

### DIFF
--- a/packages/backend-services/src/action/ActionService.ts
+++ b/packages/backend-services/src/action/ActionService.ts
@@ -87,9 +87,8 @@ class ActionService {
       const expires: string = new Date(item.action.expiresAt * 1000).toLocaleString('en-US', { timeZone: 'UTC', timeZoneName: 'short' });
       return [
         '<li>',
-        `<strong>${ActionService.escapeHtml(item.action.title)}</strong><br>`,
+        `<strong><a href="${ActionService.escapeHtml(item.confirmationUrl)}">${ActionService.escapeHtml(item.action.title)}</a></strong><br>`,
         `${ActionService.escapeHtml(item.action.description)}<br>`,
-        `Review action: ${ActionService.escapeHtml(item.confirmationUrl)}<br>`,
         ` <span style="color:#666;">Expires ${ActionService.escapeHtml(expires)}</span>`,
         '</li>',
       ].join('');


### PR DESCRIPTION
Instead of rendering a standalone "Review action: <url>" text line in the email summary HTML, each actionable proposal now embeds the callback URL as a hyperlink on the action title itself. This makes the review link clickable directly on the title while keeping the email layout cleaner.

The change is in ActionService.renderActionItems():
- Before: <strong>Title</strong><br>... Review action: <url>...
- After:  <strong><a href="<url>">Title</a></strong><br>...