### PR TITLE
Replace Unsupported internetMessageHeaders $filter With Subject Marker

### DIFF
--- a/packages/provider-clients/src/OutlookProviderUtil.ts
+++ b/packages/provider-clients/src/OutlookProviderUtil.ts
@@ -226,6 +226,8 @@ class OutlookProviderUtil {
     const sinkAddress: string = atIndex !== -1
       ? `${mailboxAddress.slice(0, atIndex)}+sink${mailboxAddress.slice(atIndex)}`
       : mailboxAddress;
+    const marker: string = crypto.randomUUID();
+    const originalSubject: string = originalMessage.subject || '';
     const response: Response = await fetch(
       `https://graph.microsoft.com/v1.0/me/messages/${encodeURIComponent(originalMessage.id)}/reply`,
       {
@@ -236,6 +238,7 @@ class OutlookProviderUtil {
         },
         body: JSON.stringify({
           message: {
+            subject: `[OtterSum-${marker}] Re: ${originalSubject}`,
             body: {
               contentType: 'html',
               content: summary,
@@ -257,16 +260,18 @@ class OutlookProviderUtil {
     if (!response.ok) {
       throw OutlookProviderUtil.createApiError('send summary reply', response, await response.text());
     }
-    const sentMessageId: string = await OutlookProviderUtil.findSentSummaryMessage(accessToken);
+    const sentMessageId: string = await OutlookProviderUtil.findSentSummaryMessage(accessToken, marker);
     await OutlookProviderUtil.copyMessage(accessToken, sentMessageId, 'inbox');
     await OutlookProviderUtil.deleteMessage(accessToken, sentMessageId);
   }
 
-  private static async findSummaryMessageInFolder(accessToken: string, folderId: string): Promise<string | null> {
+  private static async findSummaryMessageInFolder(accessToken: string, folderId: string, marker?: string): Promise<string | null> {
     const url: URL = new URL(`https://graph.microsoft.com/v1.0/me/mailFolders/${folderId}/messages`);
     url.searchParams.set(
       '$filter',
-      `internetMessageHeaders/any(h:h/name eq 'X-Mail-Otter-Summary' and h/value eq 'true')`,
+      marker
+        ? `contains(subject, 'OtterSum-${marker}')`
+        : `contains(subject, '[OtterSum-')`,
     );
     url.searchParams.set('$orderby', 'sentDateTime desc');
     url.searchParams.set('$top', '1');
@@ -277,8 +282,8 @@ class OutlookProviderUtil {
     return data.value && data.value.length > 0 ? data.value[0].id : null;
   }
 
-  private static async findSentSummaryMessage(accessToken: string): Promise<string> {
-    const id: string | null = await OutlookProviderUtil.findSummaryMessageInFolder(accessToken, 'sentitems');
+  private static async findSentSummaryMessage(accessToken: string, marker: string): Promise<string> {
+    const id: string | null = await OutlookProviderUtil.findSummaryMessageInFolder(accessToken, 'sentitems', marker);
     if (!id) {
       throw new ProviderApiRetryableError('Microsoft Graph did not return the sent summary message.');
     }

--- a/test/utils/OutlookProviderUtil.test.ts
+++ b/test/utils/OutlookProviderUtil.test.ts
@@ -44,12 +44,12 @@ describe('OutlookProviderUtil', () => {
       // Step 1: inbox idempotency check
       const inboxUrl = fetchMock.mock.calls[0][0] as string;
       expect(inboxUrl).toContain('/me/mailFolders/inbox/messages');
-      expect(inboxUrl).toContain('X-Mail-Otter-Summary');
+      expect(inboxUrl).toContain(encodeURIComponent('[OtterSum-'));
 
       // Step 2: sent items idempotency check
       const sentItemsCheckUrl = fetchMock.mock.calls[1][0] as string;
       expect(sentItemsCheckUrl).toContain('/me/mailFolders/sentitems/messages');
-      expect(sentItemsCheckUrl).toContain('X-Mail-Otter-Summary');
+      expect(sentItemsCheckUrl).toContain(encodeURIComponent('[OtterSum-'));
 
       // Step 3: reply with sink address
       expect(fetchMock).toHaveBeenNthCalledWith(
@@ -64,30 +64,22 @@ describe('OutlookProviderUtil', () => {
 
       expect(replyHeaders['Content-Type']).toBe('application/json');
       expect(replyHeaders['Authorization']).toBe('Bearer test-access-token');
-      expect(parsedBody).toEqual({
-        message: {
-          body: {
-            contentType: 'html',
-            content: htmlSummary,
-          },
-          toRecipients: [
-            {
-              emailAddress: {
-                address: 'sender+sink@example.com',
-              },
-            },
-          ],
-          internetMessageHeaders: [
-            { name: 'X-Mail-Otter-Summary', value: 'true' },
-          ],
-        },
+      expect(parsedBody.message.subject).toMatch(/^\[OtterSum-/);
+      expect(parsedBody.message.body).toEqual({
+        contentType: 'html',
+        content: htmlSummary,
       });
+      expect(parsedBody.message.toRecipients).toEqual([
+        { emailAddress: { address: 'sender+sink@example.com' } },
+      ]);
+      expect(parsedBody.message.internetMessageHeaders).toEqual([
+        { name: 'X-Mail-Otter-Summary', value: 'true' },
+      ]);
 
       // Step 4: find sent summary message (also in sentitems folder)
       const findUrl = fetchMock.mock.calls[3][0] as string;
       expect(findUrl).toContain('/me/mailFolders/sentitems/messages');
-      expect(findUrl).toContain('internetMessageHeaders');
-      expect(findUrl).toContain('X-Mail-Otter-Summary');
+      expect(findUrl).toContain('OtterSum-');
       expect(findUrl).toContain(encodeURIComponent('$top') + '=1');
       expect(findUrl).toContain(encodeURIComponent('$orderby') + '=sentDateTime+desc');
 


### PR DESCRIPTION
Microsoft Graph API does not support $filter on the `internetMessageHeaders` property, causing a 400 error when `OutlookProviderUtil.findSummaryMessageInFolder` tried to find sent summary messages by the `X-Mail-Otter-Summary` custom header.

Fix: embed a unique UUID marker in the reply subject as `[OtterSum-<uuid>]` and use `$filter=contains(subject, 'OtterSum-<uuid>')`, which IS supported. Idempotency checks use the broader `contains(subject, '[OtterSum-')` pattern.