### PR TITLE
Re-authorize OAuth2 Button Label When Already Connected

### DIFF
--- a/apps/web/src/components/mailboxes/MailboxDetail.tsx
+++ b/apps/web/src/components/mailboxes/MailboxDetail.tsx
@@ -76,8 +76,8 @@ export function MailboxDetail({
         </div>
 
         <div className="mt-5 flex flex-wrap gap-2">
-          <Button variant="primary" size="sm" onClick={onStartOAuth2} disabled={busy}>
-            Authorize OAuth2
+          <Button variant={application.status === 'connected' ? 'secondary' : 'primary'} size="sm" onClick={onStartOAuth2} disabled={busy}>
+            {application.status === 'connected' ? 'Re-authorize OAuth2' : 'Authorize OAuth2'}
           </Button>
           <Button
             variant="secondary"


### PR DESCRIPTION
Change the "Authorize OAuth2" button label to "Re-authorize OAuth2" when the application status is already 'connected', making it clear the action will replace an existing authorization rather than create a new one.