### PR TITLE
Optional Credentials On Application Update

### DIFF
--- a/apps/api/src/endpoints/user/application/PUT.ts
+++ b/apps/api/src/endpoints/user/application/PUT.ts
@@ -31,8 +31,8 @@ interface UpdateApplicationRequest extends IRequest {
   displayName: string;
   providerId: 'google-gmail' | 'microsoft-outlook';
   connectionMethod: typeof CONNECTION_METHOD_OAUTH2;
-  clientId: string;
-  clientSecret: string;
+  clientId?: string | undefined;
+  clientSecret?: string | undefined;
   gmailPubsubTopicName?: string | undefined;
   enabledFeatures?: string[] | undefined;
 }

--- a/apps/web/src/SpaApp.tsx
+++ b/apps/web/src/SpaApp.tsx
@@ -160,8 +160,8 @@ export default function SpaApp() {
         displayName: applicationForm.displayName,
         providerId: applicationForm.providerId,
         connectionMethod: providerMethod[applicationForm.providerId],
-        clientId: applicationForm.clientId,
-        clientSecret: applicationForm.clientSecret,
+        ...(applicationForm.clientId ? { clientId: applicationForm.clientId } : {}),
+        ...(applicationForm.clientSecret ? { clientSecret: applicationForm.clientSecret } : {}),
         enabledFeatures: applicationForm.enabledFeatures,
         ...(applicationForm.providerId === 'google-gmail' ? { gmailPubsubTopicName: applicationForm.gmailPubsubTopicName } : {}),
       };

