### PR TITLE
Make Outlook Summary Reply Idempotent

### DIFF
--- a/packages/provider-clients/src/OutlookProviderUtil.ts
+++ b/packages/provider-clients/src/OutlookProviderUtil.ts
@@ -207,6 +207,21 @@ class OutlookProviderUtil {
     mailboxAddress: string,
     summary: string,
   ): Promise<void> {
+    // Idempotency: if summary already in Inbox, all previous steps completed
+    const inboxMsgId: string | null = await OutlookProviderUtil.findSummaryMessageInFolder(accessToken, 'inbox');
+    if (inboxMsgId) {
+      return;
+    }
+
+    // If summary in Sent Items only, reply was sent but copy+delete are pending
+    const sentMsgId: string | null = await OutlookProviderUtil.findSummaryMessageInFolder(accessToken, 'sentitems');
+    if (sentMsgId) {
+      await OutlookProviderUtil.copyMessage(accessToken, sentMsgId, 'inbox');
+      await OutlookProviderUtil.deleteMessage(accessToken, sentMsgId);
+      return;
+    }
+
+    // First attempt: send reply
     const atIndex: number = mailboxAddress.lastIndexOf('@');
     const sinkAddress: string = atIndex !== -1
       ? `${mailboxAddress.slice(0, atIndex)}+sink${mailboxAddress.slice(atIndex)}`
@@ -247,8 +262,8 @@ class OutlookProviderUtil {
     await OutlookProviderUtil.deleteMessage(accessToken, sentMessageId);
   }
 
-  private static async findSentSummaryMessage(accessToken: string): Promise<string> {
-    const url: URL = new URL('https://graph.microsoft.com/v1.0/me/mailFolders/sentitems/messages');
+  private static async findSummaryMessageInFolder(accessToken: string, folderId: string): Promise<string | null> {
+    const url: URL = new URL(`https://graph.microsoft.com/v1.0/me/mailFolders/${folderId}/messages`);
     url.searchParams.set(
       '$filter',
       `internetMessageHeaders/any(h:h/name eq 'X-Mail-Otter-Summary' and h/value eq 'true')`,
@@ -259,10 +274,15 @@ class OutlookProviderUtil {
     const data = await OutlookProviderUtil.fetchJson<{
       value?: Array<{ id: string }> | undefined;
     }>(url.toString(), accessToken);
-    if (!data.value || data.value.length === 0) {
+    return data.value && data.value.length > 0 ? data.value[0].id : null;
+  }
+
+  private static async findSentSummaryMessage(accessToken: string): Promise<string> {
+    const id: string | null = await OutlookProviderUtil.findSummaryMessageInFolder(accessToken, 'sentitems');
+    if (!id) {
       throw new ProviderApiRetryableError('Microsoft Graph did not return the sent summary message.');
     }
-    return data.value[0].id;
+    return id;
   }
 
   public static isMessageNotFoundError(error: unknown): boolean {
@@ -314,7 +334,7 @@ class OutlookProviderUtil {
       headers: { Authorization: `Bearer ${accessToken}` },
     });
     if (!response.ok && response.status !== 404) {
-      console.error(`Failed to delete Outlook message ${messageId}: ${await response.text()}`);
+      throw OutlookProviderUtil.createApiError('delete message', response, await response.text());
     }
   }
 }

--- a/test/utils/OutlookProviderUtil.test.ts
+++ b/test/utils/OutlookProviderUtil.test.ts
@@ -1,6 +1,10 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { OutlookProviderUtil } from '@mail-otter/provider-clients/outlook';
 
+function mockEmptyResponse(): Response {
+  return new Response(JSON.stringify({ value: [] }), { status: 200 });
+}
+
 describe('OutlookProviderUtil', () => {
   beforeEach(() => {
     vi.clearAllMocks();
@@ -15,10 +19,12 @@ describe('OutlookProviderUtil', () => {
 
       const fetchMock = vi
         .fn()
-        .mockResolvedValueOnce(mockReplyResponse)
-        .mockResolvedValueOnce(mockFindResponse)
-        .mockResolvedValueOnce(mockCopyResponse)
-        .mockResolvedValueOnce(mockDeleteResponse);
+        .mockResolvedValueOnce(mockEmptyResponse())   // inbox check
+        .mockResolvedValueOnce(mockEmptyResponse())   // sentitems check
+        .mockResolvedValueOnce(mockReplyResponse)     // reply
+        .mockResolvedValueOnce(mockFindResponse)      // find after reply
+        .mockResolvedValueOnce(mockCopyResponse)      // copy
+        .mockResolvedValueOnce(mockDeleteResponse);   // delete
 
       vi.stubGlobal('fetch', fetchMock);
 
@@ -33,16 +39,26 @@ describe('OutlookProviderUtil', () => {
         htmlSummary,
       );
 
-      expect(fetchMock).toHaveBeenCalledTimes(4);
+      expect(fetchMock).toHaveBeenCalledTimes(6);
 
-      // Step 1: reply with sink address
+      // Step 1: inbox idempotency check
+      const inboxUrl = fetchMock.mock.calls[0][0] as string;
+      expect(inboxUrl).toContain('/me/mailFolders/inbox/messages');
+      expect(inboxUrl).toContain('X-Mail-Otter-Summary');
+
+      // Step 2: sent items idempotency check
+      const sentItemsCheckUrl = fetchMock.mock.calls[1][0] as string;
+      expect(sentItemsCheckUrl).toContain('/me/mailFolders/sentitems/messages');
+      expect(sentItemsCheckUrl).toContain('X-Mail-Otter-Summary');
+
+      // Step 3: reply with sink address
       expect(fetchMock).toHaveBeenNthCalledWith(
-        1,
+        3,
         'https://graph.microsoft.com/v1.0/me/messages/original-msg-id/reply',
         expect.objectContaining({ method: 'POST' }),
       );
 
-      const replyCall = fetchMock.mock.calls[0];
+      const replyCall = fetchMock.mock.calls[2];
       const replyHeaders = replyCall[1].headers as Record<string, string>;
       const parsedBody: Record<string, unknown> = JSON.parse(replyCall[1].body as string);
 
@@ -67,17 +83,17 @@ describe('OutlookProviderUtil', () => {
         },
       });
 
-      // Step 2: find sent summary message
-      const findUrl = fetchMock.mock.calls[1][0] as string;
+      // Step 4: find sent summary message (also in sentitems folder)
+      const findUrl = fetchMock.mock.calls[3][0] as string;
       expect(findUrl).toContain('/me/mailFolders/sentitems/messages');
       expect(findUrl).toContain('internetMessageHeaders');
       expect(findUrl).toContain('X-Mail-Otter-Summary');
       expect(findUrl).toContain(encodeURIComponent('$top') + '=1');
       expect(findUrl).toContain(encodeURIComponent('$orderby') + '=sentDateTime+desc');
 
-      // Step 3: copy sent message to inbox
+      // Step 5: copy sent message to inbox
       expect(fetchMock).toHaveBeenNthCalledWith(
-        3,
+        5,
         'https://graph.microsoft.com/v1.0/me/messages/sent-msg-id/copy',
         expect.objectContaining({
           method: 'POST',
@@ -85,7 +101,64 @@ describe('OutlookProviderUtil', () => {
         }),
       );
 
-      // Step 4: delete sent copy
+      // Step 6: delete sent copy
+      expect(fetchMock).toHaveBeenNthCalledWith(
+        6,
+        'https://graph.microsoft.com/v1.0/me/messages/sent-msg-id',
+        expect.objectContaining({ method: 'DELETE' }),
+      );
+    });
+
+    it('skips when summary already exists in inbox', async () => {
+      const mockInboxResponse = new Response(JSON.stringify({ value: [{ id: 'inbox-msg-id' }] }), { status: 200 });
+
+      const fetchMock = vi
+        .fn()
+        .mockResolvedValueOnce(mockInboxResponse);
+
+      vi.stubGlobal('fetch', fetchMock);
+
+      await OutlookProviderUtil.sendSelfSummaryReply(
+        'test-access-token',
+        { id: 'original-msg-id' },
+        'sender@example.com',
+        'Summary text',
+      );
+
+      expect(fetchMock).toHaveBeenCalledTimes(1);
+      const inboxUrl = fetchMock.mock.calls[0][0] as string;
+      expect(inboxUrl).toContain('/me/mailFolders/inbox/messages');
+    });
+
+    it('skips reply and only copies and deletes when summary already in sent items', async () => {
+      const mockSentItemsResponse = new Response(JSON.stringify({ value: [{ id: 'sent-msg-id' }] }), { status: 200 });
+      const mockCopyResponse = new Response(JSON.stringify({ id: 'copy-id-456' }), { status: 201 });
+      const mockDeleteResponse = new Response(null, { status: 204 });
+
+      const fetchMock = vi
+        .fn()
+        .mockResolvedValueOnce(mockEmptyResponse())    // inbox check (empty)
+        .mockResolvedValueOnce(mockSentItemsResponse)  // sentitems check (found)
+        .mockResolvedValueOnce(mockCopyResponse)       // copy
+        .mockResolvedValueOnce(mockDeleteResponse);    // delete
+
+      vi.stubGlobal('fetch', fetchMock);
+
+      await OutlookProviderUtil.sendSelfSummaryReply(
+        'test-access-token',
+        { id: 'original-msg-id' },
+        'sender@example.com',
+        'Summary text',
+      );
+
+      expect(fetchMock).toHaveBeenCalledTimes(4);
+
+      // No reply call
+      expect(fetchMock).toHaveBeenNthCalledWith(
+        3,
+        'https://graph.microsoft.com/v1.0/me/messages/sent-msg-id/copy',
+        expect.objectContaining({ method: 'POST' }),
+      );
       expect(fetchMock).toHaveBeenNthCalledWith(
         4,
         'https://graph.microsoft.com/v1.0/me/messages/sent-msg-id',
@@ -96,21 +169,28 @@ describe('OutlookProviderUtil', () => {
     it('throws when reply fails', async () => {
       const mockReplyResponse = new Response('Reply failed', { status: 500 });
 
-      vi.stubGlobal('fetch', vi.fn().mockResolvedValue(mockReplyResponse));
+      const fetchMock = vi
+        .fn()
+        .mockResolvedValueOnce(mockEmptyResponse())    // inbox check
+        .mockResolvedValueOnce(mockEmptyResponse())    // sentitems check
+        .mockResolvedValue(mockReplyResponse);          // reply fails
+
+      vi.stubGlobal('fetch', fetchMock);
 
       await expect(
         OutlookProviderUtil.sendSelfSummaryReply('test-access-token', { id: 'original-msg-id' }, 'sender@example.com', 'Summary text'),
       ).rejects.toThrow('Microsoft Graph send summary reply failed (500): Reply failed');
     });
 
-    it('throws when find returns no results', async () => {
+    it('throws when find returns no results after reply', async () => {
       const mockReplyResponse = new Response(null, { status: 202 });
-      const mockFindResponse = new Response(JSON.stringify({ value: [] }), { status: 200 });
 
       const fetchMock = vi
         .fn()
-        .mockResolvedValueOnce(mockReplyResponse)
-        .mockResolvedValueOnce(mockFindResponse);
+        .mockResolvedValueOnce(mockEmptyResponse())    // inbox check
+        .mockResolvedValueOnce(mockEmptyResponse())    // sentitems check
+        .mockResolvedValueOnce(mockReplyResponse)      // reply
+        .mockResolvedValueOnce(mockEmptyResponse());   // find after reply (empty)
 
       vi.stubGlobal('fetch', fetchMock);
 
@@ -119,14 +199,16 @@ describe('OutlookProviderUtil', () => {
       ).rejects.toThrow('Microsoft Graph did not return the sent summary message.');
     });
 
-    it('throws when find fails', async () => {
+    it('throws when find fails after reply', async () => {
       const mockReplyResponse = new Response(null, { status: 202 });
-      const mockFindResponse = new Response(JSON.stringify({ error: { message: 'Find failed' } }), { status: 500 });
+      const mockFindFailResponse = new Response(JSON.stringify({ error: { message: 'Find failed' } }), { status: 500 });
 
       const fetchMock = vi
         .fn()
-        .mockResolvedValueOnce(mockReplyResponse)
-        .mockResolvedValueOnce(mockFindResponse);
+        .mockResolvedValueOnce(mockEmptyResponse())      // inbox check
+        .mockResolvedValueOnce(mockEmptyResponse())      // sentitems check
+        .mockResolvedValueOnce(mockReplyResponse)        // reply
+        .mockResolvedValueOnce(mockFindFailResponse);    // find fails
 
       vi.stubGlobal('fetch', fetchMock);
 
@@ -138,19 +220,43 @@ describe('OutlookProviderUtil', () => {
     it('throws when copy fails', async () => {
       const mockReplyResponse = new Response(null, { status: 202 });
       const mockFindResponse = new Response(JSON.stringify({ value: [{ id: 'sent-msg-id' }] }), { status: 200 });
-      const mockCopyResponse = new Response('Copy failed', { status: 500 });
+      const mockCopyFailResponse = new Response('Copy failed', { status: 500 });
 
       const fetchMock = vi
         .fn()
-        .mockResolvedValueOnce(mockReplyResponse)
-        .mockResolvedValueOnce(mockFindResponse)
-        .mockResolvedValueOnce(mockCopyResponse);
+        .mockResolvedValueOnce(mockEmptyResponse())     // inbox check
+        .mockResolvedValueOnce(mockEmptyResponse())     // sentitems check
+        .mockResolvedValueOnce(mockReplyResponse)       // reply
+        .mockResolvedValueOnce(mockFindResponse)        // find after reply
+        .mockResolvedValueOnce(mockCopyFailResponse);   // copy fails
 
       vi.stubGlobal('fetch', fetchMock);
 
       await expect(
         OutlookProviderUtil.sendSelfSummaryReply('test-access-token', { id: 'original-msg-id' }, 'sender@example.com', 'Summary text'),
       ).rejects.toThrow('Microsoft Graph copy message failed (500): Copy failed');
+    });
+
+    it('throws when delete fails', async () => {
+      const mockReplyResponse = new Response(null, { status: 202 });
+      const mockFindResponse = new Response(JSON.stringify({ value: [{ id: 'sent-msg-id' }] }), { status: 200 });
+      const mockCopyResponse = new Response(JSON.stringify({ id: 'copy-id-456' }), { status: 201 });
+      const mockDeleteFailResponse = new Response('Delete failed', { status: 500 });
+
+      const fetchMock = vi
+        .fn()
+        .mockResolvedValueOnce(mockEmptyResponse())       // inbox check
+        .mockResolvedValueOnce(mockEmptyResponse())       // sentitems check
+        .mockResolvedValueOnce(mockReplyResponse)         // reply
+        .mockResolvedValueOnce(mockFindResponse)          // find after reply
+        .mockResolvedValueOnce(mockCopyResponse)          // copy
+        .mockResolvedValueOnce(mockDeleteFailResponse);   // delete fails
+
+      vi.stubGlobal('fetch', fetchMock);
+
+      await expect(
+        OutlookProviderUtil.sendSelfSummaryReply('test-access-token', { id: 'original-msg-id' }, 'sender@example.com', 'Summary text'),
+      ).rejects.toThrow('Microsoft Graph delete message failed (500): Delete failed');
     });
   });
 });


### PR DESCRIPTION
Refactor `sendSelfSummaryReply` to check existing state in Inbox and Sent Items before performing sub-operations. On retry, the method now skips already-completed steps:

- If the summary message is already in Inbox → all steps done, return early.
- If in Sent Items only → reply was sent, skip it; only copy + delete.
- If in neither → full first-attempt flow (reply, find, copy, delete).

Add `findSummaryMessageInFolder` private helper to search a given folder for messages with the `X-Mail-Otter-Summary` header, shared by both the idempotency checks and the existing `findSentSummaryMessage`.

Change `deleteMessage` to throw on non-404 errors (was silently logging) so that delete failures are properly retried by the workflow step policy.

Update tests to cover the idempotent paths and verify the new 6-call flow (inbox check, sentitems check, reply, find, copy, delete) for first attempts, plus a new test verifying delete errors now throw.

BREAKING BEHAVIOR: `deleteMessage` now throws instead of logging, so delete failures will trigger workflow step retries as intended.