### PR TITLE
Hide Attempt Counter When Attempt Is 1

### DIFF
--- a/apps/web/src/SpaApp.tsx
+++ b/apps/web/src/SpaApp.tsx
@@ -1525,7 +1525,7 @@ function AuditLogsModal({
                     <div className="min-w-0">
                       <div className="text-sm font-medium text-[#e5e7eb]">
                         {log.eventLabel || auditEventLabels[log.eventType] || log.eventType}
-                        {attemptNumber != null && <span className="ml-2 text-[#9ca3af]">(Attempt {attemptNumber})</span>}
+                        {attemptNumber != null && attemptNumber > 1 && <span className="ml-2 text-[#9ca3af]">(Attempt {attemptNumber})</span>}
                       </div>
                       <div className="text-xs text-[#9ca3af] mt-0.5">
                         <span className="inline-flex items-center justify-center w-5 h-5 rounded-full bg-[#2d3745] text-[#cbd5e1] text-[10px] font-medium mr-2 shrink-0">#{logs.length - index}</span>

--- a/packages/backend-services/src/email/EmailProcessingUtil.ts
+++ b/packages/backend-services/src/email/EmailProcessingUtil.ts
@@ -545,7 +545,7 @@ class EmailProcessingUtil {
       sourceDocumentId,
       eventType: CONTEXT_AUDIT_EVENT_PROCESSING_STARTED,
       eventLabel: 'Email processing started',
-      eventData: retryAttempt !== undefined ? { attempt: retryAttempt } : undefined,
+      eventData: retryAttempt != null && retryAttempt > 1 ? { attempt: retryAttempt } : undefined,
       severity: CONTEXT_AUDIT_LOG_SEVERITY_INFO,
     });
   }
@@ -565,7 +565,7 @@ class EmailProcessingUtil {
       sourceDocumentId,
       eventType: CONTEXT_AUDIT_EVENT_SUMMARY_GENERATED,
       eventLabel: 'AI summary generated',
-      eventData: retryAttempt !== undefined ? { attempt: retryAttempt } : undefined,
+      eventData: retryAttempt != null && retryAttempt > 1 ? { attempt: retryAttempt } : undefined,
       severity: CONTEXT_AUDIT_LOG_SEVERITY_INFO,
     });
   }
@@ -589,7 +589,7 @@ class EmailProcessingUtil {
       eventData: {
         actionCount: actions.length,
         actionTypes: actions.map((a) => a.action.actionType),
-        ...(retryAttempt !== undefined ? { attempt: retryAttempt } : {}),
+        ...(retryAttempt != null && retryAttempt > 1 ? { attempt: retryAttempt } : {}),
       },
       severity: CONTEXT_AUDIT_LOG_SEVERITY_INFO,
     });
@@ -610,7 +610,7 @@ class EmailProcessingUtil {
       sourceDocumentId,
       eventType: CONTEXT_AUDIT_EVENT_SUMMARY_SENT,
       eventLabel: 'Summary email sent',
-      eventData: retryAttempt !== undefined ? { attempt: retryAttempt } : undefined,
+      eventData: retryAttempt != null && retryAttempt > 1 ? { attempt: retryAttempt } : undefined,
       severity: CONTEXT_AUDIT_LOG_SEVERITY_INFO,
     });
   }
@@ -634,7 +634,7 @@ class EmailProcessingUtil {
       eventData: {
         error: error.message,
         errorType: error.constructor?.name,
-        ...(retryAttempt !== undefined ? { attempt: retryAttempt } : {}),
+        ...(retryAttempt != null && retryAttempt > 1 ? { attempt: retryAttempt } : {}),
       },
       severity: error instanceof NonRetryableError ? CONTEXT_AUDIT_LOG_SEVERITY_ERROR : CONTEXT_AUDIT_LOG_SEVERITY_WARNING,
     });


### PR DESCRIPTION
`context.attempt` in Cloudflare Workflows starts at 1 for the first execution of a step. Previously, every first-run log entry was stored with `attempt: 1` and displayed as "(Attempt 1)" in the Context Audit Logs panel — even when no retry had occurred. The label is only meaningful for actual retries (attempt ≥ 2).

- Backend: only write `attempt` into `eventData` when `retryAttempt > 1` (matches the existing `isRetryAttempt()` convention)
- UI: guard the "(Attempt X)" label with `attemptNumber > 1` to suppress it for existing stored logs that already carry `attempt: 1`