### PR TITLE
Add Integration Tests And CI Job

### DIFF
--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -47,6 +47,35 @@ jobs:
           command: pnpm run checks
           max_attempts: '2'
 
+  integration-tests:
+    name: Integration Tests
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout Repository
+        uses: actions/checkout@v6
+
+      - name: Install pnpm
+        uses: pnpm/action-setup@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '24'
+          cache: pnpm
+
+      - name: Install Dependencies
+        uses: ./.github/actions/retry-step
+        with:
+          command: pnpm install
+          max_attempts: '3'
+
+      - name: Run Integration Tests
+        uses: ./.github/actions/retry-step
+        with:
+          command: pnpm run test:integration
+          max_attempts: '2'
+
   build:
     name: Build
     runs-on: ubuntu-latest

--- a/package.json
+++ b/package.json
@@ -9,10 +9,12 @@
     "prettier": "prettier --write .",
     "typecheck": "pnpm -r typecheck",
     "test": "vitest run",
+    "test:integration": "vitest run --config test/integration/vitest.config.mts",
     "lint": "eslint --ext .ts,.tsx --fix .",
     "typegen": "wrangler types --config ./apps/api/wrangler.template.jsonc --env-interface CloudflareEnv"
   },
   "devDependencies": {
+    "@cloudflare/vitest-pool-workers": "^0.16.16",
     "@mail-otter/backend-services": "workspace:*",
     "@types/node": "25.9.x",
     "@types/react": "^19.2.x",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -8,6 +8,9 @@ importers:
 
   .:
     devDependencies:
+      '@cloudflare/vitest-pool-workers':
+        specifier: ^0.16.16
+        version: 0.16.16(@vitest/runner@4.1.8)(@vitest/snapshot@4.1.8)(vitest@4.1.8(@types/node@25.9.3)(vite@8.0.16(@types/node@25.9.3)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0)))
       '@mail-otter/backend-services':
         specifier: workspace:*
         version: link:packages/backend-services
@@ -300,8 +303,21 @@ packages:
       workerd:
         optional: true
 
+  '@cloudflare/vitest-pool-workers@0.16.16':
+    resolution: {integrity: sha512-Pwh1arsA09wAMPWb7LiPgcnIYHfzcVAmQiv9bF1NYWGaUeY4Ida+wZdBNZo4FdTn/5pOfBqaJOx1RYrCEqdivg==}
+    peerDependencies:
+      '@vitest/runner': ^4.1.0
+      '@vitest/snapshot': ^4.1.0
+      vitest: ^4.1.0
+
   '@cloudflare/workerd-darwin-64@1.20260609.1':
     resolution: {integrity: sha512-AK8tYLQm+8BqQMzjZ55ZfuhfIm1eCkj+Ykxz6kWXojdACwjjU03MrwdM9fBDdgzU3upXOs4e1scOFHySlfVQjA==}
+    engines: {node: '>=16'}
+    cpu: [x64]
+    os: [darwin]
+
+  '@cloudflare/workerd-darwin-64@1.20260616.1':
+    resolution: {integrity: sha512-8QaDRQABkwkwoeviNiyScol7EQgXfGsPNSyUn52GiXObthY4XPiokoJsgDSDNcAelHjEvDLmdvQBHPK8YvGn4A==}
     engines: {node: '>=16'}
     cpu: [x64]
     os: [darwin]
@@ -312,8 +328,20 @@ packages:
     cpu: [arm64]
     os: [darwin]
 
+  '@cloudflare/workerd-darwin-arm64@1.20260616.1':
+    resolution: {integrity: sha512-xEhiZQ62CBJ+vyKSmM13rkK/wB1kLP5sKFkF3+P+3R/c2bmnSG3Vcd5FfXUu9V0PdC+KlR02nByvZjqEw2N6Ag==}
+    engines: {node: '>=16'}
+    cpu: [arm64]
+    os: [darwin]
+
   '@cloudflare/workerd-linux-64@1.20260609.1':
     resolution: {integrity: sha512-T2Ebir2OPHAvvZ0HUh5mi1lN8q30sVi4lf7LIpc28AHoWtoOmJ0jA5AJK4IYJm1MKEbBldq+QsckaHOCQFmRpQ==}
+    engines: {node: '>=16'}
+    cpu: [x64]
+    os: [linux]
+
+  '@cloudflare/workerd-linux-64@1.20260616.1':
+    resolution: {integrity: sha512-p5laSYPiRUMHaLkneaZ9ZfIkNpmEnGFwgYmXtfcHJutTfEd8o3IBnsUVRSbPL+phcshKqmapLsQSxDEX6WSFfA==}
     engines: {node: '>=16'}
     cpu: [x64]
     os: [linux]
@@ -324,8 +352,20 @@ packages:
     cpu: [arm64]
     os: [linux]
 
+  '@cloudflare/workerd-linux-arm64@1.20260616.1':
+    resolution: {integrity: sha512-XQ7GonEl8ORvbz5fhe8Eyw2t/j09Li0KbXJxaldA318E+syF+PPTc4IRQudgqPWzzdzkH5nF7PuMOGySLSjFFw==}
+    engines: {node: '>=16'}
+    cpu: [arm64]
+    os: [linux]
+
   '@cloudflare/workerd-windows-64@1.20260609.1':
     resolution: {integrity: sha512-EWhfxKI1aqUr7S8xuGxgmRCumEzB8iSsCIz6oEqJN+3pZuW3EWiKDGFW4EY1BmwNINLW1eO5VMGYb8Fj6FVYxA==}
+    engines: {node: '>=16'}
+    cpu: [x64]
+    os: [win32]
+
+  '@cloudflare/workerd-windows-64@1.20260616.1':
+    resolution: {integrity: sha512-RaDVF9bSbPiPTq6vHYrgnv1TcQEcYnOr0WB3hWJ4yg2fBfpi2ygU6cYPuFeDwyFE9aPW5S6FBAkNmpKYueK4DQ==}
     engines: {node: '>=16'}
     cpu: [x64]
     os: [win32]
@@ -1296,6 +1336,9 @@ packages:
     engines: {node: '>=18'}
     hasBin: true
 
