### PR TITLE
Use Startswith Instead Of Contains In Microsoft Graph Filter

### DIFF
--- a/packages/provider-clients/src/OutlookProviderUtil.ts
+++ b/packages/provider-clients/src/OutlookProviderUtil.ts
@@ -270,8 +270,8 @@ class OutlookProviderUtil {
     url.searchParams.set(
       '$filter',
       marker
-        ? `contains(subject, 'OtterSum-${marker}')`
-        : `contains(subject, '[OtterSum-')`,
+        ? `startswith(subject, '[OtterSum-${marker}]')`
+        : `startswith(subject, '[OtterSum-')`,
     );
     url.searchParams.set('$orderby', 'sentDateTime desc');
     url.searchParams.set('$top', '1');


### PR DESCRIPTION
Combining $filter=contains() with $orderby on a different property causes Microsoft Graph API to return a 400 error: 'The restriction or sort order is too complex for this operation.'

Replacing contains() with startswith() resolves the issue because startswith() is index-friendly and compatible with $orderby in Exchange/Graph query plans. The summary subject always starts with '[OtterSum-', so this is functionally equivalent.