### PR TITLE
Preserve Application Status On Non-Credential Update

### DIFF
--- a/packages/backend-services/src/application/ApplicationService.ts
+++ b/packages/backend-services/src/application/ApplicationService.ts
@@ -72,17 +72,21 @@ class ApplicationService {
     }
 
     const existingOAuth2 = existing.credentials as OAuth2Credentials;
+    const newClientId = input.clientId || existingOAuth2.clientId;
+    const newClientSecret = input.clientSecret || existingOAuth2.clientSecret;
     const credentials: ConnectedApplicationCredentials = {
-      clientId: input.clientId || existingOAuth2.clientId,
-      clientSecret: input.clientSecret || existingOAuth2.clientSecret,
+      clientId: newClientId,
+      clientSecret: newClientSecret,
       refreshToken: existingOAuth2.refreshToken,
     };
+    const credentialsChanged = newClientId !== existingOAuth2.clientId || newClientSecret !== existingOAuth2.clientSecret;
+    const newStatus = credentialsChanged ? CONNECTED_APPLICATION_STATUS_DRAFT : existing.status;
     const application: ConnectedApplicationMetadata | undefined = await applicationDAO.updateForUser(
       input.applicationId,
       userEmail,
       input.displayName,
       credentials,
-      CONNECTED_APPLICATION_STATUS_DRAFT,
+      newStatus,
       input.gmailPubsubTopicName || null,
       input.enabledFeatures,
       input.senderDomainFilters,

--- a/test/services/ApplicationService.test.ts
+++ b/test/services/ApplicationService.test.ts
@@ -247,6 +247,54 @@ describe('ApplicationService', () => {
       const lastArg = mockUpdateForUser.mock.calls[0]?.at(-1);
       expect(lastArg).toBeUndefined();
     });
+
+    it('preserves connected status when credentials are unchanged', async () => {
+      mockGetByIdForUser.mockResolvedValue({
+        applicationId: 'app-1',
+        providerId: 'google-gmail',
+        connectionMethod: 'oauth2',
+        status: 'connected',
+        credentials: { clientId: 'cid', clientSecret: 'cs', refreshToken: 'rt' },
+      });
+      mockUpdateForUser.mockResolvedValue({ applicationId: 'app-1' });
+
+      await ApplicationService.updateUserApplication(
+        'user@example.com',
+        {
+          applicationId: 'app-1',
+          displayName: 'Updated',
+          providerId: 'google-gmail',
+          connectionMethod: 'oauth2',
+          senderDomainFilters: { includeRules: ['@company.com'], excludeRules: [] },
+        },
+        makeEnv(),
+        new Request('https://example.com'),
+      );
+
+      const statusArg = mockUpdateForUser.mock.calls[0]?.[4];
+      expect(statusArg).toBe('connected');
+    });
+
+    it('resets to draft when clientId changes', async () => {
+      mockGetByIdForUser.mockResolvedValue({
+        applicationId: 'app-1',
+        providerId: 'google-gmail',
+        connectionMethod: 'oauth2',
+        status: 'connected',
+        credentials: { clientId: 'old-cid', clientSecret: 'cs', refreshToken: 'rt' },
+      });
+      mockUpdateForUser.mockResolvedValue({ applicationId: 'app-1' });
+
+      await ApplicationService.updateUserApplication(
+        'user@example.com',
+        { applicationId: 'app-1', displayName: 'Updated', providerId: 'google-gmail', connectionMethod: 'oauth2', clientId: 'new-cid' },
+        makeEnv(),
+        new Request('https://example.com'),
+      );
+
+      const statusArg = mockUpdateForUser.mock.calls[0]?.[4];
+      expect(statusArg).toBe('draft');
+    });
   });
 
   describe('updateWatchedFolderIds', () => {


### PR DESCRIPTION
`ApplicationService.updateUserApplication` was hardcoding `CONNECTED_APPLICATION_STATUS_DRAFT` on every PUT request, causing connected applications to silently reset to draft whenever sender filters, display name, or enabled features were changed — requiring an unnecessary OAuth2 re-authorization.

Status is now only reset to draft when `clientId` or `clientSecret` actually change (invalidating existing OAuth2 tokens). All other field updates preserve the existing status.

Two new tests cover the happy path (connected status preserved on filter update) and the credential-change path (reset to draft).