+  cjs-module-lexer@1.2.3:
+    resolution: {integrity: sha512-0TNiGstbQmCFwt4akjjBg5pLRTSyj/PkWQ1ZoO2zntmg9yLqSRxwEa4iCfQLGjqhiqBfOJa7W/E8wfGrTDmlZQ==}
+
   commander@2.20.3:
     resolution: {integrity: sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ==}
 
@@ -1656,6 +1699,11 @@ packages:
     engines: {node: '>=22.0.0'}
     hasBin: true
 
+  miniflare@4.20260616.0:
+    resolution: {integrity: sha512-cEpzoNgSWjedzYmhJvttUPmL4Jk6nSzzeNNi118T5zwnmYP9fnM8UXwFU/Qa/1qoQ4SzGqtM1Q7tinHvHvIGtw==}
+    engines: {node: '>=22.0.0'}
+    hasBin: true
+
   minimatch@10.2.5:
     resolution: {integrity: sha512-MULkVLfKGYDFYejP07QOurDLLQpcjk7Fw+7jXS2R2czRQzR56yHRveU5NDJEOviH+hETZKSkIk5c+T23GjFUMg==}
     engines: {node: 18 || 20 || >=22}
@@ -1976,6 +2024,21 @@ packages:
     engines: {node: '>=16'}
     hasBin: true
 
+  workerd@1.20260616.1:
+    resolution: {integrity: sha512-aRGWYxviSjYZwyu97pCr5GyJ9ObpgmNcfZZs3/o+kG7Wz3SBTqA8d8uhNueY5u7ADeUp2ibJvK6mXkFLrUmPgg==}
+    engines: {node: '>=16'}
+    hasBin: true
+
+  wrangler@4.101.0:
+    resolution: {integrity: sha512-dZDDiRcT7MiA09lBDxWKmiL/iybEZ+SZe3IZmnVx1m1n1DOo730vOY5SeO7z9xFK8a/+vhGKDYB8mDXrvzEr5g==}
+    engines: {node: '>=22.0.0'}
+    hasBin: true
+    peerDependencies:
+      '@cloudflare/workers-types': ^4.20260616.1
+    peerDependenciesMeta:
+      '@cloudflare/workers-types':
+        optional: true
+
   wrangler@4.99.0:
     resolution: {integrity: sha512-i7GA2mZETTyq3ljWdEzM908FjLaMWZ1AaAHKaOJ8pFA/tonf2VqIWDyBGzKleIVBbNQxOTIY2wnbv0iaK3rC6g==}
     engines: {node: '>=22.0.0'}
@@ -2017,6 +2080,9 @@ packages:
   youch@4.1.0-beta.10:
     resolution: {integrity: sha512-rLfVLB4FgQneDr0dv1oddCVZmKjcJ6yX6mS4pU82Mq/Dt9a3cLZQ62pDBL4AUO+uVrCvtWz3ZFUL2HFAFJ/BXQ==}
 
+  zod@3.25.76:
+    resolution: {integrity: sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==}
+
   zod@4.4.3:
     resolution: {integrity: sha512-ytENFjIJFl2UwYglde2jchW2Hwm4GJFLDiSXWdTrJQBIN9Fcyp7n4DhxJEiWNAJMV1/BqWfW/kkg71UDcHJyTQ==}
 
@@ -2037,19 +2103,55 @@ snapshots:
     optionalDependencies:
       workerd: 1.20260609.1
 
+  '@cloudflare/unenv-preset@2.16.1(unenv@2.0.0-rc.24)(workerd@1.20260616.1)':
+    dependencies:
+      unenv: 2.0.0-rc.24
+    optionalDependencies:
+      workerd: 1.20260616.1
+
+  '@cloudflare/vitest-pool-workers@0.16.16(@vitest/runner@4.1.8)(@vitest/snapshot@4.1.8)(vitest@4.1.8(@types/node@25.9.3)(vite@8.0.16(@types/node@25.9.3)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0)))':
+    dependencies:
+      '@vitest/runner': 4.1.8
+      '@vitest/snapshot': 4.1.8
+      cjs-module-lexer: 1.2.3
+      esbuild: 0.27.3
+      miniflare: 4.20260616.0
+      vitest: 4.1.8(@types/node@25.9.3)(vite@8.0.16(@types/node@25.9.3)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0))
+      wrangler: 4.101.0
+      zod: 3.25.76
+    transitivePeerDependencies:
+      - '@cloudflare/workers-types'
+      - bufferutil
+      - utf-8-validate
+
   '@cloudflare/workerd-darwin-64@1.20260609.1':
+    optional: true
+
+  '@cloudflare/workerd-darwin-64@1.20260616.1':
     optional: true
 
   '@cloudflare/workerd-darwin-arm64@1.20260609.1':
     optional: true
 
+  '@cloudflare/workerd-darwin-arm64@1.20260616.1':
+    optional: true
+
   '@cloudflare/workerd-linux-64@1.20260609.1':
+    optional: true
+
+  '@cloudflare/workerd-linux-64@1.20260616.1':
     optional: true
 
   '@cloudflare/workerd-linux-arm64@1.20260609.1':
     optional: true
 
+  '@cloudflare/workerd-linux-arm64@1.20260616.1':
+    optional: true
+
   '@cloudflare/workerd-windows-64@1.20260609.1':
+    optional: true
+
+  '@cloudflare/workerd-windows-64@1.20260616.1':
     optional: true
 
   '@cspotcode/source-map-support@0.8.1':
@@ -2774,6 +2876,8 @@ snapshots:
       yargs-parser: 22.0.0
       zod: 4.4.3
 
+  cjs-module-lexer@1.2.3: {}
+
   commander@2.20.3: {}
 
   convert-source-map@2.0.0: {}
@@ -3142,6 +3246,18 @@ snapshots:
       - bufferutil
       - utf-8-validate
 
+  miniflare@4.20260616.0:
+    dependencies:
+      '@cspotcode/source-map-support': 0.8.1
+      sharp: 0.34.5
+      undici: 7.24.8
+      workerd: 1.20260616.1
+      ws: 8.20.1
+      youch: 4.1.0-beta.10
+    transitivePeerDependencies:
+      - bufferutil
+      - utf-8-validate
+
   minimatch@10.2.5:
     dependencies:
       brace-expansion: 5.0.6
