### PR TITLE
Stop Provider Watch On Application Deletion

### DIFF
--- a/apps/api/src/endpoints/user/application/DELETE.ts
+++ b/apps/api/src/endpoints/user/application/DELETE.ts
@@ -34,6 +34,7 @@ interface DeleteApplicationResponse extends IResponse {
 interface DeleteApplicationEnv extends IUserEnv {
   EMAIL_CONTEXT_INDEX?: Vectorize | undefined;
   OAUTH2_TOKEN_CACHE: KVNamespace;
+  OAUTH2_TOKEN_REFRESHERS: DurableObjectNamespace;
 }
 
 export { DeleteApplicationRoute };

--- a/packages/backend-services/src/application/ApplicationService.ts
+++ b/packages/backend-services/src/application/ApplicationService.ts
@@ -10,6 +10,8 @@ import type {
 } from '@mail-otter/shared/model';
 import { ConfigurationManager } from '@mail-otter/backend-runtime/config';
 import { EmailContextUtil } from '../email/EmailContextUtil';
+import { WatchService } from '../subscription/WatchService';
+import type { WatchServiceEnv } from '../subscription/WatchService';
 import { ApplicationResponseUtil } from './ApplicationResponseUtil';
 import type { ApplicationResponse } from './ApplicationResponseUtil';
 
@@ -109,6 +111,13 @@ class ApplicationService {
   }
 
   public static async deleteUserApplication(userEmail: string, applicationId: string, env: DeleteUserApplicationEnv): Promise<void> {
+    try {
+      await WatchService.stopApplicationWatch(userEmail, applicationId, env);
+    } catch (error: unknown) {
+      const message = error instanceof Error ? error.message : String(error);
+      console.warn(`[ApplicationService] Stop watch failed during application deletion, proceeding: ${message}`);
+    }
+
     const masterKey: string = await env.AES_ENCRYPTION_KEY_SECRET.get();
     const applicationDAO = new ConnectedApplicationDAO(env.DB, masterKey);
     const contextDAO = new ApplicationContextDAO(env.DB);
@@ -151,9 +160,8 @@ interface ApplicationServiceEnv {
   MAX_APPLICATIONS_PER_USER?: string | undefined;
 }
 
-interface DeleteUserApplicationEnv extends ApplicationServiceEnv {
+interface DeleteUserApplicationEnv extends ApplicationServiceEnv, WatchServiceEnv {
   EMAIL_CONTEXT_INDEX?: Vectorize | undefined;
-  OAUTH2_TOKEN_CACHE: KVNamespace;
 }
 
 interface UpdateWatchedFolderIdsInput {


### PR DESCRIPTION
When deleting an application, call `WatchService.stopApplicationWatch` before removing the token cache and application row. This cancels the active Gmail Pub/Sub or Outlook Graph subscription on the provider side so we don't leave orphaned webhooks that continue calling our endpoints for a non-existent application.

The call is wrapped in a try-catch so draft applications (no access token or subscription) and provider API failures do not block the rest of the cleanup. The `DeleteUserApplicationEnv` now extends `WatchServiceEnv` to bring in `OAUTH2_TOKEN_REFRESHERS` and the optional TTL env vars needed by the watch stop flow; the endpoint env is updated accordingly.