### PR TITLE
Collapsible New Mailbox Form And Edit Highlight

### DIFF
--- a/apps/web/src/SpaApp.tsx
+++ b/apps/web/src/SpaApp.tsx
@@ -36,6 +36,7 @@ export default function SpaApp() {
   const [applications, setApplications] = useState<ConnectedApplication[]>([]);
   const [selectedApplicationId, setSelectedApplicationId] = useState('');
   const [applicationForm, setApplicationForm] = useState<ApplicationFormState>(emptyForm);
+  const [isFormExpanded, setIsFormExpanded] = useState(false);
   const [notice, setNotice] = useState<{ type: 'success' | 'error'; text: string } | null>(() => getInitialNotice());
   const [isBusy, setIsBusy] = useState(false);
   const [watchWebhookUrl, setWatchWebhookUrl] = useState('');
@@ -138,7 +139,10 @@ export default function SpaApp() {
 
   // ── Mutations ─────────────────────────────────────────────────────────────
 
-  const resetForm = () => setApplicationForm(emptyForm);
+  const resetForm = () => {
+    setApplicationForm(emptyForm);
+    setIsFormExpanded(false);
+  };
 
   const editApplication = (app: ConnectedApplication) => {
     setApplicationForm({
@@ -150,6 +154,7 @@ export default function SpaApp() {
       gmailPubsubTopicName: app.gmailPubsubTopicName || '',
       enabledFeatures: app.enabledFeatures || [],
     });
+    setIsFormExpanded(true);
   };
 
   const saveApplication = async () => {
@@ -526,6 +531,8 @@ export default function SpaApp() {
           onUpdateMaxContextDocuments={updateMaxContextDocuments}
           onOpenContextAudit={(id) => { setAuditApplicationId(id); setActiveView('context'); }}
           onDeleteContextDocuments={deleteContextDocuments}
+          isFormExpanded={isFormExpanded}
+          setIsFormExpanded={setIsFormExpanded}
         />
       )}
 

--- a/apps/web/src/components/mailboxes/MailboxForm.tsx
+++ b/apps/web/src/components/mailboxes/MailboxForm.tsx
@@ -1,8 +1,11 @@
+import { useEffect, useRef, useState } from 'react';
+import { ChevronDown } from 'lucide-react';
 import type { ProviderId } from '../../../components/types';
 import { OAUTH2_FEATURES, OAUTH2_FEATURE_SCOPES } from '../../../components/constants';
 import type { OAuth2Feature } from '../../../components/constants';
 import { Input, Select } from '../ui/Input';
 import { Button } from '../ui/Button';
+import { cn } from '../../lib/utils';
 
 export interface ApplicationFormState {
   applicationId?: string;
@@ -29,13 +32,31 @@ export function MailboxForm({
   onSave,
   onCancel,
   busy,
+  isExpanded,
+  onToggleExpand,
 }: {
   form: ApplicationFormState;
   setForm: (form: ApplicationFormState) => void;
   onSave: () => void;
   onCancel: () => void;
   busy: boolean;
+  isExpanded: boolean;
+  onToggleExpand: () => void;
 }) {
+  const formRef = useRef<HTMLDivElement>(null);
+  const [isHighlighted, setIsHighlighted] = useState(false);
+  const prevApplicationId = useRef<string | undefined>(form.applicationId);
+
+  useEffect(() => {
+    if (form.applicationId && form.applicationId !== prevApplicationId.current) {
+      setIsHighlighted(true);
+      formRef.current?.scrollIntoView({ behavior: 'smooth', block: 'nearest' });
+      const t = window.setTimeout(() => setIsHighlighted(false), 1500);
+      return () => window.clearTimeout(t);
+    }
+    prevApplicationId.current = form.applicationId;
+  }, [form.applicationId]);
+
   const update = (changes: Partial<ApplicationFormState>) => setForm({ ...form, ...changes });
 
   const toggleFeature = (featureId: string, checked: boolean) => {
@@ -50,68 +71,88 @@ export function MailboxForm({
   );
 
   return (
-    <div className="rounded-xl border border-[var(--color-border)] bg-[var(--color-surface-1)] p-5">
-      <h2 className="text-base font-semibold text-[var(--color-text-primary)] mb-4">
-        {form.applicationId ? 'Edit Mailbox' : 'New Mailbox'}
-      </h2>
-      <div className="space-y-3">
-        <Input
-          value={form.displayName}
-          onChange={(e) => update({ displayName: e.target.value })}
-          placeholder="Display name"
+    <div
+      ref={formRef}
+      className={cn(
+        'rounded-xl border border-[var(--color-border)] bg-[var(--color-surface-1)] overflow-hidden',
+        isHighlighted && 'animate-highlight-pulse',
+      )}
+    >
+      <button
+        type="button"
+        onClick={onToggleExpand}
+        className="w-full flex items-center justify-between px-5 py-4 text-left hover:bg-[var(--color-surface-2)] transition-colors duration-150"
+      >
+        <h2 className="text-base font-semibold text-[var(--color-text-primary)]">
+          {form.applicationId ? 'Edit Mailbox' : 'New Mailbox'}
+        </h2>
+        <ChevronDown
+          className={cn(
+            'h-4 w-4 text-[var(--color-text-muted)] transition-transform duration-200',
+            isExpanded && 'rotate-180',
+          )}
         />
-        <Select
-          value={form.providerId}
-          onChange={(e) => update({ providerId: e.target.value as ProviderId, enabledFeatures: [] })}
-          disabled={Boolean(form.applicationId)}
-          className="w-full"
-        >
-          <option value="google-gmail">Google Gmail / OAuth2</option>
-          <option value="microsoft-outlook">Microsoft Outlook / OAuth2</option>
-        </Select>
-        <Input
-          value={form.clientId}
-          onChange={(e) => update({ clientId: e.target.value })}
-          placeholder={form.applicationId ? '(unchanged)' : 'OAuth2 client ID'}
-        />
-        <Input
-          value={form.clientSecret}
-          onChange={(e) => update({ clientSecret: e.target.value })}
-          placeholder={form.applicationId ? '(unchanged)' : 'OAuth2 client secret'}
-          type="password"
-        />
-        {form.providerId === 'google-gmail' && (
+      </button>
+      {isExpanded && (
+        <div className="px-5 pb-5 space-y-3 border-t border-[var(--color-border)] pt-4 animate-fade-in">
           <Input
-            value={form.gmailPubsubTopicName}
-            onChange={(e) => update({ gmailPubsubTopicName: e.target.value })}
-            placeholder="projects/{projectId}/topics/{topicName}"
+            value={form.displayName}
+            onChange={(e) => update({ displayName: e.target.value })}
+            placeholder="Display name"
           />
-        )}
-        {providerFeatures.length > 0 && (
-          <div className="space-y-2 pt-1">
-            <p className="text-xs font-medium text-[var(--color-text-secondary)]">Optional features (requires re-authorization)</p>
-            {providerFeatures.map(([featureId, feature]) => (
-              <label key={featureId} className="inline-flex items-center gap-2.5 text-sm text-[var(--color-text-secondary)] cursor-pointer">
-                <input
-                  type="checkbox"
-                  checked={form.enabledFeatures.includes(featureId)}
-                  onChange={(e) => toggleFeature(featureId, e.target.checked)}
-                  className="h-4 w-4 accent-[var(--color-accent)] rounded"
-                />
-                {feature.label}
-              </label>
-            ))}
+          <Select
+            value={form.providerId}
+            onChange={(e) => update({ providerId: e.target.value as ProviderId, enabledFeatures: [] })}
+            disabled={Boolean(form.applicationId)}
+            className="w-full"
+          >
+            <option value="google-gmail">Google Gmail / OAuth2</option>
+            <option value="microsoft-outlook">Microsoft Outlook / OAuth2</option>
+          </Select>
+          <Input
+            value={form.clientId}
+            onChange={(e) => update({ clientId: e.target.value })}
+            placeholder={form.applicationId ? '(unchanged)' : 'OAuth2 client ID'}
+          />
+          <Input
+            value={form.clientSecret}
+            onChange={(e) => update({ clientSecret: e.target.value })}
+            placeholder={form.applicationId ? '(unchanged)' : 'OAuth2 client secret'}
+            type="password"
+          />
+          {form.providerId === 'google-gmail' && (
+            <Input
+              value={form.gmailPubsubTopicName}
+              onChange={(e) => update({ gmailPubsubTopicName: e.target.value })}
+              placeholder="projects/{projectId}/topics/{topicName}"
+            />
+          )}
+          {providerFeatures.length > 0 && (
+            <div className="space-y-2 pt-1">
+              <p className="text-xs font-medium text-[var(--color-text-secondary)]">Optional features (requires re-authorization)</p>
+              {providerFeatures.map(([featureId, feature]) => (
+                <label key={featureId} className="inline-flex items-center gap-2.5 text-sm text-[var(--color-text-secondary)] cursor-pointer">
+                  <input
+                    type="checkbox"
+                    checked={form.enabledFeatures.includes(featureId)}
+                    onChange={(e) => toggleFeature(featureId, e.target.checked)}
+                    className="h-4 w-4 accent-[var(--color-accent)] rounded"
+                  />
+                  {feature.label}
+                </label>
+              ))}
+            </div>
+          )}
+          <div className="flex gap-2 pt-1">
+            <Button variant="primary" className="flex-1" onClick={onSave} loading={busy}>
+              {form.applicationId ? 'Save Changes' : 'Create Mailbox'}
+            </Button>
+            <Button variant="ghost" onClick={onCancel} disabled={busy}>
+              Clear
+            </Button>
           </div>
-        )}
-        <div className="flex gap-2 pt-1">
-          <Button variant="primary" className="flex-1" onClick={onSave} loading={busy}>
-            {form.applicationId ? 'Save Changes' : 'Create Mailbox'}
-          </Button>
-          <Button variant="ghost" onClick={onCancel} disabled={busy}>
-            Clear
-          </Button>
         </div>
-      </div>
+      )}
     </div>
   );
 }

--- a/apps/web/src/components/views/MailboxesView.tsx
+++ b/apps/web/src/components/views/MailboxesView.tsx
@@ -29,6 +29,8 @@ export function MailboxesView({
   onUpdateMaxContextDocuments,
   onOpenContextAudit,
   onDeleteContextDocuments,
+  isFormExpanded,
+  setIsFormExpanded,
 }: {
   applications: ConnectedApplication[];
   selectedApplicationId: string;
@@ -53,6 +55,8 @@ export function MailboxesView({
   onUpdateMaxContextDocuments: (id: string, max: number | null) => void;
   onOpenContextAudit: (id: string) => void;
   onDeleteContextDocuments: (id: string) => void;
+  isFormExpanded: boolean;
+  setIsFormExpanded: (v: boolean) => void;
 }) {
   const selectedApplication = applications.find((a) => a.applicationId === selectedApplicationId);
 
@@ -93,6 +97,8 @@ export function MailboxesView({
           onSave={onSaveForm}
           onCancel={onCancelForm}
           busy={busy}
+          isExpanded={isFormExpanded}
+          onToggleExpand={() => setIsFormExpanded(!isFormExpanded)}
         />
       </section>
 

--- a/apps/web/src/globals.css
+++ b/apps/web/src/globals.css
@@ -37,6 +37,7 @@
   --animate-stagger-1: fade-in-up 0.3s 0.05s cubic-bezier(0.16, 1, 0.3, 1) both;
   --animate-stagger-2: fade-in-up 0.3s 0.10s cubic-bezier(0.16, 1, 0.3, 1) both;
   --animate-stagger-3: fade-in-up 0.3s 0.15s cubic-bezier(0.16, 1, 0.3, 1) both;
+  --animate-highlight-pulse: highlight-pulse 1.4s ease-out both;
 }
 
 @keyframes fade-in {
@@ -79,6 +80,11 @@
     opacity: 1;
     transform: translateY(0);
   }
+}
+
+@keyframes highlight-pulse {
+  0%, 100% { box-shadow: 0 0 0 0 transparent; }
+  35% { box-shadow: 0 0 0 4px color-mix(in srgb, var(--color-accent) 35%, transparent); }
 }
 
 ::-webkit-scrollbar {


### PR DESCRIPTION
- MailboxForm is now collapsed by default, showing only a toggle header with a ChevronDown icon (from lucide-react). Clicking the header expands the form fields with a fade-in animation; the chevron rotates 180° to signal the expanded state.
- Clicking the Clear button or completing a save collapses the form back automatically (via resetForm in SpaApp calling setIsFormExpanded(false)).
- Clicking Edit on a mailbox in the right panel auto-expands the form (editApplication sets isFormExpanded = true) and applies a brief border-glow pulse animation (.animate-highlight-pulse, 1.4s ease-out) to draw the user's eye to the left panel. The form also scrolls into view.
- A new highlight-pulse keyframe in globals.css provides the box-shadow accent glow; the expansion/collapse state (isFormExpanded) is lifted into SpaApp and threaded through MailboxesView to MailboxForm as isExpanded / onToggleExpand props.