@@ -3430,6 +3546,30 @@ snapshots:
       '@cloudflare/workerd-linux-arm64': 1.20260609.1
       '@cloudflare/workerd-windows-64': 1.20260609.1
 
+  workerd@1.20260616.1:
+    optionalDependencies:
+      '@cloudflare/workerd-darwin-64': 1.20260616.1
+      '@cloudflare/workerd-darwin-arm64': 1.20260616.1
+      '@cloudflare/workerd-linux-64': 1.20260616.1
+      '@cloudflare/workerd-linux-arm64': 1.20260616.1
+      '@cloudflare/workerd-windows-64': 1.20260616.1
+
+  wrangler@4.101.0:
+    dependencies:
+      '@cloudflare/kv-asset-handler': 0.5.0
+      '@cloudflare/unenv-preset': 2.16.1(unenv@2.0.0-rc.24)(workerd@1.20260616.1)
+      blake3-wasm: 2.1.5
+      esbuild: 0.27.3
+      miniflare: 4.20260616.0
+      path-to-regexp: 6.3.0
+      unenv: 2.0.0-rc.24
+      workerd: 1.20260616.1
+    optionalDependencies:
+      fsevents: 2.3.3
+    transitivePeerDependencies:
+      - bufferutil
+      - utf-8-validate
+
   wrangler@4.99.0:
     dependencies:
       '@cloudflare/kv-asset-handler': 0.5.0
@@ -3466,5 +3606,7 @@ snapshots:
       '@speed-highlight/core': 1.2.16
       cookie: 1.1.1
       youch-core: 0.3.3
+
+  zod@3.25.76: {}
 
   zod@4.4.3: {}

--- a/test/integration/api/ActionConfirmation.int.test.ts
+++ b/test/integration/api/ActionConfirmation.int.test.ts
@@ -1,0 +1,69 @@
+import { describe, expect, it, beforeAll } from 'vitest';
+import { env, SELF, adminSecretsStore } from 'cloudflare:test';
+import type { SecretsStoreSecret } from 'cloudflare:workers';
+import { applyMigrations } from '../helpers/migrations';
+
+let appCounter = 0;
+
+async function seedApplication(): Promise<string> {
+  appCounter++;
+  const applicationId = `action-app-${appCounter}-${Date.now()}`;
+  const email = `action-user-${appCounter}@example.com`;
+  const now = Math.floor(Date.now() / 1000);
+  await env.DB.prepare(
+    `INSERT INTO users (email, created_at, updated_at) VALUES (?, ?, ?)`,
+  ).bind(email, now, now).run();
+  await env.DB.prepare(
+    `INSERT INTO connected_applications (application_id, user_email, display_name, provider_id, connection_method, encrypted_credentials, credentials_iv, status, created_at, updated_at) ` +
+    `VALUES (?, ?, ?, 'google-gmail', 'oauth2', 'enc', 'iv', 'connected', ?, ?)`,
+  ).bind(applicationId, email, 'Gmail', now, now).run();
+  return applicationId;
+}
+
+describe('Action confirmation endpoint', () => {
+  beforeAll(async () => {
+    await applyMigrations(env.DB);
+    for (const binding of ['ACTION_SIGNING_SECRET', 'ACTION_ENCRYPTION_KEY_SECRET', 'AES_ENCRYPTION_KEY_SECRET'] as const) {
+      const secret = (env as Record<string, unknown>)[binding] as SecretsStoreSecret | undefined;
+      if (secret) {
+        const admin = adminSecretsStore(secret);
+        await admin.create(`test-${binding}-value`);
+      }
+    }
+  });
+
+  it('returns 404 for a path without actionId', async () => {
+    const response: Response = await SELF.fetch('http://localhost/api/actions/', { method: 'GET' });
+
+    expect(response.status).toBe(404);
+  });
+
+  it('returns 400 for a non-existent action id', async () => {
+    const response: Response = await SELF.fetch(
+      'http://localhost/api/actions/non-existent-action',
+      { method: 'GET' },
+    );
+
+    expect(response.status).toBe(400);
+  });
+
+  it('returns 404 for an existing action with a non-matching token', async () => {
+    const applicationId = await seedApplication();
+    const now = Math.floor(Date.now() / 1000);
+    await env.DB.prepare(
+      `INSERT INTO processed_messages (processed_message_id, application_id, provider_id, provider_message_id, status, created_at, updated_at) ` +
+      `VALUES (?, ?, 'google-gmail', 'msg-action', 'summarized', ?, ?)`,
+    ).bind(`pm-${applicationId}`, applicationId, now, now).run();
+    await env.DB.prepare(
+      `INSERT INTO email_summary_actions (action_id, processed_message_id, application_id, user_email, provider_id, provider_message_id, action_type, status, risk_level, token_hash, encrypted_payload, payload_iv, payload_salt, expires_at, created_at, updated_at) ` +
+      `VALUES (?, ?, ?, ?, 'google-gmail', 'msg-action', 'email.draft_reply', 'pending', 'low', 'known-hash', 'encrypted', 'iv', 'salt', ?, ?, ?)`,
+    ).bind(`action-${applicationId}`, `pm-${applicationId}`, applicationId, `action-user-${appCounter}@example.com`, now + 86400, now, now).run();
+
+    const response: Response = await SELF.fetch(
+      `http://localhost/api/actions/action-${applicationId}?token=wrong-token`,
+      { method: 'GET' },
+    );
+
+    expect(response.status).toBe(404);
+  });
+});

--- a/test/integration/api/AuthMiddleware.int.test.ts
+++ b/test/integration/api/AuthMiddleware.int.test.ts
@@ -1,0 +1,20 @@
+import { describe, expect, it, beforeAll } from 'vitest';
+import { env, SELF } from 'cloudflare:test';
+import { applyMigrations } from '../helpers/migrations';
+
+describe('User authentication middleware', () => {
+  beforeAll(async () => {
+    await applyMigrations(env.DB);
+  });
+
+  it('returns the dev auth email when DEV_AUTH_EMAIL is set', async () => {
+    const response: Response = await SELF.fetch('http://localhost/user/me', {
+      method: 'GET',
+      headers: { 'Content-Type': 'application/json' },
+    });
+
+    expect(response.status).toBe(200);
+    const body: unknown = await response.json();
+    expect(body).toMatchObject({ email: 'test@example.com' });
+  });
+});

