### PR TITLE
Make Send Summary Steps Retry-Safe With Idempotency Checks

### DIFF
--- a/packages/backend-services/src/email/EmailProcessingUtil.ts
+++ b/packages/backend-services/src/email/EmailProcessingUtil.ts
@@ -1,4 +1,4 @@
-import { PROVIDER_SUBSCRIPTION_STATUS_ACTIVE, SOURCE_TYPE_EMAIL, CONTEXT_AUDIT_EVENT_PROCESSING_STARTED, CONTEXT_AUDIT_EVENT_SUMMARY_GENERATED, CONTEXT_AUDIT_EVENT_SUMMARY_SENT, CONTEXT_AUDIT_EVENT_ACTION_CREATED, CONTEXT_AUDIT_EVENT_ERROR, CONTEXT_AUDIT_LOG_SEVERITY_INFO, CONTEXT_AUDIT_LOG_SEVERITY_WARNING, CONTEXT_AUDIT_LOG_SEVERITY_ERROR } from '@mail-otter/shared/constants';
+import { PROCESSED_MESSAGE_STATUS_SUMMARIZED, PROVIDER_SUBSCRIPTION_STATUS_ACTIVE, SOURCE_TYPE_EMAIL, CONTEXT_AUDIT_EVENT_PROCESSING_STARTED, CONTEXT_AUDIT_EVENT_SUMMARY_GENERATED, CONTEXT_AUDIT_EVENT_SUMMARY_SENT, CONTEXT_AUDIT_EVENT_ACTION_CREATED, CONTEXT_AUDIT_EVENT_ERROR, CONTEXT_AUDIT_LOG_SEVERITY_INFO, CONTEXT_AUDIT_LOG_SEVERITY_WARNING, CONTEXT_AUDIT_LOG_SEVERITY_ERROR } from '@mail-otter/shared/constants';
 import { AiDailyUsageDAO, ApplicationContextDAO, ConnectedApplicationDAO, ProcessedMessageDAO, ProviderSubscriptionDAO } from '@mail-otter/backend-data/dao';
 import type { D1Queryable } from '@mail-otter/backend-data/utils';
 import { EmailContentUtil } from '@mail-otter/provider-clients/email-content';
@@ -170,6 +170,10 @@ class EmailProcessingUtil {
   public static async sendGmailSummary(data: GmailSummaryData, env: EmailProcessingEnv): Promise<void> {
     const contextDAO = new ApplicationContextDAO(env.DB);
     const processedDAO = new ProcessedMessageDAO(env.DB);
+    const existing = await processedDAO.getByMessageId(data.application.applicationId, data.messageId);
+    if (existing?.status === PROCESSED_MESSAGE_STATUS_SUMMARIZED) {
+      return;
+    }
     try {
       await GmailProviderUtil.sendSummaryReply(data.accessToken, data.application.providerEmail!, data.message, data.summaryHtml);
       await EmailProcessingUtil.logSummarySent(contextDAO, data.application, data.messageId, data.options.retryAttempt);
@@ -298,6 +302,10 @@ class EmailProcessingUtil {
   public static async sendOutlookSummary(data: OutlookSummaryData, env: EmailProcessingEnv): Promise<void> {
     const contextDAO = new ApplicationContextDAO(env.DB);
     const processedDAO = new ProcessedMessageDAO(env.DB);
+    const existing = await processedDAO.getByMessageId(data.application.applicationId, data.messageId);
+    if (existing?.status === PROCESSED_MESSAGE_STATUS_SUMMARIZED) {
+      return;
+    }
     try {
       await OutlookProviderUtil.sendSelfSummaryReply(data.accessToken, data.message, data.application.providerEmail!, data.summaryHtml);
       await EmailProcessingUtil.logSummarySent(contextDAO, data.application, data.messageId, data.options.retryAttempt);


### PR DESCRIPTION
Add a pre-flight idempotency check at the start of both `sendGmailSummary()` and `sendOutlookSummary()` in `EmailProcessingUtil.ts`.

Before calling the provider API to send a summary reply, the methods now check `processedDAO.getByMessageId()` for the existing status. If the message is already `summarized`, the method returns early without re-sending.

This prevents duplicate summary emails when a workflow step succeeds in sending the email but fails on the subsequent D1 `markSummarized()` write. On retry, the step skips the provider API call instead of sending the email again.

The `Generate` steps were already safe via `tryStart()` gating; this closure ensures the `Send` steps are equally idempotent.