### PR TITLE
Save Summary As Draft, Copy To Inbox, Then Delete Draft

### DIFF
--- a/packages/provider-clients/src/OutlookProviderUtil.ts
+++ b/packages/provider-clients/src/OutlookProviderUtil.ts
@@ -206,7 +206,7 @@ class OutlookProviderUtil {
     originalMessage: OutlookMessage,
     mailboxAddress: string,
     summary: string,
-    disableDelete?: boolean,
+    disableCleanup?: boolean,
   ): Promise<void> {
     const draft = await OutlookProviderUtil.fetchJson<{ id?: string | undefined }>(
       `https://graph.microsoft.com/v1.0/me/messages/${encodeURIComponent(originalMessage.id)}/createReply`,
@@ -237,18 +237,9 @@ class OutlookProviderUtil {
     if (!draft.id) {
       throw new ProviderApiRetryableError('Microsoft Graph createReply did not return a draft id.');
     }
-    const response = await fetch(`https://graph.microsoft.com/v1.0/me/messages/${encodeURIComponent(draft.id)}/send`, {
-      method: 'POST',
-      headers: {
-        Authorization: `Bearer ${accessToken}`,
-        'Content-Type': 'application/json',
-      },
-    });
-    if (!response.ok) {
-      throw OutlookProviderUtil.createApiError('send summary', response, await response.text());
-    }
-    if (!disableDelete) {
-      await OutlookProviderUtil.deleteSentCopy(accessToken, draft.id);
+    await OutlookProviderUtil.copyMessage(accessToken, draft.id, 'inbox');
+    if (!disableCleanup) {
+      await OutlookProviderUtil.deleteMessage(accessToken, draft.id);
     }
   }
 
@@ -281,13 +272,27 @@ class OutlookProviderUtil {
     return status === 408 || status === 409 || status === 425 || status === 429 || status >= 500;
   }
 
-  private static async deleteSentCopy(accessToken: string, messageId: string): Promise<void> {
+  private static async copyMessage(accessToken: string, messageId: string, destinationId: string): Promise<void> {
+    const response = await fetch(`https://graph.microsoft.com/v1.0/me/messages/${encodeURIComponent(messageId)}/copy`, {
+      method: 'POST',
+      headers: {
+        Authorization: `Bearer ${accessToken}`,
+        'Content-Type': 'application/json',
+      },
+      body: JSON.stringify({ destinationId }),
+    });
+    if (!response.ok) {
+      throw OutlookProviderUtil.createApiError('copy message', response, await response.text());
+    }
+  }
+
+  private static async deleteMessage(accessToken: string, messageId: string): Promise<void> {
     const response = await fetch(`https://graph.microsoft.com/v1.0/me/messages/${encodeURIComponent(messageId)}`, {
       method: 'DELETE',
       headers: { Authorization: `Bearer ${accessToken}` },
     });
     if (!response.ok && response.status !== 404) {
-      console.error(`Failed to delete Outlook sent summary ${messageId}: ${await response.text()}`);
+      console.error(`Failed to delete Outlook message ${messageId}: ${await response.text()}`);
     }
   }
 }

--- a/test/utils/OutlookProviderUtil.test.ts
+++ b/test/utils/OutlookProviderUtil.test.ts
@@ -7,15 +7,15 @@ describe('OutlookProviderUtil', () => {
   });
 
   describe('sendSelfSummaryReply', () => {
-    it('sends a threaded reply and deletes the sent copy', async () => {
+    it('creates a reply draft, copies it to inbox, and deletes the original draft', async () => {
       const mockCreateReplyResponse = new Response(JSON.stringify({ id: 'draft-id-123' }), { status: 201 });
-      const mockSendResponse = new Response('', { status: 202 });
+      const mockCopyResponse = new Response(JSON.stringify({ id: 'copy-id-456' }), { status: 201 });
       const mockDeleteResponse = new Response(null, { status: 204 });
 
       const fetchMock = vi
         .fn()
         .mockResolvedValueOnce(mockCreateReplyResponse)
-        .mockResolvedValueOnce(mockSendResponse)
+        .mockResolvedValueOnce(mockCopyResponse)
         .mockResolvedValueOnce(mockDeleteResponse);
 
       vi.stubGlobal('fetch', fetchMock);
@@ -61,11 +61,18 @@ describe('OutlookProviderUtil', () => {
           ],
         },
       });
+
+      // Verify copy to inbox
       expect(fetchMock).toHaveBeenNthCalledWith(
         2,
-        'https://graph.microsoft.com/v1.0/me/messages/draft-id-123/send',
-        expect.objectContaining({ method: 'POST' }),
+        'https://graph.microsoft.com/v1.0/me/messages/draft-id-123/copy',
+        expect.objectContaining({
+          method: 'POST',
+          body: JSON.stringify({ destinationId: 'inbox' }),
+        }),
       );
+
+      // Verify delete original draft
       expect(fetchMock).toHaveBeenNthCalledWith(
         3,
         'https://graph.microsoft.com/v1.0/me/messages/draft-id-123',
@@ -73,20 +80,46 @@ describe('OutlookProviderUtil', () => {
       );
     });
 
-    it('throws when send fails', async () => {
-      const mockCreateReplyResponse = new Response(JSON.stringify({ id: 'draft-id-123' }), { status: 200 });
-      const mockSendResponse = new Response('Send failed', { status: 500 });
+    it('skips deleting the draft when disable replacement is disabled', async () => {
+      const mockCreateReplyResponse = new Response(JSON.stringify({ id: 'draft-id-123' }), { status: 201 });
+      const mockCopyResponse = new Response(JSON.stringify({ id: 'copy-id-456' }), { status: 201 });
 
       const fetchMock = vi
         .fn()
         .mockResolvedValueOnce(mockCreateReplyResponse)
-        .mockResolvedValueOnce(mockSendResponse);
+        .mockResolvedValueOnce(mockCopyResponse);
+
+      vi.stubGlobal('fetch', fetchMock);
+
+      await OutlookProviderUtil.sendSelfSummaryReply(
+        'test-access-token',
+        { id: 'original-msg-id' },
+        'sender@example.com',
+        'Summary text',
+        true,
+      );
+
+      expect(fetchMock).toHaveBeenCalledTimes(2);
+      expect(fetchMock).not.toHaveBeenCalledWith(
+        'https://graph.microsoft.com/v1.0/me/messages/draft-id-123',
+        expect.objectContaining({ method: 'DELETE' }),
+      );
+    });
+
+    it('throws when copy fails', async () => {
+      const mockCreateReplyResponse = new Response(JSON.stringify({ id: 'draft-id-123' }), { status: 200 });
+      const mockCopyResponse = new Response('Copy failed', { status: 500 });
+
+      const fetchMock = vi
+        .fn()
+        .mockResolvedValueOnce(mockCreateReplyResponse)
+        .mockResolvedValueOnce(mockCopyResponse);
 
       vi.stubGlobal('fetch', fetchMock);
 
       await expect(
         OutlookProviderUtil.sendSelfSummaryReply('test-access-token', { id: 'original-msg-id' }, 'sender@example.com', 'Summary text'),
-      ).rejects.toThrow('Microsoft Graph send summary failed (500): Send failed');
+      ).rejects.toThrow('Microsoft Graph copy message failed (500): Copy failed');
     });
 
     it('throws when createReply fails', async () => {
@@ -110,5 +143,3 @@ describe('OutlookProviderUtil', () => {
     });
   });
 });
-
-


### PR DESCRIPTION
Modify the M365 summary email flow to avoid sending a reply:
1. Create a reply draft using createReply (preserves conversation/thread)
2. Copy the draft to the Inbox folder using /copy with destinationId: inbox
3. Delete the original draft from Drafts (unless disableCleanup is set)

This ensures the summary appears in the same thread in the Inbox as an unread message, rather than cluttering Sent Items.

- Rename disableDelete -> disableCleanup in sendSelfSummaryReply
- Add copyMessage helper for Graph message copy API
- Rename deleteSentCopy -> deleteMessage for generic reuse
- Update OutlookProviderUtil tests to verify new copy+delete flow