### PR TITLE
Expand DAO And Integration Test Coverage

### DIFF
--- a/test/dao/ProcessedMessageDAO.test.ts
+++ b/test/dao/ProcessedMessageDAO.test.ts
@@ -1,12 +1,14 @@
 import { ProcessedMessageDAO } from '@mail-otter/backend-data/dao';
 import {
+  PROCESSED_MESSAGE_STATUS_ERROR,
   PROCESSED_MESSAGE_STATUS_PROCESSING,
+  PROCESSED_MESSAGE_STATUS_SKIPPED,
   PROCESSED_MESSAGE_STATUS_SUMMARIZED,
   type ProcessedMessageStatus,
   type ProviderId,
 } from '@mail-otter/shared/constants';
 import type { ProcessedMessageInternal } from '@mail-otter/shared/model';
-import { describe, expect, it } from 'vitest';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
 
 class FakeProcessedMessageStatement {
   private bindings: unknown[] = [];
@@ -138,3 +140,186 @@ function createProcessedMessageRow(overrides: Partial<ProcessedMessageInternal> 
     ...overrides,
   };
 }
+
+function makeDb(overrides?: { firstResult?: unknown; runChanges?: number }) {
+  const mockRun = vi.fn().mockResolvedValue({ success: true, meta: { changes: overrides?.runChanges ?? 1 } } as D1Result);
+  const mockFirst = vi.fn().mockResolvedValue(overrides?.firstResult ?? null);
+  return {
+    db: {
+      prepare: vi.fn(() => ({
+        bind: vi.fn(() => ({
+          run: mockRun,
+          first: mockFirst,
+        })),
+      })),
+    } as unknown as D1Database,
+    mockRun,
+    mockFirst,
+  };
+}
+
+describe('ProcessedMessageDAO (mock-based)', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  describe('markSummarized', () => {
+    it('executes UPDATE with summarized status and sets summary_sent_at', async () => {
+      const { db, mockRun } = makeDb();
+      const dao = new ProcessedMessageDAO(db);
+
+      await dao.markSummarized('app-1', 'msg-1');
+
+      expect(mockRun).toHaveBeenCalledTimes(1);
+      const bindFn = (db.prepare as ReturnType<typeof vi.fn>).mock.results[0].value.bind as ReturnType<typeof vi.fn>;
+      const bindings = bindFn.mock.calls[0] as unknown[];
+      expect(bindings[0]).toBe(PROCESSED_MESSAGE_STATUS_SUMMARIZED);
+      expect(bindings[1]).toBe(1);
+    });
+  });
+
+  describe('markSkipped', () => {
+    it('executes UPDATE with skipped status and sets error_message', async () => {
+      const { db, mockRun } = makeDb();
+      const dao = new ProcessedMessageDAO(db);
+
+      await dao.markSkipped('app-1', 'msg-1', 'Already processed');
+
+      expect(mockRun).toHaveBeenCalledTimes(1);
+      const bindFn = (db.prepare as ReturnType<typeof vi.fn>).mock.results[0].value.bind as ReturnType<typeof vi.fn>;
+      const bindings = bindFn.mock.calls[0] as unknown[];
+      expect(bindings[0]).toBe(PROCESSED_MESSAGE_STATUS_SKIPPED);
+      expect(bindings[3]).toBe('Already processed');
+    });
+  });
+
+  describe('markError', () => {
+    it('executes UPDATE with error status and sets error_message', async () => {
+      const { db, mockRun } = makeDb();
+      const dao = new ProcessedMessageDAO(db);
+
+      await dao.markError('app-1', 'msg-1', 'Something went wrong');
+
+      expect(mockRun).toHaveBeenCalledTimes(1);
+      const bindFn = (db.prepare as ReturnType<typeof vi.fn>).mock.results[0].value.bind as ReturnType<typeof vi.fn>;
+      const bindings = bindFn.mock.calls[0] as unknown[];
+      expect(bindings[0]).toBe(PROCESSED_MESSAGE_STATUS_ERROR);
+      expect(bindings[3]).toBe('Something went wrong');
+    });
+
+    it('truncates error messages longer than 1024 chars', async () => {
+      const { db } = makeDb();
+      const dao = new ProcessedMessageDAO(db);
+      const longError = 'x'.repeat(2000);
+
+      await dao.markError('app-1', 'msg-1', longError);
+
+      const bindFn = (db.prepare as ReturnType<typeof vi.fn>).mock.results[0].value.bind as ReturnType<typeof vi.fn>;
+      const bindings = bindFn.mock.calls[0] as unknown[];
+      expect((bindings[3] as string).length).toBe(1024);
+    });
+  });
+
+  describe('deleteOlderThan', () => {
+    it('returns the number of deleted rows', async () => {
+      const { db } = makeDb({ runChanges: 7 });
+      const dao = new ProcessedMessageDAO(db);
+
+      const count = await dao.deleteOlderThan(1000000, [PROCESSED_MESSAGE_STATUS_SUMMARIZED, PROCESSED_MESSAGE_STATUS_SKIPPED], 100);
+
+      expect(count).toBe(7);
+    });
+
+    it('passes the correct bindings (timestamp, statuses, limit)', async () => {
+      const { db } = makeDb();
+      const dao = new ProcessedMessageDAO(db);
+
+      await dao.deleteOlderThan(9999, [PROCESSED_MESSAGE_STATUS_ERROR], 50);
+
+      const bindFn = (db.prepare as ReturnType<typeof vi.fn>).mock.results[0].value.bind as ReturnType<typeof vi.fn>;
+      const bindings = bindFn.mock.calls[0] as unknown[];
+      expect(bindings[0]).toBe(9999);
+      expect(bindings[1]).toBe(PROCESSED_MESSAGE_STATUS_ERROR);
+      expect(bindings[2]).toBe(50);
+    });
+  });
+
+  describe('getLatestForApplication', () => {
+    it('returns undefined when no summarized message exists', async () => {
+      const { db } = makeDb({ firstResult: null });
+      const dao = new ProcessedMessageDAO(db);
+
+      const result = await dao.getLatestForApplication('app-1');
+
+      expect(result).toBeUndefined();
+    });
+
+    it('maps database row to ProcessedMessage shape', async () => {
+      const row = createProcessedMessageRow({ status: PROCESSED_MESSAGE_STATUS_SUMMARIZED });
+      const { db } = makeDb({ firstResult: row });
+      const dao = new ProcessedMessageDAO(db);
+
+      const result = await dao.getLatestForApplication('app-1');
+
+      expect(result).toMatchObject({
+        processedMessageId: row.processed_message_id,
+        applicationId: row.application_id,
+        providerId: row.provider_id,
+        providerMessageId: row.provider_message_id,
+        status: PROCESSED_MESSAGE_STATUS_SUMMARIZED,
+        summarySentAt: row.summary_sent_at,
+      });
+    });
+  });
+
+  describe('getLatestErrorForApplication', () => {
+    it('returns undefined when no error message exists', async () => {
+      const { db } = makeDb({ firstResult: null });
+      const dao = new ProcessedMessageDAO(db);
+
+      const result = await dao.getLatestErrorForApplication('app-1');
+
+      expect(result).toBeUndefined();
+    });
+
+    it('maps error row to ProcessedMessage shape', async () => {
+      const row = createProcessedMessageRow({ status: PROCESSED_MESSAGE_STATUS_ERROR, error_message: 'fail', summary_sent_at: null });
+      const { db } = makeDb({ firstResult: row });
+      const dao = new ProcessedMessageDAO(db);
+
+      const result = await dao.getLatestErrorForApplication('app-1');
+
+      expect(result).toMatchObject({
+        status: PROCESSED_MESSAGE_STATUS_ERROR,
+        errorMessage: 'fail',
+      });
+    });
+  });
+
+  describe('getByMessageId', () => {
+    it('returns undefined when message does not exist', async () => {
+      const { db } = makeDb({ firstResult: null });
+      const dao = new ProcessedMessageDAO(db);
+
+      const result = await dao.getByMessageId('app-1', 'msg-x');
+
+      expect(result).toBeUndefined();
+    });
+
+    it('maps row to ProcessedMessage including providerThreadId and fingerprint', async () => {
+      const row = createProcessedMessageRow({
+        provider_thread_id: 'thread-99',
+        provider_stable_message_fingerprint: 'fp-abc',
+      });
+      const { db } = makeDb({ firstResult: row });
+      const dao = new ProcessedMessageDAO(db);
+
+      const result = await dao.getByMessageId('app-1', 'provider-message-1');
+
+      expect(result).toMatchObject({
+        providerThreadId: 'thread-99',
+        providerStableMessageFingerprint: 'fp-abc',
+      });
+    });
+  });
+});

