### PR TITLE
Hide Re-Authorization Hint When Creating A New Mailbox

### DIFF
--- a/apps/web/src/components/mailboxes/MailboxForm.tsx
+++ b/apps/web/src/components/mailboxes/MailboxForm.tsx
@@ -129,7 +129,7 @@ export function MailboxForm({
           )}
           {providerFeatures.length > 0 && (
             <div className="space-y-2 pt-1">
-              <p className="text-xs font-medium text-[var(--color-text-secondary)]">Optional features (requires re-authorization)</p>
+              <p className="text-xs font-medium text-[var(--color-text-secondary)]">Optional features{form.applicationId ? ' (requires re-authorization)' : ''}</p>
               {providerFeatures.map(([featureId, feature]) => (
                 <label key={featureId} className="inline-flex items-center gap-2.5 text-sm text-[var(--color-text-secondary)] cursor-pointer">
                   <input


### PR DESCRIPTION
The "(requires re-authorization)" parenthetical in the optional features label only applies when editing an existing mailbox whose OAuth2 scopes may need to be expanded. For a new mailbox creation flow there is no prior authorization, so the hint was misleading. It now renders conditionally based on whether `form.applicationId` is set.