--- a/apps/web/src/components/mailboxes/MailboxForm.tsx
+++ b/apps/web/src/components/mailboxes/MailboxForm.tsx
@@ -72,12 +72,12 @@ export function MailboxForm({
         <Input
           value={form.clientId}
           onChange={(e) => update({ clientId: e.target.value })}
-          placeholder="OAuth2 client ID"
+          placeholder={form.applicationId ? 'Leave blank to keep existing client ID' : 'OAuth2 client ID'}
         />
         <Input
           value={form.clientSecret}
           onChange={(e) => update({ clientSecret: e.target.value })}
-          placeholder="OAuth2 client secret"
+          placeholder={form.applicationId ? 'Leave blank to keep existing client secret' : 'OAuth2 client secret'}
           type="password"
         />
         {form.providerId === 'google-gmail' && (

--- a/packages/backend-services/src/application/ApplicationService.ts
+++ b/packages/backend-services/src/application/ApplicationService.ts
@@ -68,10 +68,11 @@ class ApplicationService {
       throw new BadRequestError('Provider and connection method cannot be changed after creation.');
     }
 
+    const existingOAuth2 = existing.credentials as OAuth2Credentials;
     const credentials: ConnectedApplicationCredentials = {
-      clientId: input.clientId,
-      clientSecret: input.clientSecret,
-      refreshToken: (existing.credentials as OAuth2Credentials).refreshToken,
+      clientId: input.clientId || existingOAuth2.clientId,
+      clientSecret: input.clientSecret || existingOAuth2.clientSecret,
+      refreshToken: existingOAuth2.refreshToken,
     };
     const application: ConnectedApplicationMetadata | undefined = await applicationDAO.updateForUser(
       input.applicationId,
@@ -137,9 +138,11 @@ interface CreateUserApplicationInput {
   enabledFeatures?: string[] | null | undefined;
 }
 
-interface UpdateUserApplicationInput extends CreateUserApplicationInput {
+interface UpdateUserApplicationInput extends Omit<CreateUserApplicationInput, 'clientId' | 'clientSecret'> {
   applicationId: string;
   connectionMethod: typeof CONNECTION_METHOD_OAUTH2;
+  clientId?: string | undefined;
+  clientSecret?: string | undefined;
 }
 
 interface ApplicationServiceEnv {

--- a/packages/shared/src/schema/input.ts
+++ b/packages/shared/src/schema/input.ts
@@ -1,6 +1,6 @@
 import { z } from 'zod';
 import type { ZodTypeAny } from 'zod';
-import { ConnectedApplicationBaseSchema, UuidSchema, nonEmptyStringSchema } from './common';
+import { ConnectedApplicationBaseSchema, GmailPubsubTopicNameSchema, ProviderIdSchema, ConnectionMethodSchema, UuidSchema, nonEmptyStringSchema } from './common';
 import {
   APPLICATION_CONTEXT_DOCUMENT_STATUS_ACTIVE,
   APPLICATION_CONTEXT_DOCUMENT_STATUS_DELETED,
@@ -11,6 +11,8 @@ import {
   EMAIL_ACTION_STATUS_FAILED,
   EMAIL_ACTION_STATUS_PENDING,
   EMAIL_ACTION_STATUS_SUCCEEDED,
+  PROVIDER_GOOGLE_GMAIL,
+  SUPPORTED_PROVIDER_CONNECTIONS,
 } from '../constants';
 
 interface RequestInputSchema {
@@ -20,9 +22,25 @@ interface RequestInputSchema {
 
 const CreateApplicationBodySchema = ConnectedApplicationBaseSchema;
 
-const UpdateApplicationBodySchema = ConnectedApplicationBaseSchema.extend({
-  applicationId: UuidSchema,
-});
+const UpdateApplicationBodySchema = z
+  .object({
+    applicationId: UuidSchema,
+    displayName: nonEmptyStringSchema('displayName', 128),
+    providerId: ProviderIdSchema,
+    connectionMethod: ConnectionMethodSchema,
+    clientId: z.string().max(512).optional(),
+    clientSecret: z.string().max(2048).optional(),
+    gmailPubsubTopicName: GmailPubsubTopicNameSchema.optional(),
+    enabledFeatures: z.array(z.string()).optional(),
+  })
+  .refine(
+    (input): boolean => SUPPORTED_PROVIDER_CONNECTIONS[input.providerId] === input.connectionMethod,
+    'providerId and connectionMethod are not a supported combination.',
+  )
+  .refine(
+    (input): boolean => input.providerId !== PROVIDER_GOOGLE_GMAIL || Boolean(input.gmailPubsubTopicName),
+    'gmailPubsubTopicName is required for Gmail applications.',
+  );
 
 const DeleteApplicationBodySchema = z.object({
   applicationId: UuidSchema,

--- a/test/services/ApplicationService.test.ts
+++ b/test/services/ApplicationService.test.ts
@@ -165,6 +165,26 @@ describe('ApplicationService', () => {
         ),
       ).rejects.toThrow('Provider and connection method cannot be changed after creation.');
     });
+
+    it('preserves existing credentials when clientId and clientSecret are omitted', async () => {
+      mockGetByIdForUser.mockResolvedValue({
+        applicationId: 'app-1',
+        providerId: 'google-gmail',
+        connectionMethod: 'oauth2',
+        credentials: { clientId: 'existing-cid', clientSecret: 'existing-cs', refreshToken: 'rt' },
+      });
+      mockUpdateForUser.mockResolvedValue({ applicationId: 'app-1' });
+
+      await ApplicationService.updateUserApplication(
+        'user@example.com',
+        { applicationId: 'app-1', displayName: 'Updated', providerId: 'google-gmail', connectionMethod: 'oauth2' },
+        makeEnv(),
+        new Request('https://example.com'),
+      );
+
+      const [, , , calledCredentials] = mockUpdateForUser.mock.calls[0] as [unknown, unknown, unknown, { clientId: string; clientSecret: string; refreshToken: string }];
+      expect(calledCredentials).toEqual({ clientId: 'existing-cid', clientSecret: 'existing-cs', refreshToken: 'rt' });
+    });
   });
 
   describe('updateWatchedFolderIds', () => {


### PR DESCRIPTION
When editing an existing application (e.g., to change optional feature scopes), the form cleared clientId and clientSecret, but the PUT endpoint required them as non-empty values — forcing users to re-enter credentials they hadn't changed.

- `UpdateApplicationBodySchema` now makes `clientId` and `clientSecret` optional on PUT; the provider/connectionMethod refinements are preserved
- `ApplicationService.updateUserApplication` falls back to the stored credential values when the caller omits them
- Frontend payload omits the credential keys when the form fields are blank
- Edit-mode placeholders now read "Leave blank to keep existing …"
- New test verifies existing credentials are preserved when omitted