--- a/test/integration/api/UserApplications.int.test.ts
+++ b/test/integration/api/UserApplications.int.test.ts
@@ -1,0 +1,227 @@
+import { describe, expect, it, beforeAll } from 'vitest';
+import { env, SELF, adminSecretsStore } from 'cloudflare:test';
+import type { SecretsStoreSecret } from 'cloudflare:workers';
+import { applyMigrations } from '../helpers/migrations';
+
+async function seedApplication(userEmail: string): Promise<string> {
+  const applicationId = crypto.randomUUID();
+  const now = Math.floor(Date.now() / 1000);
+  await env.DB.prepare(
+    `INSERT INTO connected_applications (application_id, user_email, display_name, provider_id, connection_method, encrypted_credentials, credentials_iv, status, created_at, updated_at) ` +
+    `VALUES (?, ?, ?, 'google-gmail', 'oauth2', 'enc', 'iv', 'draft', ?, ?)`,
+  ).bind(applicationId, userEmail, 'Test Gmail', now, now).run();
+  return applicationId;
+}
+
+const TEST_EMAIL = 'test@example.com';
+const GMAIL_BODY = {
+  displayName: 'My Gmail App',
+  providerId: 'google-gmail',
+  connectionMethod: 'oauth2',
+  clientId: 'test-client-id',
+  clientSecret: 'test-client-secret',
+  gmailPubsubTopicName: 'projects/my-project/topics/mail-otter',
+};
+const NONEXISTENT_UUID = '00000000-0000-0000-0000-000000000000';
+
+describe('User applications API', () => {
+  beforeAll(async () => {
+    await applyMigrations(env.DB);
+    const aesSecret = (env as Record<string, unknown>)['AES_ENCRYPTION_KEY_SECRET'] as SecretsStoreSecret | undefined;
+    if (aesSecret) {
+      const admin = adminSecretsStore(aesSecret);
+      // Valid base64-encoded 32-byte (AES-256-GCM) key (32 zero bytes)
+      await admin.create('AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=');
+    }
+    await env.DB.prepare(
+      `INSERT OR IGNORE INTO users (email, created_at, updated_at) VALUES (?, ?, ?)`,
+    ).bind(TEST_EMAIL, Math.floor(Date.now() / 1000), Math.floor(Date.now() / 1000)).run();
+  });
+
+  describe('GET /user/me', () => {
+    it('returns the authenticated user email', async () => {
+      const response: Response = await SELF.fetch('http://localhost/user/me');
+
+      expect(response.status).toBe(200);
+      const body = await response.json() as { email: string };
+      expect(body.email).toBe(TEST_EMAIL);
+    });
+  });
+
+  describe('GET /user/applications', () => {
+    it('returns a list array', async () => {
+      const response: Response = await SELF.fetch('http://localhost/user/applications');
+
+      expect(response.status).toBe(200);
+      const body = await response.json() as { applications: unknown[] };
+      expect(Array.isArray(body.applications)).toBe(true);
+    });
+
+    it('includes a seeded application in the list', async () => {
+      await seedApplication(TEST_EMAIL);
+
+      const response: Response = await SELF.fetch('http://localhost/user/applications');
+
+      expect(response.status).toBe(200);
+      const body = await response.json() as { applications: { providerId: string }[] };
+      expect(body.applications.length).toBeGreaterThan(0);
+    });
+  });
+
+  describe('POST /user/application', () => {
+    it('creates a new Gmail application and returns it', async () => {
+      const response: Response = await SELF.fetch('http://localhost/user/application', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify(GMAIL_BODY),
+      });
+
+      expect(response.status).toBe(200);
+      const body = await response.json() as { application: { applicationId: string; providerId: string } };
+      expect(body.application.applicationId).toBeDefined();
+      expect(body.application.providerId).toBe('google-gmail');
+    });
+
+    it('creates a new Outlook application and returns it', async () => {
+      const response: Response = await SELF.fetch('http://localhost/user/application', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          displayName: 'My Outlook App',
+          providerId: 'microsoft-outlook',
+          connectionMethod: 'oauth2',
+          clientId: 'outlook-client-id',
+          clientSecret: 'outlook-client-secret',
+        }),
+      });
+
+      expect(response.status).toBe(200);
+      const body = await response.json() as { application: { providerId: string } };
+      expect(body.application.providerId).toBe('microsoft-outlook');
+    });
+
+    it('returns 400 when required fields are missing', async () => {
+      const response: Response = await SELF.fetch('http://localhost/user/application', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ displayName: 'Incomplete' }),
+      });
+
+      expect(response.status).toBe(400);
+    });
+
+    it('returns 400 when gmailPubsubTopicName is missing for Gmail', async () => {
+      const response: Response = await SELF.fetch('http://localhost/user/application', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          displayName: 'Gmail without topic',
+          providerId: 'google-gmail',
+          connectionMethod: 'oauth2',
+          clientId: 'cid',
+          clientSecret: 'cs',
+        }),
+      });
+
+      expect(response.status).toBe(400);
+    });
+  });
+
+  describe('PUT /user/application', () => {
+    it('updates an existing application display name', async () => {
+      const createResponse: Response = await SELF.fetch('http://localhost/user/application', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify(GMAIL_BODY),
+      });
+      expect(createResponse.status).toBe(200);
+      const createBody = await createResponse.json() as { application: { applicationId: string } };
+      const applicationId = createBody.application.applicationId;
+
+      const response: Response = await SELF.fetch('http://localhost/user/application', {
+        method: 'PUT',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          applicationId,
+          displayName: 'Renamed App',
+          providerId: 'google-gmail',
+          connectionMethod: 'oauth2',
+          gmailPubsubTopicName: 'projects/my-project/topics/mail-otter',
+        }),
+      });
+
+      expect(response.status).toBe(200);
+      const body = await response.json() as { application: { applicationId: string } };
+      expect(body.application.applicationId).toBe(applicationId);
+    });
+
+    it('returns 400 when application is not found', async () => {
+      const response: Response = await SELF.fetch('http://localhost/user/application', {
+        method: 'PUT',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          applicationId: NONEXISTENT_UUID,
+          displayName: 'X',
+          providerId: 'google-gmail',
+          connectionMethod: 'oauth2',
+          gmailPubsubTopicName: 'projects/my-project/topics/mail-otter',
+        }),
+      });
+
+      expect(response.status).toBe(400);
+    });
+  });
+
+  describe('DELETE /user/application', () => {
+    it('deletes an existing application', async () => {
+      const applicationId = await seedApplication(TEST_EMAIL);
+
+      const response: Response = await SELF.fetch('http://localhost/user/application', {
+        method: 'DELETE',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ applicationId }),
+      });
+
+      expect(response.status).toBe(200);
+      const body = await response.json() as { success: boolean };
+      expect(body.success).toBe(true);
+    });
+
+    it('returns 200 even when application does not exist', async () => {
+      const response: Response = await SELF.fetch('http://localhost/user/application', {
+        method: 'DELETE',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ applicationId: NONEXISTENT_UUID }),
+      });
+
+      expect(response.status).toBe(200);
+      const body = await response.json() as { success: boolean };
+      expect(body.success).toBe(true);
+    });
+  });
+
+  describe('POST /user/application (max limit)', () => {
+    it('returns 400 when the max applications limit is reached', async () => {
+      const now = Math.floor(Date.now() / 1000);
+      const countRow = await env.DB.prepare(
+        `SELECT COUNT(*) as count FROM connected_applications WHERE user_email = ?`,
+      ).bind(TEST_EMAIL).first<{ count: number }>();
+      const existing = countRow?.count ?? 0;
+
+      for (let i = existing; i < 99; i++) {
+        await env.DB.prepare(
+          `INSERT INTO connected_applications (application_id, user_email, display_name, provider_id, connection_method, encrypted_credentials, credentials_iv, status, created_at, updated_at) ` +
+          `VALUES (?, ?, ?, 'google-gmail', 'oauth2', 'enc', 'iv', 'draft', ?, ?)`,
+        ).bind(`limit-app-${i}-${Date.now()}`, TEST_EMAIL, 'App', now, now).run();
+      }
+
+      const response: Response = await SELF.fetch('http://localhost/user/application', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify(GMAIL_BODY),
+      });
+
+      expect(response.status).toBe(400);
+    });
+  });
+});

