### PR TITLE
Per-Application Feature-Based OAuth2 Scopes

### DIFF
--- a/apps/api/src/endpoints/user/application/POST.ts
+++ b/apps/api/src/endpoints/user/application/POST.ts
@@ -32,6 +32,7 @@ interface CreateApplicationRequest extends IRequest {
   clientId: string;
   clientSecret: string;
   gmailPubsubTopicName?: string | undefined;
+  enabledFeatures?: string[] | undefined;
 }
 
 interface CreateApplicationResponse extends IResponse {

--- a/apps/api/src/endpoints/user/application/PUT.ts
+++ b/apps/api/src/endpoints/user/application/PUT.ts
@@ -34,6 +34,7 @@ interface UpdateApplicationRequest extends IRequest {
   clientId: string;
   clientSecret: string;
   gmailPubsubTopicName?: string | undefined;
+  enabledFeatures?: string[] | undefined;
 }
 
 interface UpdateApplicationResponse extends IResponse {

--- a/apps/web/components/types.ts
+++ b/apps/web/components/types.ts
@@ -16,6 +16,7 @@ export interface ConnectedApplication {
   providerId: ProviderId;
   connectionMethod: 'oauth2';
   status: 'draft' | 'connected' | 'error';
+  enabledFeatures?: string[] | null;
   gmailPubsubTopicName?: string | null;
   watchedFolders?: Array<{ id: string; name: string }> | null;
   oauth2RedirectUri?: string;

--- a/apps/web/src/SpaApp.tsx
+++ b/apps/web/src/SpaApp.tsx
@@ -148,6 +148,7 @@ export default function SpaApp() {
       clientId: '',
       clientSecret: '',
       gmailPubsubTopicName: app.gmailPubsubTopicName || '',
+      enabledFeatures: app.enabledFeatures || [],
     });
   };
 
@@ -161,6 +162,7 @@ export default function SpaApp() {
         connectionMethod: providerMethod[applicationForm.providerId],
         clientId: applicationForm.clientId,
         clientSecret: applicationForm.clientSecret,
+        enabledFeatures: applicationForm.enabledFeatures,
         ...(applicationForm.providerId === 'google-gmail' ? { gmailPubsubTopicName: applicationForm.gmailPubsubTopicName } : {}),
       };
       const res = await apiFetch('/user/application', {

--- a/apps/web/src/components/mailboxes/MailboxForm.tsx
+++ b/apps/web/src/components/mailboxes/MailboxForm.tsx
@@ -1,4 +1,6 @@
 import type { ProviderId } from '../../../components/types';
+import { OAUTH2_FEATURES, OAUTH2_FEATURE_SCOPES } from '../../../components/constants';
+import type { OAuth2Feature } from '../../../components/constants';
 import { Input, Select } from '../ui/Input';
 import { Button } from '../ui/Button';
 
@@ -9,6 +11,7 @@ export interface ApplicationFormState {
   clientId: string;
   clientSecret: string;
   gmailPubsubTopicName: string;
+  enabledFeatures: string[];
 }
 
 export const emptyForm: ApplicationFormState = {
@@ -17,6 +20,7 @@ export const emptyForm: ApplicationFormState = {
   clientId: '',
   clientSecret: '',
   gmailPubsubTopicName: '',
+  enabledFeatures: [],
 };
 
 export function MailboxForm({
@@ -34,6 +38,17 @@ export function MailboxForm({
 }) {
   const update = (changes: Partial<ApplicationFormState>) => setForm({ ...form, ...changes });
 
+  const toggleFeature = (featureId: string, checked: boolean) => {
+    const next = checked
+      ? [...form.enabledFeatures, featureId]
+      : form.enabledFeatures.filter((f) => f !== featureId);
+    update({ enabledFeatures: next });
+  };
+
+  const providerFeatures: [string, OAuth2Feature][] = (Object.entries(OAUTH2_FEATURES) as [string, OAuth2Feature][]).filter(
+    ([featureId]) => (OAUTH2_FEATURE_SCOPES[featureId]?.[form.providerId] ?? []).length > 0,
+  );
+
   return (
     <div className="rounded-xl border border-[var(--color-border)] bg-[var(--color-surface-1)] p-5">
       <h2 className="text-base font-semibold text-[var(--color-text-primary)] mb-4">
@@ -47,7 +62,7 @@ export function MailboxForm({
         />
         <Select
           value={form.providerId}
-          onChange={(e) => update({ providerId: e.target.value as ProviderId })}
+          onChange={(e) => update({ providerId: e.target.value as ProviderId, enabledFeatures: [] })}
           disabled={Boolean(form.applicationId)}
           className="w-full"
         >
@@ -71,6 +86,22 @@ export function MailboxForm({
             onChange={(e) => update({ gmailPubsubTopicName: e.target.value })}
             placeholder="projects/{projectId}/topics/{topicName}"
           />
+        )}
+        {providerFeatures.length > 0 && (
+          <div className="space-y-2 pt-1">
+            <p className="text-xs font-medium text-[var(--color-text-secondary)]">Optional features (requires re-authorization)</p>
+            {providerFeatures.map(([featureId, feature]) => (
+              <label key={featureId} className="inline-flex items-center gap-2.5 text-sm text-[var(--color-text-secondary)] cursor-pointer">
+                <input
+                  type="checkbox"
+                  checked={form.enabledFeatures.includes(featureId)}
+                  onChange={(e) => toggleFeature(featureId, e.target.checked)}
+                  className="h-4 w-4 accent-[var(--color-accent)] rounded"
+                />
+                {feature.label}
+              </label>
+            ))}
+          </div>
         )}
         <div className="flex gap-2 pt-1">
           <Button variant="primary" className="flex-1" onClick={onSave} loading={busy}>

--- a/packages/backend-data/src/dao/ConnectedApplicationDAO.ts
+++ b/packages/backend-data/src/dao/ConnectedApplicationDAO.ts
@@ -34,6 +34,7 @@ class ConnectedApplicationDAO {
     credentials: ConnectedApplicationCredentials,
     status: string,
     gmailPubsubTopicName?: string | null,
+    enabledFeatures?: string[] | null,
   ): Promise<ConnectedApplicationMetadata> {
     const now: number = TimestampUtil.getCurrentUnixTimestampInSeconds();
     const applicationId: string = UUIDUtil.getRandomUUID();
@@ -67,6 +68,9 @@ class ConnectedApplicationDAO {
     );
     if (gmailPubsubTopicName) {
       await this.setProviderConfig(applicationId, 'gmail_pubsub_topic_name', gmailPubsubTopicName, now);
+    }
+    if (enabledFeatures && enabledFeatures.length > 0) {
+      await this.setProviderConfig(applicationId, 'oauth2_enabled_features', JSON.stringify(enabledFeatures), now);
     }
     const application: ConnectedApplicationMetadata | undefined = await this.getMetadataByIdForUser(applicationId, userEmail);
     if (!application) {
@@ -136,6 +140,7 @@ class ConnectedApplicationDAO {
     credentials: ConnectedApplicationCredentials,
     status: string,
     gmailPubsubTopicName?: string | null,
+    enabledFeatures?: string[] | null,
   ): Promise<ConnectedApplicationMetadata | undefined> {
     const now: number = TimestampUtil.getCurrentUnixTimestampInSeconds();
     const encrypted = await encryptData(JSON.stringify(credentials), this.masterKey);
@@ -157,6 +162,11 @@ class ConnectedApplicationDAO {
       await this.setProviderConfig(applicationId, 'gmail_pubsub_topic_name', gmailPubsubTopicName, now);
     } else if (gmailPubsubTopicName === null) {
       await this.deleteProviderConfig(applicationId, 'gmail_pubsub_topic_name');
+    }
+    if (enabledFeatures && enabledFeatures.length > 0) {
+      await this.setProviderConfig(applicationId, 'oauth2_enabled_features', JSON.stringify(enabledFeatures), now);
+    } else if (enabledFeatures !== undefined) {
+      await this.deleteProviderConfig(applicationId, 'oauth2_enabled_features');
     }
     return this.getMetadataByIdForUser(applicationId, userEmail);
   }
@@ -396,9 +406,14 @@ class ConnectedApplicationDAO {
         : row.status === CONNECTED_APPLICATION_STATUS_ERROR
           ? CONNECTED_APPLICATION_STATUS_ERROR
           : CONNECTED_APPLICATION_STATUS_DRAFT;
-    const [watchedFolders, gmailPubsubTopicName]: [Array<{ folderPath: string; folderName: string }>, string | null] = await Promise.all([
+    const [watchedFolders, gmailPubsubTopicName, enabledFeaturesJson]: [
+      Array<{ folderPath: string; folderName: string }>,
+      string | null,
+      string | null,
+    ] = await Promise.all([
       this.getWatchedFolders(row.application_id),
       this.getProviderConfig(row.application_id, 'gmail_pubsub_topic_name'),
+      this.getProviderConfig(row.application_id, 'oauth2_enabled_features'),
     ]);
     return {
       applicationId: row.application_id,
@@ -410,6 +425,7 @@ class ConnectedApplicationDAO {
       status,
       contextIndexingEnabled: row.context_indexing_enabled !== 0,
       maxContextDocuments: row.max_context_documents ?? null,
+      enabledFeatures: enabledFeaturesJson ? (JSON.parse(enabledFeaturesJson) as string[]) : null,
       watchedFolders: watchedFolders.length > 0 ? watchedFolders.map((f) => ({ id: f.folderPath, name: f.folderName })) : null,
       createdAt: row.created_at,
       updatedAt: row.updated_at,

--- a/packages/backend-services/src/application/ApplicationService.ts
+++ b/packages/backend-services/src/application/ApplicationService.ts
@@ -48,6 +48,7 @@ class ApplicationService {
       credentials,
       CONNECTED_APPLICATION_STATUS_DRAFT,
       input.gmailPubsubTopicName || null,
+      input.enabledFeatures || null,
     );
     return ApplicationResponseUtil.decorateApplication(application, env, raw);
   }
@@ -79,6 +80,7 @@ class ApplicationService {
       credentials,
       CONNECTED_APPLICATION_STATUS_DRAFT,
       input.gmailPubsubTopicName || null,
+      input.enabledFeatures,
     );
     if (!application) {
       throw new BadRequestError('Connected application was not found.');
@@ -132,6 +134,7 @@ interface CreateUserApplicationInput {
   clientId: string;
   clientSecret: string;
   gmailPubsubTopicName?: string | undefined;
+  enabledFeatures?: string[] | null | undefined;
 }
 
 interface UpdateUserApplicationInput extends CreateUserApplicationInput {

--- a/packages/backend-services/src/oauth2/OAuth2AuthorizationService.ts
+++ b/packages/backend-services/src/oauth2/OAuth2AuthorizationService.ts
@@ -43,6 +43,7 @@ class OAuth2AuthorizationService {
         redirectUri,
         state,
         codeChallenge,
+        enabledFeatures: application.enabledFeatures ?? [],
       }),
       redirectUri,
       expiresAt,

--- a/packages/provider-clients/src/OAuth2ProviderUtil.ts
+++ b/packages/provider-clients/src/OAuth2ProviderUtil.ts
@@ -1,4 +1,4 @@
-import { PROVIDER_GOOGLE_GMAIL, PROVIDER_MICROSOFT_OUTLOOK } from '@mail-otter/shared/constants';
+import { OAUTH2_FEATURE_SCOPES, PROVIDER_GOOGLE_GMAIL, PROVIDER_MICROSOFT_OUTLOOK } from '@mail-otter/shared/constants';
 import type { ProviderId } from '@mail-otter/shared/constants';
 import { BadRequestError, InternalServerError } from '@mail-otter/backend-errors';
 import type { OAuth2Credentials } from '@mail-otter/shared/model';
@@ -9,6 +9,7 @@ interface OAuth2AuthorizationInput {
   redirectUri: string;
   state: string;
   codeChallenge: string;
+  enabledFeatures?: string[];
 }
 
 interface OAuth2TokenExchangeInput {
@@ -34,14 +35,14 @@ const ProviderConfig = {
   [PROVIDER_GOOGLE_GMAIL]: {
     authorizationEndpoint: 'https://accounts.google.com/o/oauth2/v2/auth',
     tokenEndpoint: 'https://oauth2.googleapis.com/token',
-    scope:
-      'https://www.googleapis.com/auth/gmail.readonly https://www.googleapis.com/auth/gmail.send https://www.googleapis.com/auth/gmail.compose https://www.googleapis.com/auth/calendar.events',
+    requiredScopes:
+      'https://www.googleapis.com/auth/gmail.readonly https://www.googleapis.com/auth/gmail.send https://www.googleapis.com/auth/gmail.compose',
   },
   [PROVIDER_MICROSOFT_OUTLOOK]: {
     authorizationEndpoint: 'https://login.microsoftonline.com/consumers/oauth2/v2.0/authorize',
     tokenEndpoint: 'https://login.microsoftonline.com/consumers/oauth2/v2.0/token',
-    scope:
-      'https://graph.microsoft.com/User.Read https://graph.microsoft.com/Mail.Read https://graph.microsoft.com/Mail.ReadWrite https://graph.microsoft.com/Mail.Send https://graph.microsoft.com/Calendars.ReadWrite offline_access',
+    requiredScopes:
+      'https://graph.microsoft.com/User.Read https://graph.microsoft.com/Mail.Read https://graph.microsoft.com/Mail.ReadWrite https://graph.microsoft.com/Mail.Send offline_access',
   },
 } as const;
 
@@ -52,7 +53,11 @@ class OAuth2ProviderUtil {
     url.searchParams.set('client_id', input.clientId);
     url.searchParams.set('redirect_uri', input.redirectUri);
     url.searchParams.set('response_type', 'code');
-    url.searchParams.set('scope', config.scope);
+    const optionalScopes: string[] = (input.enabledFeatures ?? []).flatMap(
+      (feature: string): string[] => OAUTH2_FEATURE_SCOPES[feature]?.[input.providerId] ?? [],
+    );
+    const scope: string = [config.requiredScopes, ...optionalScopes].join(' ');
+    url.searchParams.set('scope', scope);
     url.searchParams.set('state', input.state);
     url.searchParams.set('code_challenge', input.codeChallenge);
     url.searchParams.set('code_challenge_method', 'S256');

--- a/packages/shared/src/constants/OAuth2Scopes.ts
+++ b/packages/shared/src/constants/OAuth2Scopes.ts
@@ -1,5 +1,3 @@
-const ZERO_TRUST_AUTHENTICATION_PATH = '/user/';
-
 interface OAuth2Feature {
   label: string;
 }
@@ -15,5 +13,5 @@ const OAUTH2_FEATURE_SCOPES: Record<string, Record<string, string[]>> = {
   },
 };
 
-export { OAUTH2_FEATURE_SCOPES, OAUTH2_FEATURES, ZERO_TRUST_AUTHENTICATION_PATH };
+export { OAUTH2_FEATURES, OAUTH2_FEATURE_SCOPES };
 export type { OAuth2Feature };

--- a/packages/shared/src/constants/index.ts
+++ b/packages/shared/src/constants/index.ts
@@ -1,2 +1,3 @@
 export * from './Context';
+export * from './OAuth2Scopes';
 export * from './Providers';

--- a/packages/shared/src/model/ConnectedApplication.ts
+++ b/packages/shared/src/model/ConnectedApplication.ts
@@ -18,6 +18,7 @@ interface ConnectedApplicationMetadata {
   status: ConnectedApplicationStatus;
   contextIndexingEnabled: boolean;
   maxContextDocuments?: number | null | undefined;
+  enabledFeatures?: string[] | null | undefined;
   gmailPubsubTopicName?: string | null | undefined;
   watchedFolders?: Array<{ id: string; name: string }> | null | undefined;
   oauth2RedirectUri?: string | undefined;


### PR DESCRIPTION
Replaces hardcoded provider scopes with a feature-toggle system that lets users enable/disable optional capabilities (currently: Calendar) per mailbox application and then reconnect OAuth to apply the selection.

- `packages/shared/src/constants/OAuth2Scopes.ts`: new `OAUTH2_FEATURES` and `OAUTH2_FEATURE_SCOPES` maps defining feature → provider-specific scope URLs.
- `ConnectedApplicationMetadata`: add `enabledFeatures?: string[] | null`.
- `ConnectedApplicationDAO`: read/write `oauth2_enabled_features` in the `provider_application_configs` table (no new migration); thread the param through `create()` and `updateForUser()`.
- `OAuth2ProviderUtil`: split `scope` into `requiredScopes` (always sent) and optional scopes resolved from `enabledFeatures` at auth-URL build time.
- `OAuth2AuthorizationService`: pass `application.enabledFeatures` to `buildAuthorizationUrl()`.
- `ApplicationService` + API endpoints (`POST`/`PUT /user/application`): accept and propagate `enabledFeatures`.
- Web UI: feature checkboxes in `MailboxForm` (filtered to scopes the current provider supports); `SpaApp` populates and saves the selection.