--- a/test/integration/api/GmailWebhook.int.test.ts
+++ b/test/integration/api/GmailWebhook.int.test.ts
@@ -1,0 +1,101 @@
+import { describe, expect, it, beforeAll } from 'vitest';
+import { env, SELF } from 'cloudflare:test';
+import { CryptoUtil } from '@mail-otter/shared/utils';
+import { applyMigrations } from '../helpers/migrations';
+
+let appCounter = 0;
+
+const VALID_TOKEN = 'valid-test-token';
+
+async function seedApplication(): Promise<string> {
+  appCounter++;
+  const applicationId = `gmail-app-${appCounter}-${Date.now()}`;
+  const email = `gmail-user-${appCounter}@example.com`;
+  const now = Math.floor(Date.now() / 1000);
+  await env.DB.prepare(
+    `INSERT INTO users (email, created_at, updated_at) VALUES (?, ?, ?)`,
+  ).bind(email, now, now).run();
+  await env.DB.prepare(
+    `INSERT INTO connected_applications (application_id, user_email, display_name, provider_id, connection_method, encrypted_credentials, credentials_iv, status, created_at, updated_at) ` +
+    `VALUES (?, ?, ?, 'google-gmail', 'oauth2', 'enc', 'iv', 'connected', ?, ?)`,
+  ).bind(applicationId, email, 'Gmail', now, now).run();
+  return applicationId;
+}
+
+describe('Gmail webhook endpoint', () => {
+  beforeAll(async () => {
+    await applyMigrations(env.DB);
+  });
+
+  it('rejects a request missing the required token query parameter', async () => {
+    const response: Response = await SELF.fetch('http://localhost/api/webhooks/gmail/app-1', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        message: {
+          data: 'not-valid-base64',
+          messageId: 'msg-1',
+        },
+      }),
+    });
+
+    expect(response.status).toBe(400);
+  });
+
+  it('returns 401 for a missing subscription', async () => {
+    const data: string = btoa(JSON.stringify({ historyId: '12345' }));
+    const response: Response = await SELF.fetch('http://localhost/api/webhooks/gmail/non-existent-app?token=some-token', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        message: { data, messageId: 'msg-1' },
+      }),
+    });
+
+    expect(response.status).toBe(401);
+  });
+
+  it('returns 401 when the token does not match the stored webhook secret', async () => {
+    const appId = await seedApplication();
+    const now = Math.floor(Date.now() / 1000);
+    const tokenHash: string = await CryptoUtil.sha256Hex(VALID_TOKEN);
+    await env.DB.prepare(
+      `INSERT INTO provider_subscriptions (subscription_id, application_id, provider_id, external_subscription_id, webhook_secret_hash, client_state_hash, status, created_at, updated_at) ` +
+      `VALUES (?, ?, 'google-gmail', 'ext-sub-1', ?, NULL, 'active', ?, ?)`,
+    ).bind(`sub-${appId}`, appId, tokenHash, now, now).run();
+
+    const data: string = btoa(JSON.stringify({ historyId: '12345' }));
+    const response: Response = await SELF.fetch(`http://localhost/api/webhooks/gmail/${appId}?token=wrong-token`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        message: { data, messageId: 'msg-1' },
+      }),
+    });
+
+    expect(response.status).toBe(401);
+  });
+
+  it('accepts a valid Gmail webhook notification and enqueues an event', async () => {
+    const appId = await seedApplication();
+    const now = Math.floor(Date.now() / 1000);
+    const tokenHash: string = await CryptoUtil.sha256Hex(VALID_TOKEN);
+    await env.DB.prepare(
+      `INSERT INTO provider_subscriptions (subscription_id, application_id, provider_id, external_subscription_id, webhook_secret_hash, status, created_at, updated_at) ` +
+      `VALUES (?, ?, 'google-gmail', 'ext-sub-valid', ?, 'active', ?, ?)`,
+    ).bind(`sub-${appId}`, appId, tokenHash, now, now).run();
+
+    const data: string = btoa(JSON.stringify({ historyId: '12345' }));
+    const response: Response = await SELF.fetch(`http://localhost/api/webhooks/gmail/${appId}?token=${VALID_TOKEN}`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        message: { data, messageId: 'msg-1' },
+      }),
+    });
+
+    expect(response.status).toBe(200);
+    const body: unknown = await response.json();
+    expect(body).toEqual({ message: 'accepted' });
+  });
+});

