### PR TITLE
Pruning Tasks Use Unix Seconds For Retention Thresholds

### DIFF
--- a/apps/background/src/scheduled/ContextDeletionRunPruningTask.ts
+++ b/apps/background/src/scheduled/ContextDeletionRunPruningTask.ts
@@ -13,7 +13,7 @@ class ContextDeletionRunPruningTask extends IScheduledTask<ContextDeletionRunPru
     _ctx: ExecutionContext,
   ): Promise<void> {
     const retentionDays: number = ConfigurationManager.getContextDeletionRunRetentionDays(env);
-    const olderThan: number = Date.now() - retentionDays * 86400 * 1000;
+    const olderThan: number = Math.floor(Date.now() / 1000) - retentionDays * 86400;
     const sessionEnv = createD1SessionEnv(env);
     const dao = new ApplicationContextDAO(sessionEnv.DB);
 

--- a/apps/background/src/scheduled/ProcessedMessagePruningTask.ts
+++ b/apps/background/src/scheduled/ProcessedMessagePruningTask.ts
@@ -17,7 +17,7 @@ class ProcessedMessagePruningTask extends IScheduledTask<ProcessedMessagePruning
     _ctx: ExecutionContext,
   ): Promise<void> {
     const retentionDays: number = ConfigurationManager.getProcessedMessageRetentionDays(env);
-    const olderThan: number = Date.now() - retentionDays * 86400 * 1000;
+    const olderThan: number = Math.floor(Date.now() / 1000) - retentionDays * 86400;
     const sessionEnv = createD1SessionEnv(env);
     const dao = new ProcessedMessageDAO(sessionEnv.DB);
 

--- a/apps/background/src/scheduled/StaleContextDocumentPruningTask.ts
+++ b/apps/background/src/scheduled/StaleContextDocumentPruningTask.ts
@@ -14,8 +14,8 @@ class StaleContextDocumentPruningTask extends IScheduledTask<StaleContextDocumen
   ): Promise<void> {
     const deletedGraceDays: number = ConfigurationManager.getStaleContextDocumentDeletedGraceDays(env);
     const errorGraceDays: number = ConfigurationManager.getStaleContextDocumentErrorGraceDays(env);
-    const deletedBefore: number = Date.now() - deletedGraceDays * 86400 * 1000;
-    const errorBefore: number = Date.now() - errorGraceDays * 86400 * 1000;
+    const deletedBefore: number = Math.floor(Date.now() / 1000) - deletedGraceDays * 86400;
+    const errorBefore: number = Math.floor(Date.now() / 1000) - errorGraceDays * 86400;
     const sessionEnv = createD1SessionEnv(env);
     const dao = new ApplicationContextDAO(sessionEnv.DB);
 

--- a/test/tasks/PruningTasks.test.ts
+++ b/test/tasks/PruningTasks.test.ts
@@ -100,6 +100,8 @@ describe('ProcessedMessagePruningTask', () => {
   it('deletes old processed messages', async () => {
     await new ProcessedMessagePruningTask().handle(createScheduledController(), createMockEnv() as Env, createExecutionContext());
     expect(mocks.mockDeleteOlderThan).toHaveBeenCalled();
+    const olderThan: number = mocks.mockDeleteOlderThan.mock.calls[0][0] as number;
+    expect(olderThan).toBeLessThan(Date.now() / 1000);
   });
 });
 
@@ -138,6 +140,10 @@ describe('StaleContextDocumentPruningTask', () => {
     await new StaleContextDocumentPruningTask().handle(createScheduledController(), createMockEnv() as Env, createExecutionContext());
     expect(mocks.mockDeleteStaleDeletedDocuments).toHaveBeenCalled();
     expect(mocks.mockDeleteStaleErrorDocuments).toHaveBeenCalled();
+    const deletedBefore: number = mocks.mockDeleteStaleDeletedDocuments.mock.calls[0][0] as number;
+    const errorBefore: number = mocks.mockDeleteStaleErrorDocuments.mock.calls[0][0] as number;
+    expect(deletedBefore).toBeLessThan(Date.now() / 1000);
+    expect(errorBefore).toBeLessThan(Date.now() / 1000);
   });
 });
 
@@ -150,6 +156,8 @@ describe('ContextDeletionRunPruningTask', () => {
   it('deletes old context deletion runs', async () => {
     await new ContextDeletionRunPruningTask().handle(createScheduledController(), createMockEnv() as Env, createExecutionContext());
     expect(mocks.mockDeleteOldDeletionRuns).toHaveBeenCalled();
+    const olderThan: number = mocks.mockDeleteOldDeletionRuns.mock.calls[0][0] as number;
+    expect(olderThan).toBeLessThan(Date.now() / 1000);
   });
 });
 


### PR DESCRIPTION
Three scheduled pruning tasks computed the `olderThan` cutoff with `Date.now()` (milliseconds) but all DB timestamp columns are stored as Unix seconds. Because any realistic seconds value (~1.7 billion) is always less than a milliseconds value (~1.7 trillion), the comparison `updated_at < olderThan` was unconditionally true — every qualifying row was deleted on every cron run (every 10 minutes).

The most destructive case was `ProcessedMessagePruningTask`: the `email_summary_actions` table has `ON DELETE CASCADE` back to `processed_messages`, so bulk-deleting summarized processed messages cascade-deleted all their pending actions. Users clicking action links within the stated validity window received "Action not found or has expired" immediately after receiving the summary email.

Fix all three tasks by replacing `Date.now() - days * 86400 * 1000` with `Math.floor(Date.now() / 1000) - days * 86400`, matching the correct pattern already used in `AuditLogPruningTask`. Add assertions to the affected pruning task tests to verify the threshold is passed in seconds going forward.