### PR TITLE
Stop Watch On Microsoft Tolerates Transient Graph Errors

### DIFF
--- a/packages/backend-services/src/subscription/WatchService.ts
+++ b/packages/backend-services/src/subscription/WatchService.ts
@@ -41,10 +41,15 @@ class WatchService {
     const subscriptionDAO = new ProviderSubscriptionDAO(env.DB);
     const subscription: ProviderSubscription | undefined = await subscriptionDAO.getByApplication(application.applicationId);
     const accessToken: string = await OAuth2AccessTokenService.getAccessToken(application.applicationId, env);
-    if (application.providerId === PROVIDER_GOOGLE_GMAIL) {
-      await GmailProviderUtil.stopWatch(accessToken);
-    } else if (application.providerId === PROVIDER_MICROSOFT_OUTLOOK && subscription?.externalSubscriptionId) {
-      await OutlookProviderUtil.deleteSubscription(accessToken, subscription.externalSubscriptionId);
+    try {
+      if (application.providerId === PROVIDER_GOOGLE_GMAIL) {
+        await GmailProviderUtil.stopWatch(accessToken);
+      } else if (application.providerId === PROVIDER_MICROSOFT_OUTLOOK && subscription?.externalSubscriptionId) {
+        await OutlookProviderUtil.deleteSubscription(accessToken, subscription.externalSubscriptionId);
+      }
+    } catch (error: unknown) {
+      const message = error instanceof Error ? error.message : String(error);
+      console.warn(`[WatchService] Provider unsubscribe failed, proceeding with local stop: ${message}`);
     }
     await subscriptionDAO.markStopped(application.applicationId);
   }


### PR DESCRIPTION
When stopping an Outlook watch, Microsoft Graph occasionally returns 503 (ServiceUnavailable) for the DELETE subscription call. Previously this ProviderApiRetryableError propagated uncaught, leaving the local DB in an "active" state and returning 500 to the user — with no recovery path.

Wrap the provider unsubscribe call in a try/catch so that transient provider failures are logged as warnings and local cleanup (markStopped) always proceeds. The remote Graph subscription will expire naturally via its TTL; honoring the user's intent to stop locally is more important than guaranteeing remote teardown.