--- a/test/integration/vitest.config.mts
+++ b/test/integration/vitest.config.mts
@@ -47,6 +47,10 @@ export default defineConfig({
         '**/index.ts',
         '**/types.d.ts',
       ],
+      // NOTE: V8 coverage instrumentation is not functional with @cloudflare/vitest-pool-workers
+      // because the Cloudflare Workers sandbox does not expose node:inspector/promises.
+      // Run `pnpm run test:integration` (without --coverage) for integration testing.
+      // Coverage thresholds are omitted intentionally — they would always fail at 0%.
     },
     pool: cloudflarePool({
       wrangler: {


### PR DESCRIPTION
- Add 13 new ProcessedMessageDAO tests covering markSummarized, markSkipped, markError (with 1024-char truncation), deleteOlderThan, getLatestForApplication, getLatestErrorForApplication, and getByMessageId using the vi.fn makeDb() stub pattern.

- Add UserApplications integration test suite (12 tests) covering GET /user/me, GET /user/applications, POST /user/application (Gmail, Outlook, validation errors, max-limit), PUT /user/application (update
  + not-found), and DELETE /user/application (existing + non-existent). Uses adminSecretsStore to seed a valid AES-256-GCM key so credential encryption succeeds end-to-end through miniflare.

- Add a comment to test/integration/vitest.config.mts explaining why coverage thresholds are intentionally omitted: the Cloudflare Workers sandbox lacks node:inspector/promises, so --coverage always produces 0% and adding thresholds would permanently break CI.