### PR TITLE
Use Reply Endpoint Instead Of Draft+Send For Outlook Summary

### DIFF
--- a/packages/provider-clients/src/OutlookProviderUtil.ts
+++ b/packages/provider-clients/src/OutlookProviderUtil.ts
@@ -211,12 +211,14 @@ class OutlookProviderUtil {
     const sinkAddress: string = atIndex !== -1
       ? `${mailboxAddress.slice(0, atIndex)}+sink${mailboxAddress.slice(atIndex)}`
       : mailboxAddress;
-    const draft = await OutlookProviderUtil.fetchJson<{ id?: string | undefined }>(
-      `https://graph.microsoft.com/v1.0/me/messages/${encodeURIComponent(originalMessage.id)}/createReply`,
-      accessToken,
+    const response: Response = await fetch(
+      `https://graph.microsoft.com/v1.0/me/messages/${encodeURIComponent(originalMessage.id)}/reply`,
       {
         method: 'POST',
-        headers: { 'Content-Type': 'application/json' },
+        headers: {
+          Authorization: `Bearer ${accessToken}`,
+          'Content-Type': 'application/json',
+        },
         body: JSON.stringify({
           message: {
             body: {
@@ -237,21 +239,30 @@ class OutlookProviderUtil {
         }),
       },
     );
-    if (!draft.id) {
-      throw new ProviderApiRetryableError('Microsoft Graph createReply did not return a draft id.');
+    if (!response.ok) {
+      throw OutlookProviderUtil.createApiError('send summary reply', response, await response.text());
     }
-    const sendResponse: Response = await fetch(`https://graph.microsoft.com/v1.0/me/messages/${encodeURIComponent(draft.id)}/send`, {
-      method: 'POST',
-      headers: {
-        Authorization: `Bearer ${accessToken}`,
-        'Content-Type': 'application/json',
-      },
-    });
-    if (!sendResponse.ok) {
-      throw OutlookProviderUtil.createApiError('send summary', sendResponse, await sendResponse.text());
+    const sentMessageId: string = await OutlookProviderUtil.findSentSummaryMessage(accessToken);
+    await OutlookProviderUtil.copyMessage(accessToken, sentMessageId, 'inbox');
+    await OutlookProviderUtil.deleteMessage(accessToken, sentMessageId);
+  }
+
+  private static async findSentSummaryMessage(accessToken: string): Promise<string> {
+    const url: URL = new URL('https://graph.microsoft.com/v1.0/me/mailFolders/sentitems/messages');
+    url.searchParams.set(
+      '$filter',
+      `internetMessageHeaders/any(h:h/name eq 'X-Mail-Otter-Summary' and h/value eq 'true')`,
+    );
+    url.searchParams.set('$orderby', 'sentDateTime desc');
+    url.searchParams.set('$top', '1');
+    url.searchParams.set('$select', 'id');
+    const data = await OutlookProviderUtil.fetchJson<{
+      value?: Array<{ id: string }> | undefined;
+    }>(url.toString(), accessToken);
+    if (!data.value || data.value.length === 0) {
+      throw new ProviderApiRetryableError('Microsoft Graph did not return the sent summary message.');
     }
-    await OutlookProviderUtil.copyMessage(accessToken, draft.id, 'inbox');
-    await OutlookProviderUtil.deleteMessage(accessToken, draft.id);
+    return data.value[0].id;
   }
 
   public static isMessageNotFoundError(error: unknown): boolean {

--- a/test/utils/OutlookProviderUtil.test.ts
+++ b/test/utils/OutlookProviderUtil.test.ts
@@ -7,16 +7,16 @@ describe('OutlookProviderUtil', () => {
   });
 
   describe('sendSelfSummaryReply', () => {
-    it('sends summary to sink address, copies to inbox, and deletes sent copy', async () => {
-      const mockCreateReplyResponse = new Response(JSON.stringify({ id: 'draft-id-123' }), { status: 201 });
-      const mockSendResponse = new Response(null, { status: 202 });
+    it('sends summary as a reply, finds sent message, copies to inbox, and deletes sent copy', async () => {
+      const mockReplyResponse = new Response(null, { status: 202 });
+      const mockFindResponse = new Response(JSON.stringify({ value: [{ id: 'sent-msg-id' }] }), { status: 200 });
       const mockCopyResponse = new Response(JSON.stringify({ id: 'copy-id-456' }), { status: 201 });
       const mockDeleteResponse = new Response(null, { status: 204 });
 
       const fetchMock = vi
         .fn()
-        .mockResolvedValueOnce(mockCreateReplyResponse)
-        .mockResolvedValueOnce(mockSendResponse)
+        .mockResolvedValueOnce(mockReplyResponse)
+        .mockResolvedValueOnce(mockFindResponse)
         .mockResolvedValueOnce(mockCopyResponse)
         .mockResolvedValueOnce(mockDeleteResponse);
 
@@ -35,18 +35,19 @@ describe('OutlookProviderUtil', () => {
 
       expect(fetchMock).toHaveBeenCalledTimes(4);
 
-      // Step 1: createReply with sink address
+      // Step 1: reply with sink address
       expect(fetchMock).toHaveBeenNthCalledWith(
         1,
-        'https://graph.microsoft.com/v1.0/me/messages/original-msg-id/createReply',
+        'https://graph.microsoft.com/v1.0/me/messages/original-msg-id/reply',
         expect.objectContaining({ method: 'POST' }),
       );
 
-      const createReplyCall = fetchMock.mock.calls[0];
-      const createReplyHeaders = createReplyCall[1].headers as Headers;
-      const parsedBody: Record<string, unknown> = JSON.parse(createReplyCall[1].body as string);
+      const replyCall = fetchMock.mock.calls[0];
+      const replyHeaders = replyCall[1].headers as Record<string, string>;
+      const parsedBody: Record<string, unknown> = JSON.parse(replyCall[1].body as string);
 
-      expect(createReplyHeaders.get('Content-Type')).toBe('application/json');
+      expect(replyHeaders['Content-Type']).toBe('application/json');
+      expect(replyHeaders['Authorization']).toBe('Bearer test-access-token');
       expect(parsedBody).toEqual({
         message: {
           body: {
@@ -66,17 +67,18 @@ describe('OutlookProviderUtil', () => {
         },
       });
 
-      // Step 2: send the draft
-      expect(fetchMock).toHaveBeenNthCalledWith(
-        2,
-        'https://graph.microsoft.com/v1.0/me/messages/draft-id-123/send',
-        expect.objectContaining({ method: 'POST' }),
-      );
+      // Step 2: find sent summary message
+      const findUrl = fetchMock.mock.calls[1][0] as string;
+      expect(findUrl).toContain('/me/mailFolders/sentitems/messages');
+      expect(findUrl).toContain('internetMessageHeaders');
+      expect(findUrl).toContain('X-Mail-Otter-Summary');
+      expect(findUrl).toContain(encodeURIComponent('$top') + '=1');
+      expect(findUrl).toContain(encodeURIComponent('$orderby') + '=sentDateTime+desc');
 
       // Step 3: copy sent message to inbox
       expect(fetchMock).toHaveBeenNthCalledWith(
         3,
-        'https://graph.microsoft.com/v1.0/me/messages/draft-id-123/copy',
+        'https://graph.microsoft.com/v1.0/me/messages/sent-msg-id/copy',
         expect.objectContaining({
           method: 'POST',
           body: JSON.stringify({ destinationId: 'inbox' }),
@@ -86,20 +88,62 @@ describe('OutlookProviderUtil', () => {
       // Step 4: delete sent copy
       expect(fetchMock).toHaveBeenNthCalledWith(
         4,
-        'https://graph.microsoft.com/v1.0/me/messages/draft-id-123',
+        'https://graph.microsoft.com/v1.0/me/messages/sent-msg-id',
         expect.objectContaining({ method: 'DELETE' }),
       );
     });
 
+    it('throws when reply fails', async () => {
+      const mockReplyResponse = new Response('Reply failed', { status: 500 });
+
+      vi.stubGlobal('fetch', vi.fn().mockResolvedValue(mockReplyResponse));
+
+      await expect(
+        OutlookProviderUtil.sendSelfSummaryReply('test-access-token', { id: 'original-msg-id' }, 'sender@example.com', 'Summary text'),
+      ).rejects.toThrow('Microsoft Graph send summary reply failed (500): Reply failed');
+    });
+
+    it('throws when find returns no results', async () => {
+      const mockReplyResponse = new Response(null, { status: 202 });
+      const mockFindResponse = new Response(JSON.stringify({ value: [] }), { status: 200 });
+
+      const fetchMock = vi
+        .fn()
+        .mockResolvedValueOnce(mockReplyResponse)
+        .mockResolvedValueOnce(mockFindResponse);
+
+      vi.stubGlobal('fetch', fetchMock);
+
+      await expect(
+        OutlookProviderUtil.sendSelfSummaryReply('test-access-token', { id: 'original-msg-id' }, 'sender@example.com', 'Summary text'),
+      ).rejects.toThrow('Microsoft Graph did not return the sent summary message.');
+    });
+
+    it('throws when find fails', async () => {
+      const mockReplyResponse = new Response(null, { status: 202 });
+      const mockFindResponse = new Response(JSON.stringify({ error: { message: 'Find failed' } }), { status: 500 });
+
+      const fetchMock = vi
+        .fn()
+        .mockResolvedValueOnce(mockReplyResponse)
+        .mockResolvedValueOnce(mockFindResponse);
+
+      vi.stubGlobal('fetch', fetchMock);
+
+      await expect(
+        OutlookProviderUtil.sendSelfSummaryReply('test-access-token', { id: 'original-msg-id' }, 'sender@example.com', 'Summary text'),
+      ).rejects.toThrow('Microsoft Graph request failed (500): Find failed');
+    });
+
     it('throws when copy fails', async () => {
-      const mockCreateReplyResponse = new Response(JSON.stringify({ id: 'draft-id-123' }), { status: 200 });
-      const mockSendResponse = new Response(null, { status: 202 });
+      const mockReplyResponse = new Response(null, { status: 202 });
+      const mockFindResponse = new Response(JSON.stringify({ value: [{ id: 'sent-msg-id' }] }), { status: 200 });
       const mockCopyResponse = new Response('Copy failed', { status: 500 });
 
       const fetchMock = vi
         .fn()
-        .mockResolvedValueOnce(mockCreateReplyResponse)
-        .mockResolvedValueOnce(mockSendResponse)
+        .mockResolvedValueOnce(mockReplyResponse)
+        .mockResolvedValueOnce(mockFindResponse)
         .mockResolvedValueOnce(mockCopyResponse);
 
       vi.stubGlobal('fetch', fetchMock);
@@ -108,42 +152,5 @@ describe('OutlookProviderUtil', () => {
         OutlookProviderUtil.sendSelfSummaryReply('test-access-token', { id: 'original-msg-id' }, 'sender@example.com', 'Summary text'),
       ).rejects.toThrow('Microsoft Graph copy message failed (500): Copy failed');
     });
-
-    it('throws when send fails', async () => {
-      const mockCreateReplyResponse = new Response(JSON.stringify({ id: 'draft-id-123' }), { status: 200 });
-      const mockSendResponse = new Response('Send failed', { status: 500 });
-
-      const fetchMock = vi
-        .fn()
-        .mockResolvedValueOnce(mockCreateReplyResponse)
-        .mockResolvedValueOnce(mockSendResponse);
-
-      vi.stubGlobal('fetch', fetchMock);
-
-      await expect(
-        OutlookProviderUtil.sendSelfSummaryReply('test-access-token', { id: 'original-msg-id' }, 'sender@example.com', 'Summary text'),
-      ).rejects.toThrow('Microsoft Graph send summary failed (500): Send failed');
-    });
-
-    it('throws when createReply fails', async () => {
-      const mockCreateReplyResponse = new Response(JSON.stringify({ error: { message: 'createReply failed' } }), { status: 400 });
-
-      vi.stubGlobal('fetch', vi.fn().mockResolvedValue(mockCreateReplyResponse));
-
-      await expect(
-        OutlookProviderUtil.sendSelfSummaryReply('test-access-token', { id: 'original-msg-id' }, 'sender@example.com', 'Summary text'),
-      ).rejects.toThrow('Microsoft Graph request failed (400): createReply failed');
-    });
-
-    it('throws when draft has no id', async () => {
-      const mockCreateReplyResponse = new Response('{}', { status: 200 });
-
-      vi.stubGlobal('fetch', vi.fn().mockResolvedValue(mockCreateReplyResponse));
-
-      await expect(
-        OutlookProviderUtil.sendSelfSummaryReply('test-access-token', { id: 'original-msg-id' }, 'sender@example.com', 'Summary text'),
-      ).rejects.toThrow('Microsoft Graph createReply did not return a draft id.');
-    });
   });
 });
-


### PR DESCRIPTION
Replace the two-step createReply (creates draft) then /send (sends draft) flow with Microsoft Graph's /reply endpoint, which atomically creates and sends the reply in a single API call. This eliminates intermediate drafts entirely, preventing orphaned drafts from accumulating in the Drafts folder when the workflow step is retried.

After the /reply call, the sent message is located by querying Sent Items via the X-Mail-Otter-Summary header, then copied to Inbox and deleted from Sent Items to preserve the existing UX (summary appears in the original thread in Inbox without cluttering Sent Items).

A new private helper findSentSummaryMessage queries the Sent Items folder with an OData filter on the custom header. If the message is not found yet (eventual consistency), it throws ProviderApiRetryableError so the workflow step retries.

Updated OutlookProviderUtil tests to verify the new flow:
- /reply body and headers
- Sent Items query URL construction
- Copy to inbox and delete from sent items using the found message ID
- Error cases: reply failure, find empty results, find API failure, copy failure