### PR TITLE
Fix Action Callback Link Expiration

### DIFF
--- a/packages/backend-data/src/dao/EmailActionDAO.ts
+++ b/packages/backend-data/src/dao/EmailActionDAO.ts
@@ -220,6 +220,23 @@ class EmailActionDAO {
     return (result.meta as { changes?: number } | undefined)?.changes ?? 0;
   }
 
+  public async deleteByProcessedMessageId(processedMessageId: string): Promise<number> {
+    const result: D1Result = await executeD1WithRetry(
+      (): Promise<D1Result> =>
+        this.database
+          .prepare(
+            `
+              DELETE FROM email_summary_actions
+              WHERE processed_message_id = ? AND status = ?
+            `,
+          )
+          .bind(processedMessageId, EMAIL_ACTION_STATUS_PENDING)
+          .run(),
+      'delete pending email actions by processed message',
+    );
+    return (result.meta as { changes?: number } | undefined)?.changes ?? 0;
+  }
+
   public async deleteOlderThan(olderThan: number, limit: number): Promise<number> {
     const result: D1Result = await executeD1WithRetry(
       (): Promise<D1Result> =>

--- a/packages/backend-services/src/action/ActionService.ts
+++ b/packages/backend-services/src/action/ActionService.ts
@@ -47,6 +47,7 @@ class ActionService {
     if (!baseUrl || input.proposals.length === 0) return [];
 
     const actionDAO: EmailActionDAO = await ActionService.createActionDAO(env);
+    await actionDAO.deleteByProcessedMessageId(input.processedMessage.processedMessageId);
     const signingSecret: string = await env.ACTION_SIGNING_SECRET.get();
     const allowedUrls: Set<string> = ActionService.extractUrls(input.body);
     const now: number = TimestampUtil.getCurrentUnixTimestampInSeconds();
@@ -292,7 +293,7 @@ class ActionService {
     const title: string = ActionService.cleanText(proposal.title || ActionService.getFallbackActionTitle(proposal.type));
     const description: string = ActionService.cleanText(proposal.description || title);
     const parameters: Record<string, unknown> = proposal.parameters || {};
-    const expiresAt: number = ActionService.resolveExpiresAt(proposal.expiresAt, now, env);
+    const expiresAt: number = ActionService.resolveExpiresAt(now, env);
     const base = { title, description, sourceSubject: input.subject, sourceFrom: input.from };
 
     if (proposal.type === EMAIL_ACTION_TYPE_CALENDAR_ADD_EVENT) {
@@ -404,12 +405,8 @@ class ActionService {
     return url;
   }
 
-  private static resolveExpiresAt(expiresAt: string | undefined, now: number, env: ActionCreationEnv): number {
-    const defaultExpiresAt: number = TimestampUtil.addHours(now, ConfigurationManager.getActionDefaultExpiryHours(env));
-    if (!expiresAt) return defaultExpiresAt;
-    const parsed: number = Math.floor(new Date(expiresAt).getTime() / 1000);
-    if (!Number.isFinite(parsed) || parsed <= now) return defaultExpiresAt;
-    return Math.min(parsed, defaultExpiresAt);
+  private static resolveExpiresAt(now: number, env: ActionCreationEnv): number {
+    return TimestampUtil.addHours(now, ConfigurationManager.getActionDefaultExpiryHours(env));
   }
 
   private static extractUrls(body: string): Set<string> {

--- a/packages/backend-services/src/email/EmailSummaryUtil.ts
+++ b/packages/backend-services/src/email/EmailSummaryUtil.ts
@@ -32,7 +32,6 @@ const SUMMARY_JSON_SCHEMA = {
           title: { type: 'string' },
           description: { type: 'string' },
           confidence: { type: 'number' },
-          expiresAt: { type: 'string' },
           parameters: {
             type: 'object',
             additionalProperties: true,
@@ -130,7 +129,7 @@ class EmailSummaryUtil {
   private static buildSummaryInstructions(): string {
     return [
       'You are a helpful assistant that summarizes emails for a mailbox owner.',
-      'Return only JSON with this exact shape: {"gist":"one sentence","keyDetails":["short fact"],"actionItems":["owner deadline or request"],"actions":[{"type":"calendar.add_event|email.draft_reply|external.open_link|manual.todo","title":"short title","description":"what will happen","confidence":0.8,"expiresAt":"ISO-8601 optional","parameters":{}}]}.',
+      'Return only JSON with this exact shape: {"gist":"one sentence","keyDetails":["short fact"],"actionItems":["owner deadline or request"],"actions":[{"type":"calendar.add_event|email.draft_reply|external.open_link|manual.todo","title":"short title","description":"what will happen","confidence":0.8,"parameters":{}}]}.',
       'Keep the gist to one sentence.',
       'Details must be short factual bullets copied from the email when possible.',
       'Actions must include deadlines or owners when present.',
@@ -448,7 +447,6 @@ class EmailSummaryUtil {
         title: EmailSummaryUtil.normalizeSentence(item.title),
         description: EmailSummaryUtil.normalizeSentence(item.description),
         confidence: typeof item.confidence === 'number' && Number.isFinite(item.confidence) ? item.confidence : undefined,
-        expiresAt: typeof item.expiresAt === 'string' ? item.expiresAt : undefined,
         parameters: EmailSummaryUtil.isRecord(item.parameters) ? item.parameters : {},
       });
     }

--- a/packages/shared/src/model/EmailAction.ts
+++ b/packages/shared/src/model/EmailAction.ts
@@ -126,7 +126,6 @@ interface EmailActionProposal {
   title: string;
   description: string;
   confidence?: number | undefined;
-  expiresAt?: string | undefined;
   parameters?: Record<string, unknown> | undefined;
 }
 


### PR DESCRIPTION
AI-proposed expiresAt was overriding the 7-day default via Math.min, causing callback links to expire far sooner than the user expected. The email displayed the correct (short) time, but users often missed the fine-print timestamp and assumed the standard 7-day window.

- resolveExpiresAt now always returns the configured default (7 days) regardless of any AI-proposed expiresAt string
- createActionsForSummary now deletes existing pending actions for the same processedMessageId before inserting new ones, preventing orphaned stale links from accumulating on workflow retries
- Added EmailActionDAO.deleteByProcessedMessageId to support the cleanup


Closes #154 