--- a/test/integration/api/OutlookWebhook.int.test.ts
+++ b/test/integration/api/OutlookWebhook.int.test.ts
@@ -1,0 +1,131 @@
+import { describe, expect, it, beforeAll } from 'vitest';
+import { env, SELF } from 'cloudflare:test';
+import { CryptoUtil } from '@mail-otter/shared/utils';
+import { applyMigrations } from '../helpers/migrations';
+
+let appCounter = 0;
+
+const CLIENT_STATE = 'test-client-state';
+
+async function seedApplicationWithSubscription(clientStateHash?: string | null): Promise<{ applicationId: string; externalSubscriptionId: string }> {
+  appCounter++;
+  const applicationId = `outlook-app-${appCounter}-${Date.now()}`;
+  const externalSubscriptionId = `ext-sub-${appCounter}-${Date.now()}`;
+  const email = `outlook-user-${appCounter}@example.com`;
+  const now = Math.floor(Date.now() / 1000);
+  await env.DB.prepare(
+    `INSERT INTO users (email, created_at, updated_at) VALUES (?, ?, ?)`,
+  ).bind(email, now, now).run();
+  await env.DB.prepare(
+    `INSERT INTO connected_applications (application_id, user_email, display_name, provider_id, connection_method, encrypted_credentials, credentials_iv, status, created_at, updated_at) ` +
+    `VALUES (?, ?, ?, 'microsoft-outlook', 'oauth2', 'enc', 'iv', 'connected', ?, ?)`,
+  ).bind(applicationId, email, 'Outlook', now, now).run();
+  await env.DB.prepare(
+    `INSERT INTO provider_subscriptions (subscription_id, application_id, provider_id, external_subscription_id, client_state_hash, status, created_at, updated_at) ` +
+    `VALUES (?, ?, 'microsoft-outlook', ?, ?, 'active', ?, ?)`,
+  ).bind(`sub-${applicationId}`, applicationId, externalSubscriptionId, clientStateHash ?? null, now, now).run();
+  return { applicationId, externalSubscriptionId };
+}
+
+describe('Outlook webhook endpoints', () => {
+  beforeAll(async () => {
+    await applyMigrations(env.DB);
+  });
+
+  describe('POST /api/webhooks/outlook/:applicationId', () => {
+    it('returns the validation token as text/plain when validationToken query param is present', async () => {
+      const response: Response = await SELF.fetch(
+        'http://localhost/api/webhooks/outlook/app-1?validationToken=abc123',
+        { method: 'POST' },
+      );
+
+      expect(response.status).toBe(200);
+      expect(response.headers.get('Content-Type')).toBe('text/plain');
+      const body: string = await response.text();
+      expect(body).toBe('abc123');
+    });
+
+    it('rejects notifications for an unknown subscription', async () => {
+      const response: Response = await SELF.fetch('http://localhost/api/webhooks/outlook/app-1', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          value: [
+            {
+              subscriptionId: 'unknown-sub',
+              clientState: CLIENT_STATE,
+              changeType: 'created',
+              resource: 'Users/me/Messages/msg-1',
+            },
+          ],
+        }),
+      });
+
+      expect(response.status).toBe(401);
+    });
+
+    it('accepts notifications for a known subscription and enqueues events', async () => {
+      const clientStateHash: string = await CryptoUtil.sha256Hex(CLIENT_STATE);
+      const { applicationId, externalSubscriptionId } = await seedApplicationWithSubscription(clientStateHash);
+
+      const response: Response = await SELF.fetch(`http://localhost/api/webhooks/outlook/${applicationId}`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          value: [
+            {
+              subscriptionId: externalSubscriptionId,
+              clientState: CLIENT_STATE,
+              changeType: 'created',
+              resource: 'Users/me/Messages/msg-1',
+              resourceData: { id: 'msg-1' },
+            },
+          ],
+        }),
+      });
+
+      expect(response.status).toBe(202);
+    });
+  });
+
+  describe('POST /api/webhooks/outlook/lifecycle/:applicationId', () => {
+    it('returns validation token as text/plain when validationToken query param is present', async () => {
+      const response: Response = await SELF.fetch(
+        'http://localhost/api/webhooks/outlook/lifecycle/app-1?validationToken=lifecycle-token',
+        { method: 'POST' },
+      );
+
+      expect(response.status).toBe(200);
+      expect(response.headers.get('Content-Type')).toBe('text/plain');
+      const body: string = await response.text();
+      expect(body).toBe('lifecycle-token');
+    });
+
+    it('handles subscriptionRemoved lifecycle event by marking the subscription as error', async () => {
+      const { applicationId, externalSubscriptionId } = await seedApplicationWithSubscription(undefined);
+
+      const response: Response = await SELF.fetch(`http://localhost/api/webhooks/outlook/lifecycle/${applicationId}`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          value: [
+            {
+              subscriptionId: externalSubscriptionId,
+              clientState: undefined,
+              lifecycleEvent: 'subscriptionRemoved',
+            },
+          ],
+        }),
+      });
+
+      expect(response.status).toBe(202);
+
+      const subscriptionId = `sub-${applicationId}`;
+      const sub = await env.DB.prepare(
+        `SELECT status, last_error FROM provider_subscriptions WHERE subscription_id = ?`,
+      ).bind(subscriptionId).first<{ status: string; last_error: string | null }>();
+      expect(sub!.status).toBe('error');
+      expect(sub!.last_error).toContain('subscriptionRemoved');
+    });
+  });
+});

--- a/test/integration/dao/AiDailyUsageDAO.int.test.ts
+++ b/test/integration/dao/AiDailyUsageDAO.int.test.ts
@@ -1,0 +1,80 @@
+import { describe, expect, it, beforeAll } from 'vitest';
+import { env } from 'cloudflare:test';
+import { AiDailyUsageDAO } from '@mail-otter/backend-data/dao';
+import { applyMigrations } from '../helpers/migrations';
+
+describe('AiDailyUsageDAO', () => {
+  beforeAll(async () => {
+    await applyMigrations(env.DB);
+  });
+
+  it('starts with zero estimated neurons for any date', async () => {
+    const dao = new AiDailyUsageDAO(env.DB);
+
+    const neurons: number = await dao.getEstimatedNeuronsForDate('2026-06-01');
+
+    expect(neurons).toBe(0);
+  });
+
+  it('increments usage and reads it back', async () => {
+    const dao = new AiDailyUsageDAO(env.DB);
+    const usageDate: string = '2026-06-15';
+
+    await dao.incrementUsage({ usageDate, estimatedNeurons: 100, promptTokens: 500, completionTokens: 50 });
+
+    const usage = await dao.getByDate(usageDate);
+    expect(usage).toBeDefined();
+    expect(usage!.estimatedNeurons).toBe(100);
+    expect(usage!.promptTokens).toBe(500);
+    expect(usage!.completionTokens).toBe(50);
+    expect(usage!.requestCount).toBe(1);
+  });
+
+  it('accumulates multiple increments on the same date', async () => {
+    const dao = new AiDailyUsageDAO(env.DB);
+    const usageDate: string = '2026-06-20';
+
+    await dao.incrementUsage({ usageDate, estimatedNeurons: 50, promptTokens: 200, completionTokens: 20 });
+    await dao.incrementUsage({ usageDate, estimatedNeurons: 30, promptTokens: 100, completionTokens: 10 });
+
+    const usage = await dao.getByDate(usageDate);
+    expect(usage!.estimatedNeurons).toBe(80);
+    expect(usage!.promptTokens).toBe(300);
+    expect(usage!.completionTokens).toBe(30);
+    expect(usage!.requestCount).toBe(2);
+  });
+
+  it('handles zero values gracefully', async () => {
+    const dao = new AiDailyUsageDAO(env.DB);
+
+    await dao.incrementUsage({ usageDate: '2026-06-25', estimatedNeurons: 0, promptTokens: 0, completionTokens: 0 });
+
+    const usage = await dao.getByDate('2026-06-25');
+    expect(usage!.estimatedNeurons).toBe(0);
+    expect(usage!.requestCount).toBe(1);
+  });
+
+  it('deletes entries older than a given date', async () => {
+    const dao = new AiDailyUsageDAO(env.DB);
+    await dao.incrementUsage({ usageDate: '2026-01-01', estimatedNeurons: 10 });
+    await dao.incrementUsage({ usageDate: '2026-06-01', estimatedNeurons: 10 });
+
+    const deleted: number = await dao.deleteOlderThanDate('2026-03-01');
+
+    expect(deleted).toBeGreaterThanOrEqual(1);
+    const old = await dao.getByDate('2026-01-01');
+    expect(old).toBeUndefined();
+    const recent = await dao.getByDate('2026-06-01');
+    expect(recent).toBeDefined();
+  });
+
+  it('estimates total daily neurons across multiple increments', async () => {
+    const dao = new AiDailyUsageDAO(env.DB);
+
+    await dao.incrementUsage({ usageDate: '2026-07-01', estimatedNeurons: 200 });
+    await dao.incrementUsage({ usageDate: '2026-07-01', estimatedNeurons: 300 });
+
+    const neurons: number = await dao.getEstimatedNeuronsForDate('2026-07-01');
+    expect(neurons).toBe(500);
+  });
+});

