### PR TITLE
Delete Stale Sent Items Copy On Workflow Retry

### DIFF
--- a/packages/provider-clients/src/OutlookProviderUtil.ts
+++ b/packages/provider-clients/src/OutlookProviderUtil.ts
@@ -212,6 +212,11 @@ class OutlookProviderUtil {
     // Idempotency: if this email's summary already in Inbox, all steps completed
     const inboxMsgId: string | null = await OutlookProviderUtil.findSummaryMessageInFolder(accessToken, 'inbox', marker);
     if (inboxMsgId) {
+      // Clean up any leftover Sent Items copy if a previous delete attempt failed
+      const staleSentMsgId: string | null = await OutlookProviderUtil.findSummaryMessageInFolder(accessToken, 'sentitems', marker);
+      if (staleSentMsgId) {
+        await OutlookProviderUtil.deleteMessage(accessToken, staleSentMsgId);
+      }
       return;
     }
 

--- a/test/utils/OutlookProviderUtil.test.ts
+++ b/test/utils/OutlookProviderUtil.test.ts
@@ -106,12 +106,13 @@ describe('OutlookProviderUtil', () => {
       );
     });
 
-    it('skips when summary already exists in inbox', async () => {
+    it('skips when summary already exists in inbox and no stale sent copy', async () => {
       const mockInboxResponse = new Response(JSON.stringify({ value: [{ id: 'inbox-msg-id' }] }), { status: 200 });
 
       const fetchMock = vi
         .fn()
-        .mockResolvedValueOnce(mockInboxResponse);
+        .mockResolvedValueOnce(mockInboxResponse)   // inbox check (found)
+        .mockResolvedValueOnce(mockEmptyResponse()); // sentitems check (empty)
 
       vi.stubGlobal('fetch', fetchMock);
 
@@ -122,10 +123,38 @@ describe('OutlookProviderUtil', () => {
         'Summary text',
       );
 
-      expect(fetchMock).toHaveBeenCalledTimes(1);
+      expect(fetchMock).toHaveBeenCalledTimes(2);
       const inboxUrl = fetchMock.mock.calls[0][0] as string;
       expect(inboxUrl).toContain('/me/mailFolders/inbox/messages');
       expect(inboxUrl).toContain(encodeURIComponent(`[OtterSum-${EXPECTED_MARKER}]`));
+    });
+
+    it('deletes stale Sent Items copy when summary already exists in inbox', async () => {
+      const mockInboxResponse = new Response(JSON.stringify({ value: [{ id: 'inbox-msg-id' }] }), { status: 200 });
+      const mockSentItemsResponse = new Response(JSON.stringify({ value: [{ id: 'stale-sent-id' }] }), { status: 200 });
+      const mockDeleteResponse = new Response(null, { status: 204 });
+
+      const fetchMock = vi
+        .fn()
+        .mockResolvedValueOnce(mockInboxResponse)     // inbox check (found)
+        .mockResolvedValueOnce(mockSentItemsResponse) // sentitems check (stale copy found)
+        .mockResolvedValueOnce(mockDeleteResponse);   // delete stale copy
+
+      vi.stubGlobal('fetch', fetchMock);
+
+      await OutlookProviderUtil.sendSelfSummaryReply(
+        'test-access-token',
+        { id: 'original-msg-id' },
+        'sender@example.com',
+        'Summary text',
+      );
+
+      expect(fetchMock).toHaveBeenCalledTimes(3);
+      expect(fetchMock).toHaveBeenNthCalledWith(
+        3,
+        'https://graph.microsoft.com/v1.0/me/messages/stale-sent-id',
+        expect.objectContaining({ method: 'DELETE' }),
+      );
     });
 
     it('skips reply and only copies and deletes when summary already in sent items', async () => {


### PR DESCRIPTION
When the Outlook summary workflow retried after a transient delete failure, the inbox idempotency check detected the already-copied message and returned early without attempting to delete the leftover Sent Items copy. The workflow then succeeded, permanently orphaning the sent message.

Fix: when the inbox idempotency path is taken, also query Sent Items for a stale copy by the same deterministic marker and delete it if present. The delete already tolerates 404, so the path is idempotent and safe under all retry scenarios.