### PR TITLE
Rename "Store Documents" Label To "Index New Emails"

### DIFF
--- a/apps/web/src/components/mailboxes/ContextSection.tsx
+++ b/apps/web/src/components/mailboxes/ContextSection.tsx
@@ -34,7 +34,7 @@ export function ContextSection({
               disabled={busy}
               className="h-4 w-4 accent-[var(--color-accent)] rounded"
             />
-            Store documents
+            Index new emails
           </label>
           <label className="inline-flex items-center gap-2 text-sm text-[var(--color-text-secondary)]">
             Max docs


### PR DESCRIPTION
The previous label "Store documents" was ambiguous — it wasn't clear what documents or where they came from. "Index new emails" directly describes what the toggle does: incoming emails are indexed into the RAG context.