### PR TITLE
Fix Summary Send Idempotency And Graph Filter Complexity

### DIFF
--- a/packages/provider-clients/src/OutlookProviderUtil.ts
+++ b/packages/provider-clients/src/OutlookProviderUtil.ts
@@ -207,14 +207,16 @@ class OutlookProviderUtil {
     mailboxAddress: string,
     summary: string,
   ): Promise<void> {
-    // Idempotency: if summary already in Inbox, all previous steps completed
-    const inboxMsgId: string | null = await OutlookProviderUtil.findSummaryMessageInFolder(accessToken, 'inbox');
+    const marker: string = await OutlookProviderUtil.deriveMessageMarker(originalMessage.id);
+
+    // Idempotency: if this email's summary already in Inbox, all steps completed
+    const inboxMsgId: string | null = await OutlookProviderUtil.findSummaryMessageInFolder(accessToken, 'inbox', marker);
     if (inboxMsgId) {
       return;
     }
 
-    // If summary in Sent Items only, reply was sent but copy+delete are pending
-    const sentMsgId: string | null = await OutlookProviderUtil.findSummaryMessageInFolder(accessToken, 'sentitems');
+    // If this email's summary in Sent Items only, reply was sent but copy+delete are pending
+    const sentMsgId: string | null = await OutlookProviderUtil.findSummaryMessageInFolder(accessToken, 'sentitems', marker);
     if (sentMsgId) {
       await OutlookProviderUtil.copyMessage(accessToken, sentMsgId, 'inbox');
       await OutlookProviderUtil.deleteMessage(accessToken, sentMsgId);
@@ -226,7 +228,6 @@ class OutlookProviderUtil {
     const sinkAddress: string = atIndex !== -1
       ? `${mailboxAddress.slice(0, atIndex)}+sink${mailboxAddress.slice(atIndex)}`
       : mailboxAddress;
-    const marker: string = crypto.randomUUID();
     const originalSubject: string = originalMessage.subject || '';
     const response: Response = await fetch(
       `https://graph.microsoft.com/v1.0/me/messages/${encodeURIComponent(originalMessage.id)}/reply`,
@@ -273,7 +274,6 @@ class OutlookProviderUtil {
         ? `startswith(subject, '[OtterSum-${marker}]')`
         : `startswith(subject, '[OtterSum-')`,
     );
-    url.searchParams.set('$orderby', 'sentDateTime desc');
     url.searchParams.set('$top', '1');
     url.searchParams.set('$select', 'id');
     const data = await OutlookProviderUtil.fetchJson<{
@@ -341,6 +341,15 @@ class OutlookProviderUtil {
     if (!response.ok && response.status !== 404) {
       throw OutlookProviderUtil.createApiError('delete message', response, await response.text());
     }
+  }
+
+  private static async deriveMessageMarker(messageId: string): Promise<string> {
+    const bytes = new TextEncoder().encode(messageId);
+    const hashBuffer = await crypto.subtle.digest('SHA-256', bytes);
+    return Array.from(new Uint8Array(hashBuffer))
+      .slice(0, 8)
+      .map((b) => b.toString(16).padStart(2, '0'))
+      .join('');
   }
 }
 

--- a/test/utils/OutlookProviderUtil.test.ts
+++ b/test/utils/OutlookProviderUtil.test.ts
@@ -1,6 +1,9 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { OutlookProviderUtil } from '@mail-otter/provider-clients/outlook';
 
+// SHA-256('original-msg-id').slice(0, 8 bytes) as hex = '45da5cec0da75b4c'
+const EXPECTED_MARKER = '45da5cec0da75b4c';
+
 function mockEmptyResponse(): Response {
   return new Response(JSON.stringify({ value: [] }), { status: 200 });
 }
@@ -41,15 +44,17 @@ describe('OutlookProviderUtil', () => {
 
       expect(fetchMock).toHaveBeenCalledTimes(6);
 
-      // Step 1: inbox idempotency check
+      // Step 1: inbox idempotency check uses deterministic marker, no $orderby
       const inboxUrl = fetchMock.mock.calls[0][0] as string;
       expect(inboxUrl).toContain('/me/mailFolders/inbox/messages');
-      expect(inboxUrl).toContain(encodeURIComponent('[OtterSum-'));
+      expect(inboxUrl).toContain(encodeURIComponent(`[OtterSum-${EXPECTED_MARKER}]`));
+      expect(inboxUrl).not.toContain('orderby');
 
-      // Step 2: sent items idempotency check
+      // Step 2: sent items idempotency check uses same deterministic marker
       const sentItemsCheckUrl = fetchMock.mock.calls[1][0] as string;
       expect(sentItemsCheckUrl).toContain('/me/mailFolders/sentitems/messages');
-      expect(sentItemsCheckUrl).toContain(encodeURIComponent('[OtterSum-'));
+      expect(sentItemsCheckUrl).toContain(encodeURIComponent(`[OtterSum-${EXPECTED_MARKER}]`));
+      expect(sentItemsCheckUrl).not.toContain('orderby');
 
       // Step 3: reply with sink address
       expect(fetchMock).toHaveBeenNthCalledWith(
@@ -64,7 +69,7 @@ describe('OutlookProviderUtil', () => {
 
       expect(replyHeaders['Content-Type']).toBe('application/json');
       expect(replyHeaders['Authorization']).toBe('Bearer test-access-token');
-      expect(parsedBody.message.subject).toMatch(/^\[OtterSum-/);
+      expect(parsedBody.message.subject).toBe(`[OtterSum-${EXPECTED_MARKER}] Re: `);
       expect(parsedBody.message.body).toEqual({
         contentType: 'html',
         content: htmlSummary,
@@ -76,12 +81,12 @@ describe('OutlookProviderUtil', () => {
         { name: 'X-Mail-Otter-Summary', value: 'true' },
       ]);
 
-      // Step 4: find sent summary message (also in sentitems folder)
+      // Step 4: find sent summary message by same marker, no $orderby
       const findUrl = fetchMock.mock.calls[3][0] as string;
       expect(findUrl).toContain('/me/mailFolders/sentitems/messages');
-      expect(findUrl).toContain('OtterSum-');
+      expect(findUrl).toContain(encodeURIComponent(`[OtterSum-${EXPECTED_MARKER}]`));
       expect(findUrl).toContain(encodeURIComponent('$top') + '=1');
-      expect(findUrl).toContain(encodeURIComponent('$orderby') + '=sentDateTime+desc');
+      expect(findUrl).not.toContain('orderby');
 
       // Step 5: copy sent message to inbox
       expect(fetchMock).toHaveBeenNthCalledWith(
@@ -120,6 +125,7 @@ describe('OutlookProviderUtil', () => {
       expect(fetchMock).toHaveBeenCalledTimes(1);
       const inboxUrl = fetchMock.mock.calls[0][0] as string;
       expect(inboxUrl).toContain('/me/mailFolders/inbox/messages');
+      expect(inboxUrl).toContain(encodeURIComponent(`[OtterSum-${EXPECTED_MARKER}]`));
     });
 
     it('skips reply and only copies and deletes when summary already in sent items', async () => {


### PR DESCRIPTION
Two bugs in `sendSelfSummaryReply`:

1. **400 error — filter+orderby complexity**: Combining `$filter=startswith(subject, ...)` with `$orderby=sentDateTime desc` on a different property causes Microsoft Graph to return "The restriction or sort order is too complex for this operation." Fixed by removing `$orderby` from `findSummaryMessageInFolder`; `$top=1` with a subject-based filter is sufficient and within Graph query limits.

2. **Correctness bug — overly broad idempotency checks**: The inbox and sent-items checks searched for any `[OtterSum-` prefix, which matches summaries from prior emails. For a user with multiple processed emails, the inbox check would find a previous email's summary and return early, silently skipping the current email. Fixed by deriving a deterministic 16-char hex marker from the original message ID (SHA-256 truncated to 8 bytes) so each email's summary is uniquely identifiable across retries without relying on a random UUID.

3. **Retry-unsafety**: The old `crypto.randomUUID()` marker meant workflow retries after the reply was sent but before the find/copy/delete steps would generate a new UUID, causing `findSentSummaryMessage` to fail. The deterministic marker resolves this — same message ID always produces the same marker.