### PR TITLE
Credential Placeholder Text To "(unchanged)"

### DIFF
--- a/apps/web/src/components/mailboxes/MailboxForm.tsx
+++ b/apps/web/src/components/mailboxes/MailboxForm.tsx
@@ -72,12 +72,12 @@ export function MailboxForm({
         <Input
           value={form.clientId}
           onChange={(e) => update({ clientId: e.target.value })}
-          placeholder={form.applicationId ? 'Leave blank to keep existing client ID' : 'OAuth2 client ID'}
+          placeholder={form.applicationId ? '(unchanged)' : 'OAuth2 client ID'}
         />
         <Input
           value={form.clientSecret}
           onChange={(e) => update({ clientSecret: e.target.value })}
-          placeholder={form.applicationId ? 'Leave blank to keep existing client secret' : 'OAuth2 client secret'}
+          placeholder={form.applicationId ? '(unchanged)' : 'OAuth2 client secret'}
           type="password"
         />
         {form.providerId === 'google-gmail' && (


### PR DESCRIPTION
Rename the edit-mode placeholder text for OAuth2 client ID and client secret fields from verbose "Leave blank to keep existing …" strings to the concise "(unchanged)" to match tighter UI conventions.