--- a/test/integration/dao/ProcessedMessageDAO.int.test.ts
+++ b/test/integration/dao/ProcessedMessageDAO.int.test.ts
@@ -1,0 +1,157 @@
+import { describe, expect, it, beforeAll } from 'vitest';
+import { env } from 'cloudflare:test';
+import { ProcessedMessageDAO } from '@mail-otter/backend-data/dao';
+import { applyMigrations } from '../helpers/migrations';
+
+let appCounter = 0;
+
+async function seedApplication(providerId: string = 'microsoft-outlook'): Promise<string> {
+  appCounter++;
+  const applicationId = `app-${appCounter}-${Date.now()}`;
+  const email = `user-${appCounter}@example.com`;
+  const now = Math.floor(Date.now() / 1000);
+  await env.DB.prepare(
+    `INSERT INTO users (email, created_at, updated_at) VALUES (?, ?, ?)`,
+  ).bind(email, now, now).run();
+  await env.DB.prepare(
+    `INSERT INTO connected_applications (application_id, user_email, display_name, provider_id, connection_method, encrypted_credentials, credentials_iv, status, created_at, updated_at) ` +
+    `VALUES (?, ?, ?, ?, 'oauth2', 'enc', 'iv', 'connected', ?, ?)`,
+  ).bind(applicationId, email, 'Test App', providerId, now, now).run();
+  return applicationId;
+}
+
+describe('ProcessedMessageDAO', () => {
+  beforeAll(async () => {
+    await applyMigrations(env.DB);
+  });
+
+  it('inserts a new processed message row when tryStart is called for an unseen message', async () => {
+    const applicationId = await seedApplication();
+    const dao = new ProcessedMessageDAO(env.DB);
+
+    const result: boolean = await dao.tryStart(applicationId, 'microsoft-outlook', 'msg-1', 'thread-1');
+
+    expect(result).toBe(true);
+    const message = await dao.getByMessageId(applicationId, 'msg-1');
+    expect(message).toBeDefined();
+    expect(message!.processedMessageId).toBeDefined();
+    expect(message!.status).toBe('processing');
+  });
+
+  it('returns false when tryStart encounters an existing application_id + provider_message_id pair', async () => {
+    const applicationId = await seedApplication();
+    const dao = new ProcessedMessageDAO(env.DB);
+    await dao.tryStart(applicationId, 'microsoft-outlook', 'dup-msg', 'thread-1');
+
+    const result: boolean = await dao.tryStart(applicationId, 'microsoft-outlook', 'dup-msg', 'thread-1');
+
+    expect(result).toBe(false);
+  });
+
+  it('allows different applications to process the same provider message id', async () => {
+    const appA = await seedApplication();
+    const appB = await seedApplication();
+    const dao = new ProcessedMessageDAO(env.DB);
+
+    const resultA: boolean = await dao.tryStart(appA, 'microsoft-outlook', 'shared-msg', 'thread-1');
+    const resultB: boolean = await dao.tryStart(appB, 'microsoft-outlook', 'shared-msg', 'thread-1');
+
+    expect(resultA).toBe(true);
+    expect(resultB).toBe(true);
+  });
+
+  it('does not start a moved message when the stable provider message fingerprint already exists', async () => {
+    const applicationId = await seedApplication();
+    const dao = new ProcessedMessageDAO(env.DB);
+    await dao.tryStart(applicationId, 'microsoft-outlook', 'old-provider-id', 'thread-1', {
+      providerStableMessageFingerprint: 'stable-1',
+    });
+
+    const result: boolean = await dao.tryStart(applicationId, 'microsoft-outlook', 'new-provider-id', 'thread-1', {
+      providerStableMessageFingerprint: 'stable-1',
+    });
+
+    expect(result).toBe(false);
+  });
+
+  it('starts a new reply when its stable fingerprint differs from the existing one', async () => {
+    const applicationId = await seedApplication();
+    const dao = new ProcessedMessageDAO(env.DB);
+    await dao.tryStart(applicationId, 'microsoft-outlook', 'old-msg', 'thread-1', {
+      providerStableMessageFingerprint: 'stable-1',
+    });
+
+    const result: boolean = await dao.tryStart(applicationId, 'microsoft-outlook', 'reply-msg', 'thread-1', {
+      providerStableMessageFingerprint: 'stable-2',
+    });
+
+    expect(result).toBe(true);
+  });
+
+  it('marks a message as summarized and tracks the sent timestamp', async () => {
+    const applicationId = await seedApplication();
+    const dao = new ProcessedMessageDAO(env.DB);
+    await dao.tryStart(applicationId, 'microsoft-outlook', 'summarize-me', 'thread-1');
+
+    await dao.markSummarized(applicationId, 'summarize-me');
+
+    const message = await dao.getByMessageId(applicationId, 'summarize-me');
+    expect(message!.status).toBe('summarized');
+    expect(message!.summarySentAt).toBeDefined();
+    expect(typeof message!.summarySentAt).toBe('number');
+  });
+
+  it('marks a message as skipped with a reason', async () => {
+    const applicationId = await seedApplication();
+    const dao = new ProcessedMessageDAO(env.DB);
+    await dao.tryStart(applicationId, 'microsoft-outlook', 'skip-me', 'thread-1');
+
+    await dao.markSkipped(applicationId, 'skip-me', 'Message was deleted before processing.');
+
+    const message = await dao.getByMessageId(applicationId, 'skip-me');
+    expect(message!.status).toBe('skipped');
+    expect(message!.errorMessage).toBe('Message was deleted before processing.');
+  });
+
+  it('marks a message as error', async () => {
+    const applicationId = await seedApplication();
+    const dao = new ProcessedMessageDAO(env.DB);
+    await dao.tryStart(applicationId, 'microsoft-outlook', 'error-me', 'thread-1');
+
+    await dao.markError(applicationId, 'error-me', 'Provider API failure.');
+
+    const message = await dao.getByMessageId(applicationId, 'error-me');
+    expect(message!.status).toBe('error');
+    expect(message!.errorMessage).toBe('Provider API failure.');
+  });
+
+  it('reports the latest summarized message for an application', async () => {
+    const applicationId = await seedApplication();
+    const dao = new ProcessedMessageDAO(env.DB);
+    await dao.tryStart(applicationId, 'microsoft-outlook', 'older-msg', 'thread-1');
+    await dao.markSummarized(applicationId, 'older-msg');
+    await dao.tryStart(applicationId, 'microsoft-outlook', 'newer-msg', 'thread-1');
+    await dao.markSummarized(applicationId, 'newer-msg');
+
+    const latest = await dao.getLatestForApplication(applicationId);
+
+    expect(latest!.providerMessageId).toBe('newer-msg');
+  });
+
+  it('deletes processed messages older than the given timestamp with matching status', async () => {
+    const applicationId = await seedApplication();
+    const dao = new ProcessedMessageDAO(env.DB);
+    const now = Math.floor(Date.now() / 1000);
+    await dao.tryStart(applicationId, 'microsoft-outlook', 'delete-old', 'thread-1');
+    await dao.markSummarized(applicationId, 'delete-old');
+    await env.DB.prepare(
+      `UPDATE processed_messages SET updated_at = ? WHERE application_id = ? AND provider_message_id = 'delete-old'`,
+    ).bind(now - 86400, applicationId).run();
+
+    const deleted = await dao.deleteOlderThan(now - 3600, ['summarized'], 10);
+
+    expect(deleted).toBe(1);
+    const message = await dao.getByMessageId(applicationId, 'delete-old');
+    expect(message).toBeUndefined();
+  });
+});

