### PR TITLE
Fix OAuth2 Callback Post-Authorization 404

### DIFF
--- a/apps/api/src/endpoints/api/oauth2/callback/GET.ts
+++ b/apps/api/src/endpoints/api/oauth2/callback/GET.ts
@@ -26,7 +26,7 @@ class OAuth2CallbackRoute extends IBaseRoute<OAuth2CallbackRequest, OAuth2Callba
     const url: URL = new URL(request.raw.url);
     const error: string | null = url.searchParams.get('error');
     if (error) {
-      return this.redirect(`/user?oauth2=error&message=${encodeURIComponent(error)}`);
+      return this.redirect(`/user/?oauth2=error&message=${encodeURIComponent(error)}`);
     }
     const code: string | null = url.searchParams.get('code');
     const state: string | null = url.searchParams.get('state');
@@ -42,7 +42,7 @@ class OAuth2CallbackRoute extends IBaseRoute<OAuth2CallbackRequest, OAuth2Callba
       },
       env,
     );
-    return this.redirect(`/user?oauth2=connected&applicationId=${encodeURIComponent(applicationId)}`);
+    return this.redirect(`/user/?oauth2=connected&applicationId=${encodeURIComponent(applicationId)}`);
   }
 
   private redirect(location: string): ExtendedResponse<OAuth2CallbackResponse> {

--- a/apps/api/src/workers/MailOtterWorker.ts
+++ b/apps/api/src/workers/MailOtterWorker.ts
@@ -54,7 +54,7 @@ class MailOtterWorker extends AbstractEntrypointWorker {
     }>();
 
     app.get('/', (c) => c.redirect('/user/'));
-    app.get('/user', (c) => c.redirect('/user/'));
+    app.get('/user', (c) => c.redirect('/user/' + new URL(c.req.url).search));
     app.options('/user/*', (_c) => {
       return new Response(null, {
         status: 204,

--- a/apps/api/wrangler.template.jsonc
+++ b/apps/api/wrangler.template.jsonc
@@ -28,6 +28,7 @@
   },
   "assets": {
     "directory": "./apps/web/dist/",
+    "not_found_handling": "single-page-application",
   },
   "durable_objects": {
     "bindings": [


### PR DESCRIPTION
After OAuth2 authorization, the callback endpoint redirected to `/user?oauth2=...` (no trailing slash). The Worker's `/user` route intercepted this and redirected to `/user/` stripping all query parameters, then Cloudflare Assets returned 404 because no `user/index.html` exists and `SERVE_SPA_FROM_WORKER` defaults to false.

- Redirect OAuth2 callback to `/user/?oauth2=...` (trailing slash before `?`) to bypass the intermediate `/user` → `/user/` bounce entirely
- Fix the `/user` redirect to forward any query string to `/user/` so that other callers landing on `/user?...` don't silently lose params
- Add `not_found_handling: single-page-application` to the assets config so Cloudflare Workers Assets serves `index.html` for any unmatched path, fixing the 404 for `/user/` and all other SPA routes