### PR TITLE
Rename "Available Actions" Label To "Actions"

### DIFF
--- a/packages/backend-services/src/action/ActionService.ts
+++ b/packages/backend-services/src/action/ActionService.ts
@@ -100,7 +100,7 @@ class ActionService {
     if (actions.length === 0) return '';
     return [
       '',
-      '<p><strong>Available actions:</strong></p>',
+      '<p><strong>Actions:</strong></p>',
       '<ul>',
       ...ActionService.renderActionItems(actions),
       '</ul>',

--- a/test/services/ActionService.test.ts
+++ b/test/services/ActionService.test.ts
@@ -184,7 +184,7 @@ describe('ActionService', () => {
       ]);
 
       expect(html).toContain('<ul>');
-      expect(html).toContain('Available actions');
+      expect(html).toContain('Actions');
       expect(html).toContain('</ul>');
     });
   });


### PR DESCRIPTION
Shortens the email summary action section heading from "Available actions:" to "Actions:" for brevity.