--- a/test/integration/global.d.ts
+++ b/test/integration/global.d.ts
@@ -1,0 +1,1 @@
+declare const __INTEGRATION_MIGRATION_SQL__: string;

--- a/test/integration/helpers/migrations.ts
+++ b/test/integration/helpers/migrations.ts
@@ -1,0 +1,42 @@
+function splitSql(sql: string): string[] {
+  const statements: string[] = [];
+  let current = '';
+  let inString = false;
+  let stringChar = '';
+  let i = 0;
+  while (i < sql.length) {
+    const ch = sql[i];
+    if (inString) {
+      current += ch;
+      if (ch === stringChar && sql[i - 1] !== '\\') {
+        inString = false;
+      }
+    } else if (ch === "'" || ch === '"') {
+      current += ch;
+      inString = true;
+      stringChar = ch;
+    } else if (ch === ';') {
+      const trimmed = current.trim();
+      if (trimmed.length > 0) {
+        statements.push(trimmed);
+      }
+      current = '';
+    } else {
+      current += ch;
+    }
+    i++;
+  }
+  const trimmed = current.trim();
+  if (trimmed.length > 0) {
+    statements.push(trimmed);
+  }
+  return statements;
+}
+
+export async function applyMigrations(db: D1Database): Promise<void> {
+  const statements = splitSql(__INTEGRATION_MIGRATION_SQL__);
+  for (const stmt of statements) {
+    if (stmt.length === 0) continue;
+    await db.prepare(stmt).run();
+  }
+}

--- a/test/integration/self.ts
+++ b/test/integration/self.ts
@@ -1,0 +1,1 @@
+export { default } from '../../apps/api/src/index';

--- a/test/integration/tsconfig.json
+++ b/test/integration/tsconfig.json
@@ -1,0 +1,7 @@
+{
+  "extends": "../../tsconfig.json",
+  "compilerOptions": {
+    "types": ["@cloudflare/workers-types/experimental", "@cloudflare/vitest-pool-workers"]
+  },
+  "include": ["**/*.ts", "../../apps/api/src/**/*.ts"]
+}

