### PR TITLE
Retry Find Sent Summary Message On Graph Propagation Delay

### DIFF
--- a/packages/provider-clients/src/OutlookProviderUtil.ts
+++ b/packages/provider-clients/src/OutlookProviderUtil.ts
@@ -282,12 +282,22 @@ class OutlookProviderUtil {
     return data.value && data.value.length > 0 ? data.value[0].id : null;
   }
 
+  private static sleep(ms: number): Promise<void> {
+    return new Promise<void>((resolve) => setTimeout(resolve, ms));
+  }
+
   private static async findSentSummaryMessage(accessToken: string, marker: string): Promise<string> {
-    const id: string | null = await OutlookProviderUtil.findSummaryMessageInFolder(accessToken, 'sentitems', marker);
-    if (!id) {
-      throw new ProviderApiRetryableError('Microsoft Graph did not return the sent summary message.');
+    const delays = [1000, 2000, 4000];
+    for (let attempt = 0; attempt <= delays.length; attempt++) {
+      if (attempt > 0) {
+        await OutlookProviderUtil.sleep(delays[attempt - 1]);
+      }
+      const id: string | null = await OutlookProviderUtil.findSummaryMessageInFolder(accessToken, 'sentitems', marker);
+      if (id) {
+        return id;
+      }
     }
-    return id;
+    throw new ProviderApiRetryableError('Microsoft Graph did not return the sent summary message.');
   }
 
   public static isMessageNotFoundError(error: unknown): boolean {

--- a/test/utils/OutlookProviderUtil.test.ts
+++ b/test/utils/OutlookProviderUtil.test.ts
@@ -180,21 +180,26 @@ describe('OutlookProviderUtil', () => {
       ).rejects.toThrow('Microsoft Graph send summary reply failed (500): Reply failed');
     });
 
-    it('throws when find returns no results after reply', async () => {
+    it('throws when find returns no results after reply (all retries exhausted)', async () => {
+      // Bypass sleep delays so the test runs instantly
+      vi.spyOn(OutlookProviderUtil as unknown as { sleep: () => Promise<void> }, 'sleep').mockResolvedValue(undefined);
+
       const mockReplyResponse = new Response(null, { status: 202 });
 
       const fetchMock = vi
         .fn()
-        .mockResolvedValueOnce(mockEmptyResponse())    // inbox check
-        .mockResolvedValueOnce(mockEmptyResponse())    // sentitems check
-        .mockResolvedValueOnce(mockReplyResponse)      // reply
-        .mockResolvedValueOnce(mockEmptyResponse());   // find after reply (empty)
+        .mockResolvedValueOnce(mockEmptyResponse())                           // inbox check
+        .mockResolvedValueOnce(mockEmptyResponse())                           // sentitems check
+        .mockResolvedValueOnce(mockReplyResponse)                             // reply
+        .mockImplementation(() => Promise.resolve(mockEmptyResponse()));      // all 4 find retries (fresh body each time)
 
       vi.stubGlobal('fetch', fetchMock);
 
       await expect(
         OutlookProviderUtil.sendSelfSummaryReply('test-access-token', { id: 'original-msg-id' }, 'sender@example.com', 'Summary text'),
       ).rejects.toThrow('Microsoft Graph did not return the sent summary message.');
+
+      expect(fetchMock).toHaveBeenCalledTimes(7); // 2 idempotency + 1 reply + 4 find retries
     });
 
     it('throws when find fails after reply', async () => {


### PR DESCRIPTION
Microsoft Graph's `/reply` endpoint returns 202 before the sent message is searchable in Sent Items, causing `findSentSummaryMessage` to throw `ProviderApiRetryableError` for every Outlook email. The workflow-level retry recovered after 10 s, but the error was logged each time.

Add a private `sleep` helper and retry loop inside `findSentSummaryMessage` that polls up to 4 times (immediately, then after 1 s, 2 s, and 4 s) before giving up. Total internal wait of 7 s is well within the step's 2-minute timeout.

Update the exhausted-retries test to spy on `sleep` (instant resolution), drive all 4 find attempts via fresh `Response` bodies, and assert the correct total fetch call count.