### PR TITLE
Add Hash Prefix To Audit Log Sequence Numbers

### DIFF
--- a/apps/web/src/SpaApp.tsx
+++ b/apps/web/src/SpaApp.tsx
@@ -1502,7 +1502,7 @@ function AuditLogsModal({
                         {attemptNumber != null && <span className="ml-2 text-[#9ca3af]">(Attempt {attemptNumber})</span>}
                       </div>
                       <div className="text-xs text-[#9ca3af] mt-0.5">
-                        <span className="inline-flex items-center justify-center w-5 h-5 rounded-full bg-[#2d3745] text-[#cbd5e1] text-[10px] font-medium mr-2 shrink-0">{logs.length - index}</span>
+                        <span className="inline-flex items-center justify-center w-5 h-5 rounded-full bg-[#2d3745] text-[#cbd5e1] text-[10px] font-medium mr-2 shrink-0">#{logs.length - index}</span>
                         {formatTimestamp(log.createdAt)}
                         <span className="ml-2 inline-block px-1.5 py-0.5 rounded bg-[#2d3745] text-[#cbd5e1] text-[10px] uppercase">{log.eventType}</span>
                       </div>


### PR DESCRIPTION
Prepend `#` to the reverse-sequence number in AuditLogsModal so users immediately recognize the number as a sequence identifier rather than a raw count.