--- a/test/integration/vitest.config.mts
+++ b/test/integration/vitest.config.mts
@@ -1,0 +1,59 @@
+import { defineConfig } from 'vitest/config';
+import { cloudflareTest, cloudflarePool } from '@cloudflare/vitest-pool-workers';
+import { fileURLToPath } from 'node:url';
+import { readFileSync, readdirSync } from 'node:fs';
+import { resolve } from 'node:path';
+
+const apiSrcPath = fileURLToPath(new URL('../../apps/api/src', import.meta.url));
+const backgroundSrcPath = fileURLToPath(new URL('../../apps/background/src', import.meta.url));
+const backendCoreSrcPath = fileURLToPath(new URL('../../packages/backend-core/src', import.meta.url));
+const backendDataSrcPath = fileURLToPath(new URL('../../packages/backend-data/src', import.meta.url));
+const backendErrorsSrcPath = fileURLToPath(new URL('../../packages/backend-errors/src', import.meta.url));
+const backendRuntimeSrcPath = fileURLToPath(new URL('../../packages/backend-runtime/src', import.meta.url));
+const providerClientsSrcPath = fileURLToPath(new URL('../../packages/provider-clients/src', import.meta.url));
+const sharedSrcPath = fileURLToPath(new URL('../../packages/shared/src', import.meta.url));
+
+const migrationsDir = resolve(fileURLToPath(new URL('../../migrations', import.meta.url)));
+const migrationFiles = readdirSync(migrationsDir).filter(f => f.endsWith('.sql')).sort();
+const migrationSql = migrationFiles.map(f => readFileSync(resolve(migrationsDir, f), 'utf-8')).join('\n\n');
+
+export default defineConfig({
+  define: {
+    __INTEGRATION_MIGRATION_SQL__: JSON.stringify(migrationSql),
+  },
+  plugins: [
+    cloudflareTest({
+      wrangler: {
+        configPath: './test/integration/wrangler.test.jsonc',
+      },
+    }),
+  ],
+  test: {
+    globals: true,
+    include: ['test/integration/**/*.int.test.ts'],
+    pool: cloudflarePool({
+      wrangler: {
+        configPath: './test/integration/wrangler.test.jsonc',
+      },
+    }),
+  },
+  ssr: {
+    noExternal: [
+      'hono',
+      'chanfana',
+      '@mail-otter',
+    ],
+  },
+  resolve: {
+    alias: [
+      { find: '@mail-otter/background', replacement: backgroundSrcPath },
+      { find: '@mail-otter/backend-core', replacement: backendCoreSrcPath },
+      { find: '@mail-otter/backend-data', replacement: backendDataSrcPath },
+      { find: '@mail-otter/backend-errors', replacement: backendErrorsSrcPath },
+      { find: '@mail-otter/backend-runtime', replacement: backendRuntimeSrcPath },
+      { find: '@mail-otter/provider-clients', replacement: providerClientsSrcPath },
+      { find: '@mail-otter/shared', replacement: sharedSrcPath },
+      { find: /^@\//, replacement: `${apiSrcPath}/` },
+    ],
+  },
+});

--- a/test/integration/wrangler.test.jsonc
+++ b/test/integration/wrangler.test.jsonc
@@ -1,0 +1,76 @@
+{
+  "$schema": "../../node_modules/wrangler/config-schema.json",
+  "name": "mail-otter-integration-test",
+  "main": "self.ts",
+  "compatibility_date": "2025-11-29",
+  "compatibility_flags": ["nodejs_compat"],
+  "d1_databases": [
+    {
+      "binding": "DB",
+      "database_name": "mail-otter-test-db",
+      "database_id": "00000000-0000-0000-0000-000000000000",
+    },
+  ],
+  "kv_namespaces": [
+    {
+      "binding": "OAUTH2_TOKEN_CACHE",
+      "id": "00000000-0000-0000-0000-000000000000",
+    },
+  ],
+  "queues": {
+    "producers": [
+      {
+        "binding": "EMAIL_EVENTS_QUEUE",
+        "queue": "mail-otter-test-events",
+      },
+    ],
+  },
+  "secrets_store_secrets": [
+    {
+      "binding": "AES_ENCRYPTION_KEY_SECRET",
+      "store_id": "00000000-0000-0000-0000-000000000000",
+      "secret_name": "test-aes-encryption-key",
+    },
+    {
+      "binding": "ACTION_ENCRYPTION_KEY_SECRET",
+      "store_id": "00000000-0000-0000-0000-000000000000",
+      "secret_name": "test-action-encryption-key",
+    },
+    {
+      "binding": "ACTION_SIGNING_SECRET",
+      "store_id": "00000000-0000-0000-0000-000000000000",
+      "secret_name": "test-action-signing-secret",
+    },
+  ],
+  "vars": {
+    "DEV_AUTH_EMAIL": "test@example.com",
+
+    "DEBUG_MODE": "false",
+    "SERVE_SPA_FROM_WORKER": "false",
+    "POLICY_AUD": "test-aud",
+    "TEAM_DOMAIN": "https://test.cloudflareaccess.com",
+    "MAX_APPLICATIONS_PER_USER": "99",
+    "MAX_CONTEXT_DOCUMENTS_PER_APPLICATION": "1000",
+    "OAUTH2_STATE_EXPIRY_MINUTES": "15",
+    "AI_SUMMARY_MODEL": "@cf/openai/gpt-oss-120b",
+    "AI_SUMMARY_FALLBACK_MODEL": "@cf/openai/gpt-oss-20b",
+    "AI_DAILY_NEURON_FALLBACK_THRESHOLD": "6000",
+    "AI_EMBEDDING_MODEL": "@cf/baai/bge-m3",
+    "MAX_EMAIL_BODY_CHARS": "12000",
+    "MAX_CONTEXT_MEMORY_CHARS": "1800",
+    "MAX_RAG_CONTEXT_CHARS": "6000",
+    "RAG_TOP_K": "5",
+    "RAG_VECTOR_QUERY_TOP_K": "50",
+    "GMAIL_WATCH_RENEWAL_WINDOW_HOURS": "48",
+    "OUTLOOK_SUBSCRIPTION_RENEWAL_WINDOW_HOURS": "24",
+    "OUTLOOK_SUBSCRIPTION_TTL_DAYS": "6",
+    "OAUTH2_ACCESS_TOKEN_REFRESH_WINDOW_SECONDS": "900",
+    "OAUTH2_ACCESS_TOKEN_MIN_VALID_SECONDS": "60",
+    "OAUTH2_ACCESS_TOKEN_FALLBACK_TTL_SECONDS": "3600",
+    "OAUTH2_TOKEN_REFRESH_BATCH_SIZE": "25",
+    "ACTION_CALLBACK_BASE_URL": "https://mail.example.com",
+    "ACTION_DEFAULT_EXPIRY_HOURS": "168",
+    "ACTION_RETENTION_DAYS": "90",
+    "DISABLE_DELETE_AFTER_SEND": "false",
+  },
+}

--- a/vitest.config.mts
+++ b/vitest.config.mts
@@ -17,6 +17,7 @@ export default defineConfig({
     globals: true,
     environment: 'node',
     include: ['test/**/*.test.ts'],
+    exclude: ['test/integration/**'],
   },
   resolve: {
     alias: [


### PR DESCRIPTION
Set up integration test infrastructure using @cloudflare/vitest-pool-workers:

- Configure vitest with Cloudflare pool, D1/KV/Queue/secrets_store_secrets bindings, alias resolution for @mail-otter/* packages, and inline migration SQL
- Add 29 passing integration tests across 6 test files covering DAO layer (ProcessedMessageDAO, AiDailyUsageDAO) and API routes (auth middleware, Gmail webhooks, Outlook webhooks, action confirmation)
- Implement helper for running D1 migrations in test setup
- Add integration-tests job to GitHub Actions CI pipeline
- Add test:integration script to root package.json