### PR TITLE
Remove Plain-Text Action Items From Summary

### DIFF
--- a/packages/backend-services/src/email/EmailProcessingUtil.ts
+++ b/packages/backend-services/src/email/EmailProcessingUtil.ts
@@ -385,15 +385,9 @@ class EmailProcessingUtil {
   }
 
   private static withActionSection(summaryHtml: string, actions: CreatedEmailAction[]): string {
-    let body: string = summaryHtml;
-    if (actions.length > 0) {
-      const actionLiHtml: string = ActionService.renderActionItems(actions).join('\n');
-      const lastUlIndex: number = summaryHtml.lastIndexOf('</ul>');
-      if (lastUlIndex !== -1) {
-        body = summaryHtml.slice(0, lastUlIndex) + actionLiHtml + '\n' + summaryHtml.slice(lastUlIndex);
-      }
-    }
-    return [body, '', '<p><em>Powered by Mail-Otter</em></p>'].join('\n');
+    const actionSection = ActionService.renderEmailActionSection(actions);
+    const parts = [summaryHtml, actionSection].filter(Boolean);
+    return [...parts, '', '<p><em>Powered by Mail-Otter</em></p>'].join('\n');
   }
 
   private static async resolveSummaryModel(env: EmailProcessingEnv, estimatedPromptText: string): Promise<string> {

--- a/packages/backend-services/src/email/EmailSummaryUtil.ts
+++ b/packages/backend-services/src/email/EmailSummaryUtil.ts
@@ -5,16 +5,12 @@ import type { EmailActionProposal } from '@mail-otter/shared/model';
 const SUMMARY_JSON_SCHEMA = {
   type: 'object',
   additionalProperties: false,
-  required: ['gist', 'keyDetails', 'actionItems', 'actions'],
+  required: ['gist', 'keyDetails', 'actions'],
   properties: {
     gist: {
       type: 'string',
     },
     keyDetails: {
-      type: 'array',
-      items: { type: 'string' },
-    },
-    actionItems: {
       type: 'array',
       items: { type: 'string' },
     },
@@ -129,11 +125,9 @@ class EmailSummaryUtil {
   private static buildSummaryInstructions(): string {
     return [
       'You are a helpful assistant that summarizes emails for a mailbox owner.',
-      'Return only JSON with this exact shape: {"gist":"one sentence","keyDetails":["short fact"],"actionItems":["owner deadline or request"],"actions":[{"type":"calendar.add_event|email.draft_reply|external.open_link|manual.todo","title":"short title","description":"what will happen","confidence":0.8,"parameters":{}}]}.',
+      'Return only JSON with this exact shape: {"gist":"one sentence","keyDetails":["short fact"],"actions":[{"type":"calendar.add_event|email.draft_reply|external.open_link|manual.todo","title":"short title","description":"what will happen","confidence":0.8,"parameters":{}}]}.',
       'Keep the gist to one sentence.',
       'Details must be short factual bullets copied from the email when possible.',
-      'Actions must include deadlines or owners when present.',
-      'If there are no action items, return an empty array.',
       'Actions are optional executable proposals; return an empty actions array when no safe action exists.',
       'Use calendar.add_event only when start time, end time, and timezone are clear; parameters must include eventTitle, startTime, endTime, timeZone, and optional location or notes.',
       'Use email.draft_reply when the owner should respond; parameters must include draftBody and optional draftSubject.',
@@ -248,7 +242,6 @@ class EmailSummaryUtil {
     return {
       gist: EmailSummaryUtil.normalizeSentence(parsed.gist),
       keyDetails: EmailSummaryUtil.normalizeItems(parsed.keyDetails),
-      actionItems: EmailSummaryUtil.normalizeItems(parsed.actionItems),
       actions: EmailSummaryUtil.normalizeActionProposals(parsed.actions),
     };
   }
@@ -256,7 +249,6 @@ class EmailSummaryUtil {
   static renderHtmlSummary(summary: EmailSummary): string {
     const gist: string = EmailSummaryUtil.normalizeSentence(summary.gist) || 'No clear gist available.';
     const keyDetails: string[] = EmailSummaryUtil.normalizeItems(summary.keyDetails);
-    const actionItems: string[] = EmailSummaryUtil.normalizeItems(summary.actionItems);
 
     return [
       `<p><strong>Gist:</strong> ${EmailContentUtil.sanitizeHtml(gist)}</p>`,
@@ -264,11 +256,6 @@ class EmailSummaryUtil {
       '<p><strong>Details:</strong></p>',
       '<ul>',
       ...EmailSummaryUtil.renderHtmlList(keyDetails, '<li>No key details noted.</li>'),
-      '</ul>',
-      '',
-      '<p><strong>Actions:</strong></p>',
-      '<ul>',
-      ...EmailSummaryUtil.renderHtmlList(actionItems, '<li>None.</li>'),
       '</ul>',
     ].join('\n');
   }
@@ -290,7 +277,6 @@ class EmailSummaryUtil {
     return {
       gist: gistLine,
       keyDetails: bulletLines,
-      actionItems: [],
       actions: [],
     };
   }
@@ -428,8 +414,6 @@ class EmailSummaryUtil {
       typeof candidate.gist === 'string' &&
       Array.isArray(candidate.keyDetails) &&
       candidate.keyDetails.every((item: unknown): boolean => typeof item === 'string') &&
-      Array.isArray(candidate.actionItems) &&
-      candidate.actionItems.every((item: unknown): boolean => typeof item === 'string') &&
       (candidate.actions === undefined || Array.isArray(candidate.actions))
     );
   }
@@ -457,7 +441,6 @@ class EmailSummaryUtil {
 interface EmailSummary {
   gist: string;
   keyDetails: string[];
-  actionItems: string[];
   actions: EmailActionProposal[];
 }
 

--- a/test/utils/EmailSummaryUtil.test.ts
+++ b/test/utils/EmailSummaryUtil.test.ts
@@ -8,7 +8,6 @@ describe('EmailSummaryUtil', () => {
         response: JSON.stringify({
           gist: 'The sender wants approval for the May campaign budget.',
           keyDetails: ['Budget requested is $12,000.', 'Launch is planned for May 20.'],
-          actionItems: ['Approve or reject the budget by Friday.'],
         }),
       }),
     } as unknown as Ai;
@@ -20,11 +19,6 @@ describe('EmailSummaryUtil', () => {
 <ul>
 <li>Budget requested is $12,000.</li>
 <li>Launch is planned for May 20.</li>
-</ul>
-
-<p><strong>Actions:</strong></p>
-<ul>
-<li>Approve or reject the budget by Friday.</li>
 </ul>`);
     expect(ai.run).toHaveBeenCalledWith(
       '@cf/meta/llama-3.1-8b-instruct',
@@ -42,7 +36,6 @@ describe('EmailSummaryUtil', () => {
         response: JSON.stringify({
           gist: 'The email shares a status update with no requests.',
           keyDetails: [],
-          actionItems: [],
         }),
       }),
     } as unknown as Ai;
@@ -53,11 +46,6 @@ describe('EmailSummaryUtil', () => {
 <p><strong>Details:</strong></p>
 <ul>
 <li>No key details noted.</li>
-</ul>
-
-<p><strong>Actions:</strong></p>
-<ul>
-<li>None.</li>
 </ul>`);
   });
 
@@ -92,8 +80,7 @@ describe('EmailSummaryUtil', () => {
 \`\`\`json
 {
   "gist": "The sender needs approval for the budget.",
-  "keyDetails": ["Budget is $12,000."],
-  "actionItems": ["Approve the budget by Friday."]
+  "keyDetails": ["Budget is $12,000."]
 }
 \`\`\``,
       }),
@@ -105,11 +92,6 @@ describe('EmailSummaryUtil', () => {
 <p><strong>Details:</strong></p>
 <ul>
 <li>Budget is $12,000.</li>
-</ul>
-
-<p><strong>Actions:</strong></p>
-<ul>
-<li>Approve the budget by Friday.</li>
 </ul>`);
     expect(ai.run).toHaveBeenCalledWith(
       '@cf/openai/gpt-oss-120b',
@@ -138,7 +120,6 @@ describe('EmailSummaryUtil', () => {
                 text: JSON.stringify({
                   gist: 'The email shares a launch update.',
                   keyDetails: ['Launch starts Monday.'],
-                  actionItems: [],
                 }),
               },
             ],
@@ -153,11 +134,6 @@ describe('EmailSummaryUtil', () => {
 <p><strong>Details:</strong></p>
 <ul>
 <li>Launch starts Monday.</li>
-</ul>
-
-<p><strong>Actions:</strong></p>
-<ul>
-<li>None.</li>
 </ul>`);
   });
 
@@ -167,7 +143,6 @@ describe('EmailSummaryUtil', () => {
         response: JSON.stringify({
           gist: 'The email asks for feedback.',
           keyDetails: ['Review is due Tuesday.'],
-          actionItems: ['Send feedback by Tuesday.'],
         }),
         usage: {
           prompt_tokens: 1000,
@@ -194,7 +169,6 @@ describe('EmailSummaryUtil', () => {
         output_text: JSON.stringify({
           gist: 'The email asks for feedback.',
           keyDetails: ['Review is due Tuesday.'],
-          actionItems: ['Send feedback by Tuesday.'],
         }),
         usage: {
           input_tokens: 1000,
@@ -228,7 +202,6 @@ describe('EmailSummaryUtil', () => {
               content: JSON.stringify({
                 gist: 'The email asks for feedback.',
                 keyDetails: ['Review is due Tuesday.'],
-                actionItems: ['Send feedback by Tuesday.'],
               }),
             },
           },


### PR DESCRIPTION
The AI schema previously included `actionItems: string[]` — a simple plain-text list rendered as a static `<strong>Actions:</strong>` section in each summary email. These items are now redundant because the Mail-Otter callback action system (`email_summary_actions`) already captures the same intent with structured, token-secured, executable links.

Remove `actionItems` from:
- the JSON schema sent to Workers AI
- the AI prompt instructions
- the `EmailSummary` interface and all parse/render paths in `EmailSummaryUtil`
- the splice logic in `EmailProcessingUtil.withActionSection`, which now delegates entirely to `ActionService.renderEmailActionSection` for a clean "Available actions:" block appended after the summary

Update `EmailSummaryUtil` tests to reflect the simplified HTML output.