### PR TITLE
Disable Pnpm Minimum Release Age

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,0 +1,1 @@
+minimum-release-age=0

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -5,7 +5,3 @@ allowBuilds:
   esbuild: true
   sharp: true
   workerd: true
-minimumReleaseAgeExclude:
-  - miniflare@4.20260520.0
-  - terser@5.48.0
-  - wrangler@4.93.1


### PR DESCRIPTION
Set minimum-release-age to 0 in .npmrc to disable pnpm's minimum release age security feature for all packages. Remove now-unnecessary minimumReleaseAgeExclude entries from pnpm-workspace.yaml since the restriction is disabled globally.