### PR TITLE
Apply Title Case To All Web UI Text

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -194,6 +194,22 @@ The sink derivation is done in `OutlookProviderUtil.sendSelfSummaryReply` by spl
 
 Do not reintroduce password signup or user-managed refresh-token paste flows.
 
+## Web UI Text Conventions
+
+All user-visible text in `apps/web/` must use **Title Case** (capitalize the first letter of every word). This applies to:
+
+- Button labels, headings, card titles, section headers
+- Form labels, placeholders, and input hints
+- Empty-state messages, error/success toast notifications, and confirm dialog text
+- Tooltip `title` attributes, `aria-label` values, and `<option>` text
+- Inline metric labels and status suffixes
+
+**Exceptions — do not Title Case:**
+- Text already in ALL CAPS (e.g., from CSS `text-transform: uppercase`)
+- Content inside `<code>` tags (e.g., `@domain.com`, technical format strings)
+- Technical URI/path placeholders (e.g., `projects/{projectId}/topics/{topicName}`)
+- Dynamic content from API responses (provider names, user-supplied data)
+
 ## Test Coverage History
 
 - Initial threshold: 90/80/90/90

--- a/apps/web/components/Unauthorized.tsx
+++ b/apps/web/components/Unauthorized.tsx
@@ -12,7 +12,7 @@ export default function Unauthorized() {
           <span className="text-[var(--color-accent)]">Mail</span>-Otter
         </div>
         <h1 className="text-lg font-medium mt-4 mb-1">Access Required</h1>
-        <p className="text-[var(--color-text-secondary)] text-sm">You must authenticate to access this application.</p>
+        <p className="text-[var(--color-text-secondary)] text-sm">You Must Authenticate To Access This Application.</p>
         <button
           type="button"
           onClick={authenticateWithZeroTrust}

--- a/apps/web/src/SpaApp.tsx
+++ b/apps/web/src/SpaApp.tsx
@@ -26,8 +26,8 @@ import { emptyForm } from './components/mailboxes/MailboxForm';
 
 function getInitialNotice(): { type: 'success' | 'error'; text: string } | null {
   const params = new URLSearchParams(window.location.search);
-  if (params.get('oauth2') === 'connected') return { type: 'success', text: 'OAuth2 connection completed.' };
-  if (params.get('oauth2') === 'error') return { type: 'error', text: params.get('message') || 'OAuth2 connection failed.' };
+  if (params.get('oauth2') === 'connected') return { type: 'success', text: 'OAuth2 Connection Completed.' };
+  if (params.get('oauth2') === 'error') return { type: 'error', text: params.get('message') || 'OAuth2 Connection Failed.' };
   return null;
 }
 
@@ -128,13 +128,13 @@ export default function SpaApp() {
 
   useEffect(() => {
     if (authorized && activeView === 'context') {
-      loadContextAudit().catch((e: unknown) => showNotice('error', e instanceof Error ? e.message : 'Unable to load context.'));
+      loadContextAudit().catch((e: unknown) => showNotice('error', e instanceof Error ? e.message : 'Unable To Load Context.'));
     }
   }, [activeView, authorized, loadContextAudit, showNotice]);
 
   useEffect(() => {
     if (authorized && activeView === 'actions') {
-      loadActions().catch((e: unknown) => showNotice('error', e instanceof Error ? e.message : 'Unable to load actions.'));
+      loadActions().catch((e: unknown) => showNotice('error', e instanceof Error ? e.message : 'Unable To Load Actions.'));
     }
   }, [activeView, authorized, loadActions, showNotice]);
 
@@ -177,12 +177,12 @@ export default function SpaApp() {
         body: JSON.stringify(payload),
       });
       const data = await readJson<{ application: ConnectedApplication }>(res);
-      showNotice('success', applicationForm.applicationId ? 'Mailbox updated.' : 'Mailbox created.');
+      showNotice('success', applicationForm.applicationId ? 'Mailbox Updated.' : 'Mailbox Created.');
       resetForm();
       await loadApplications();
       setSelectedApplicationId(data.application.applicationId);
     } catch (e) {
-      showNotice('error', e instanceof Error ? e.message : 'Unable to save mailbox.');
+      showNotice('error', e instanceof Error ? e.message : 'Unable To Save Mailbox.');
     } finally {
       setIsBusy(false);
     }
@@ -198,12 +198,12 @@ export default function SpaApp() {
           body: JSON.stringify({ applicationId }),
         }),
       );
-      showNotice('success', 'Mailbox deleted.');
+      showNotice('success', 'Mailbox Deleted.');
       setSelectedApplicationId('');
       setWatchWebhookUrl('');
       await loadApplications();
     } catch (e) {
-      showNotice('error', e instanceof Error ? e.message : 'Unable to delete mailbox.');
+      showNotice('error', e instanceof Error ? e.message : 'Unable To Delete Mailbox.');
     } finally {
       setIsBusy(false);
     }
@@ -221,7 +221,7 @@ export default function SpaApp() {
       );
       window.location.assign(data.authorizationUrl);
     } catch (e) {
-      showNotice('error', e instanceof Error ? e.message : 'Unable to start OAuth2.');
+      showNotice('error', e instanceof Error ? e.message : 'Unable To Start OAuth2.');
       setIsBusy(false);
     }
   };
@@ -240,7 +240,7 @@ export default function SpaApp() {
       await loadApplications();
       showNotice('success', data.message);
     } catch (e) {
-      showNotice('error', e instanceof Error ? e.message : 'Unable to start watch.');
+      showNotice('error', e instanceof Error ? e.message : 'Unable To Start Watch.');
     } finally {
       setIsBusy(false);
     }
@@ -260,7 +260,7 @@ export default function SpaApp() {
       await loadApplications();
       showNotice('success', data.message);
     } catch (e) {
-      showNotice('error', e instanceof Error ? e.message : 'Unable to stop watch.');
+      showNotice('error', e instanceof Error ? e.message : 'Unable To Stop Watch.');
     } finally {
       setIsBusy(false);
     }
@@ -277,10 +277,10 @@ export default function SpaApp() {
         }),
       );
       setApplications((c) => c.map((a) => (a.applicationId === data.application.applicationId ? data.application : a)));
-      showNotice('success', contextIndexingEnabled ? 'Context indexing enabled.' : 'Context indexing disabled.');
+      showNotice('success', contextIndexingEnabled ? 'Context Indexing Enabled.' : 'Context Indexing Disabled.');
       if (activeView === 'context') await loadContextAudit();
     } catch (e) {
-      showNotice('error', e instanceof Error ? e.message : 'Unable to update context setting.');
+      showNotice('error', e instanceof Error ? e.message : 'Unable To Update Context Setting.');
     } finally {
       setIsBusy(false);
     }
@@ -297,9 +297,9 @@ export default function SpaApp() {
         }),
       );
       setApplications((c) => c.map((a) => (a.applicationId === data.application.applicationId ? data.application : a)));
-      showNotice('success', maxContextDocuments != null ? `Document limit set to ${maxContextDocuments}.` : 'Document limit reset.');
+      showNotice('success', maxContextDocuments != null ? `Document Limit Set To ${maxContextDocuments}.` : 'Document Limit Reset.');
     } catch (e) {
-      showNotice('error', e instanceof Error ? e.message : 'Unable to update document limit.');
+      showNotice('error', e instanceof Error ? e.message : 'Unable To Update Document Limit.');
     } finally {
       setIsBusy(false);
     }
@@ -313,7 +313,7 @@ export default function SpaApp() {
       );
       setAvailableFolders(data.folders);
     } catch (e) {
-      showNotice('error', e instanceof Error ? e.message : 'Unable to load folders.');
+      showNotice('error', e instanceof Error ? e.message : 'Unable To Load Folders.');
     } finally {
       setLoadingFolders(false);
     }
@@ -338,7 +338,7 @@ export default function SpaApp() {
       );
       setApplications((c) => c.map((a) => (a.applicationId === data.application.applicationId ? data.application : a)));
     } catch (e) {
-      showNotice('error', e instanceof Error ? e.message : 'Unable to update watch folders.');
+      showNotice('error', e instanceof Error ? e.message : 'Unable To Update Watch Folders.');
     } finally {
       setIsBusy(false);
     }
@@ -365,9 +365,9 @@ export default function SpaApp() {
         }),
       );
       setApplications((c) => c.map((a) => (a.applicationId === data.application.applicationId ? data.application : a)));
-      showNotice('success', 'Sender filter rules updated.');
+      showNotice('success', 'Sender Filter Rules Updated.');
     } catch (e) {
-      showNotice('error', e instanceof Error ? e.message : 'Unable to update sender filters.');
+      showNotice('error', e instanceof Error ? e.message : 'Unable To Update Sender Filters.');
     } finally {
       setIsBusy(false);
     }
@@ -375,7 +375,7 @@ export default function SpaApp() {
 
   const deleteContextDocuments = async (applicationId: string) => {
     const app = applications.find((a) => a.applicationId === applicationId);
-    if (!window.confirm(`Delete all indexed documents for ${app?.displayName || 'this mailbox'}?`)) return;
+    if (!window.confirm(`Delete All Indexed Documents For ${app?.displayName || 'This Mailbox'}?`)) return;
     setIsBusy(true);
     try {
       const data = await readJson<{ deletionRun: ApplicationContextDeletionRun }>(
@@ -389,10 +389,10 @@ export default function SpaApp() {
       if (activeView === 'context') await loadContextAudit();
       showNotice(
         data.deletionRun.status === 'accepted' ? 'success' : 'error',
-        data.deletionRun.status === 'accepted' ? 'Context documents deletion accepted.' : data.deletionRun.errorMessage || 'Context deletion failed.',
+        data.deletionRun.status === 'accepted' ? 'Context Documents Deletion Accepted.' : data.deletionRun.errorMessage || 'Context Deletion Failed.',
       );
     } catch (e) {
-      showNotice('error', e instanceof Error ? e.message : 'Unable to delete context documents.');
+      showNotice('error', e instanceof Error ? e.message : 'Unable To Delete Context Documents.');
     } finally {
       setIsBusy(false);
     }
@@ -431,7 +431,7 @@ export default function SpaApp() {
       );
       setActionExecutions(data.executions);
     } catch (e) {
-      showNotice('error', e instanceof Error ? e.message : 'Unable to load action audit.');
+      showNotice('error', e instanceof Error ? e.message : 'Unable To Load Action Audit.');
     }
   };
 
@@ -445,7 +445,7 @@ export default function SpaApp() {
       await loadActionExecutions(actionId);
       showNotice(data.action.status === 'succeeded' ? 'success' : 'error', data.action.result?.summary || data.action.errorMessage || data.action.status);
     } catch (e) {
-      showNotice('error', e instanceof Error ? e.message : 'Unable to execute action.');
+      showNotice('error', e instanceof Error ? e.message : 'Unable To Execute Action.');
     } finally {
       setIsBusy(false);
     }
@@ -458,7 +458,7 @@ export default function SpaApp() {
       );
       window.open(data.url, '_blank', 'noopener,noreferrer');
     } catch (e) {
-      showNotice('error', e instanceof Error ? e.message : 'Unable to open provider document.');
+      showNotice('error', e instanceof Error ? e.message : 'Unable To Open Provider Document.');
     }
   };
 
@@ -472,7 +472,7 @@ export default function SpaApp() {
       setAuditLogs(data.logs);
       setAuditLogsCursor(data.nextCursor ?? undefined);
     } catch (e) {
-      showNotice('error', e instanceof Error ? e.message : 'Unable to load audit logs.');
+      showNotice('error', e instanceof Error ? e.message : 'Unable To Load Audit Logs.');
       setAuditLogDocumentId(null);
     } finally {
       setLoadingAuditLogs(false);
@@ -487,7 +487,7 @@ export default function SpaApp() {
       setAuditLogs((p) => [...p, ...data.logs]);
       setAuditLogsCursor(data.nextCursor ?? undefined);
     } catch (e) {
-      showNotice('error', e instanceof Error ? e.message : 'Unable to load more audit logs.');
+      showNotice('error', e instanceof Error ? e.message : 'Unable To Load More Audit Logs.');
     } finally {
       setLoadingAuditLogs(false);
     }
@@ -501,7 +501,7 @@ export default function SpaApp() {
       setAuditLogs(data.logs);
       setAuditLogsCursor(data.nextCursor ?? undefined);
     } catch (e) {
-      showNotice('error', e instanceof Error ? e.message : 'Unable to refresh audit logs.');
+      showNotice('error', e instanceof Error ? e.message : 'Unable To Refresh Audit Logs.');
     } finally {
       setLoadingAuditLogs(false);
     }

--- a/apps/web/src/components/context/ContextDeletionRunRow.tsx
+++ b/apps/web/src/components/context/ContextDeletionRunRow.tsx
@@ -17,7 +17,7 @@ export function ContextDeletionRunRow({
             {application?.displayName || run.applicationId}
           </div>
           <div className="text-sm text-[var(--color-text-secondary)] mt-0.5">
-            {run.deletedVectorCount}/{run.requestedVectorCount} vectors deleted
+            {run.deletedVectorCount}/{run.requestedVectorCount} Vectors Deleted
           </div>
           <div className="text-xs text-[var(--color-text-muted)] mt-0.5">{formatTimestamp(run.createdAt)}</div>
         </div>

--- a/apps/web/src/components/context/ContextDocumentRow.tsx
+++ b/apps/web/src/components/context/ContextDocumentRow.tsx
@@ -36,7 +36,7 @@ export function ContextDocumentRow({
             Document {formatFingerprint(document.sourceDocumentFingerprint)}
           </div>
           <div className="text-sm text-[var(--color-text-secondary)] truncate mt-0.5">
-            {application?.displayName || document.applicationId} · {providerLabels[document.sourceProviderId]} · {document.indexedTextChars} chars
+            {application?.displayName || document.applicationId} · {providerLabels[document.sourceProviderId]} · {document.indexedTextChars} Chars
           </div>
           <div className="text-xs text-[var(--color-text-muted)] mt-0.5">
             Indexed {formatTimestamp(document.indexedAt)} · Updated {formatTimestamp(document.updatedAt)}

--- a/apps/web/src/components/mailboxes/ContextSection.tsx
+++ b/apps/web/src/components/mailboxes/ContextSection.tsx
@@ -34,10 +34,10 @@ export function ContextSection({
               disabled={busy}
               className="h-4 w-4 accent-[var(--color-accent)] rounded"
             />
-            Index new emails
+            Index New Emails
           </label>
           <label className="inline-flex items-center gap-2 text-sm text-[var(--color-text-secondary)]">
-            Max docs
+            Max Docs
             <input
               type="number"
               min={1}
@@ -56,11 +56,11 @@ export function ContextSection({
       </CardHeader>
 
       <div className="grid grid-cols-1 md:grid-cols-4 gap-3">
-        <Metric label="Indexed docs" value={String(application.contextDocumentCount || 0)} />
-        <Metric label="Last indexed" value={formatTimestamp(application.contextLastIndexedAt)} />
-        <Metric label="Last deletion" value={formatTimestamp(application.contextLastDeleteAcceptedAt)} />
+        <Metric label="Indexed Docs" value={String(application.contextDocumentCount || 0)} />
+        <Metric label="Last Indexed" value={formatTimestamp(application.contextLastIndexedAt)} />
+        <Metric label="Last Deletion" value={formatTimestamp(application.contextLastDeleteAcceptedAt)} />
         <Metric
-          label="Context error"
+          label="Context Error"
           value={application.contextLastError || 'None'}
           tone={application.contextLastError ? 'error' : 'muted'}
           subtitle={application.contextLastError ? formatTimestamp(application.contextLastErrorAt) : undefined}

--- a/apps/web/src/components/mailboxes/MailboxCard.tsx
+++ b/apps/web/src/components/mailboxes/MailboxCard.tsx
@@ -29,11 +29,11 @@ export function MailboxCard({
             {providerLabels[application.providerId]}
           </div>
           <div className="text-xs text-[var(--color-text-muted)] truncate mt-0.5">
-            {application.providerEmail || 'Not authorized'}
+            {application.providerEmail || 'Not Authorized'}
           </div>
           <div className="mt-2 flex items-center gap-2">
             <ContextIndexBadge enabled={application.contextIndexingEnabled} />
-            <span className="text-xs text-[var(--color-text-muted)]">{application.contextDocumentCount || 0} docs</span>
+            <span className="text-xs text-[var(--color-text-muted)]">{application.contextDocumentCount || 0} Docs</span>
           </div>
         </div>
         <ConnectionBadge status={application.status} />

--- a/apps/web/src/components/mailboxes/MailboxDetail.tsx
+++ b/apps/web/src/components/mailboxes/MailboxDetail.tsx
@@ -61,7 +61,7 @@ export function MailboxDetail({
               {application.watchStatus && <WatchBadge status={application.watchStatus} />}
             </div>
             <div className="text-sm text-[var(--color-text-secondary)]">
-              {providerLabels[application.providerId]} · {application.providerEmail || 'Not authorized'}
+              {providerLabels[application.providerId]} · {application.providerEmail || 'Not Authorized'}
             </div>
             <div className="text-xs text-[var(--color-text-muted)] mt-1">Updated {formatTimestamp(application.updatedAt)}</div>
           </div>
@@ -72,16 +72,16 @@ export function MailboxDetail({
         </div>
 
         <div className="mt-5 grid grid-cols-1 gap-3">
-          <ReadOnlyField label="OAuth2 redirect URI" value={application.oauth2RedirectUri || ''} showCopy />
+          <ReadOnlyField label="OAuth2 Redirect URI" value={application.oauth2RedirectUri || ''} showCopy />
           {application.providerId === 'google-gmail' && (
-            <ReadOnlyField label="Gmail Pub/Sub topic" value={application.gmailPubsubTopicName || ''} />
+            <ReadOnlyField label="Gmail Pub/Sub Topic" value={application.gmailPubsubTopicName || ''} />
           )}
-          <ReadOnlyField label="Webhook endpoint" value={watchWebhookUrl || application.webhookUrl || ''} showCopy />
+          <ReadOnlyField label="Webhook Endpoint" value={watchWebhookUrl || application.webhookUrl || ''} showCopy />
         </div>
 
         <div className="mt-5 flex flex-wrap gap-2">
           <Button variant={application.status === 'connected' ? 'secondary' : 'primary'} size="sm" onClick={onStartOAuth2} disabled={busy}>
-            {application.status === 'connected' ? 'Re-authorize OAuth2' : 'Authorize OAuth2'}
+            {application.status === 'connected' ? 'Re-Authorize OAuth2' : 'Authorize OAuth2'}
           </Button>
           <Button
             variant="secondary"
@@ -108,10 +108,10 @@ export function MailboxDetail({
           <CardTitle>Processing</CardTitle>
         </CardHeader>
         <div className="grid grid-cols-1 md:grid-cols-3 gap-3">
-          <Metric label="Watch expires" value={formatExpiryTimestamp(application.watchExpiresAt)} />
-          <Metric label="Last summary" value={formatTimestamp(application.lastSummaryAt)} />
+          <Metric label="Watch Expires" value={formatExpiryTimestamp(application.watchExpiresAt)} />
+          <Metric label="Last Summary" value={formatTimestamp(application.lastSummaryAt)} />
           <Metric
-            label="Last error"
+            label="Last Error"
             value={application.lastError || 'None'}
             tone={application.lastError ? 'error' : 'muted'}
             subtitle={application.lastError ? formatTimestamp(application.lastErrorAt) : undefined}

--- a/apps/web/src/components/mailboxes/MailboxForm.tsx
+++ b/apps/web/src/components/mailboxes/MailboxForm.tsx
@@ -98,7 +98,7 @@ export function MailboxForm({
           <Input
             value={form.displayName}
             onChange={(e) => update({ displayName: e.target.value })}
-            placeholder="Display name"
+            placeholder="Display Name"
           />
           <Select
             value={form.providerId}
@@ -112,12 +112,12 @@ export function MailboxForm({
           <Input
             value={form.clientId}
             onChange={(e) => update({ clientId: e.target.value })}
-            placeholder={form.applicationId ? '(unchanged)' : 'OAuth2 client ID'}
+            placeholder={form.applicationId ? '(Unchanged)' : 'OAuth2 Client ID'}
           />
           <Input
             value={form.clientSecret}
             onChange={(e) => update({ clientSecret: e.target.value })}
-            placeholder={form.applicationId ? '(unchanged)' : 'OAuth2 client secret'}
+            placeholder={form.applicationId ? '(Unchanged)' : 'OAuth2 Client Secret'}
             type="password"
           />
           {form.providerId === 'google-gmail' && (
@@ -129,7 +129,7 @@ export function MailboxForm({
           )}
           {providerFeatures.length > 0 && (
             <div className="space-y-2 pt-1">
-              <p className="text-xs font-medium text-[var(--color-text-secondary)]">Optional features{form.applicationId ? ' (requires re-authorization)' : ''}</p>
+              <p className="text-xs font-medium text-[var(--color-text-secondary)]">Optional Features{form.applicationId ? ' (Requires Re-Authorization)' : ''}</p>
               {providerFeatures.map(([featureId, feature]) => (
                 <label key={featureId} className="inline-flex items-center gap-2.5 text-sm text-[var(--color-text-secondary)] cursor-pointer">
                   <input

--- a/apps/web/src/components/mailboxes/SenderFilterSection.tsx
+++ b/apps/web/src/components/mailboxes/SenderFilterSection.tsx
@@ -90,13 +90,13 @@ export function SenderFilterSection({
         <CardTitle>Sender Filters</CardTitle>
       </CardHeader>
       <p className="text-xs text-[var(--color-text-muted)] mb-4">
-        Include rules: only process emails from matching senders. Exclude rules: skip emails from matching senders.
-        Use <code className="font-mono">@domain.com</code> to match a domain or <code className="font-mono">user@domain.com</code> for an exact address.
-        Exclude rules are checked first.
+        Include Rules: Only Process Emails From Matching Senders. Exclude Rules: Skip Emails From Matching Senders.
+        Use <code className="font-mono">@domain.com</code> To Match A Domain Or <code className="font-mono">user@domain.com</code> For An Exact Address.
+        Exclude Rules Are Checked First.
       </p>
       <div className="flex flex-col gap-4">
-        <RuleList label="Include rules" rules={current.includeRules} busy={busy} onAdd={addInclude} onRemove={removeInclude} />
-        <RuleList label="Exclude rules" rules={current.excludeRules} busy={busy} onAdd={addExclude} onRemove={removeExclude} />
+        <RuleList label="Include Rules" rules={current.includeRules} busy={busy} onAdd={addInclude} onRemove={removeInclude} />
+        <RuleList label="Exclude Rules" rules={current.excludeRules} busy={busy} onAdd={addExclude} onRemove={removeExclude} />
       </div>
     </Card>
   );

--- a/apps/web/src/components/mailboxes/WatchSection.tsx
+++ b/apps/web/src/components/mailboxes/WatchSection.tsx
@@ -36,7 +36,7 @@ export function WatchSection({
 
       {availableFolders ? (
         availableFolders.length === 0 ? (
-          <p className="text-sm text-[var(--color-text-secondary)]">No folders found.</p>
+          <p className="text-sm text-[var(--color-text-secondary)]">No Folders Found.</p>
         ) : (
           <div className="flex flex-col gap-2">
             {availableFolders.map((folder) => {
@@ -67,11 +67,11 @@ export function WatchSection({
         )
       ) : application.watchedFolders && application.watchedFolders.length > 0 ? (
         <p className="text-sm text-[var(--color-text-secondary)]">
-          Watching: {application.watchedFolders.map((wf) => wf.name).join(', ')} — click &quot;Load Folders&quot; to change.
+          Watching: {application.watchedFolders.map((wf) => wf.name).join(', ')} — Click &quot;Load Folders&quot; To Change.
         </p>
       ) : (
         <p className="text-sm text-[var(--color-text-secondary)]">
-          Watching default folder (Inbox). Click &quot;Load Folders&quot; to customize.
+          Watching Default Folder (Inbox). Click &quot;Load Folders&quot; To Customize.
         </p>
       )}
     </Card>

--- a/apps/web/src/components/modals/AuditLogsModal.tsx
+++ b/apps/web/src/components/modals/AuditLogsModal.tsx
@@ -60,7 +60,7 @@ export function AuditLogsModal({
 
         <div className="overflow-y-auto p-5 space-y-2.5 max-h-[calc(82vh-4rem)]">
           {logs.length === 0 && !loading && (
-            <div className="text-center text-[var(--color-text-muted)] py-10 text-sm">No audit logs found for this document.</div>
+            <div className="text-center text-[var(--color-text-muted)] py-10 text-sm">No Audit Logs Found For This Document.</div>
           )}
           {logs.map((log, index) => {
             const dotClass =

--- a/apps/web/src/components/modals/ConfirmDeleteModal.tsx
+++ b/apps/web/src/components/modals/ConfirmDeleteModal.tsx
@@ -15,7 +15,7 @@ export function ConfirmDeleteModal({
     <div
       onClick={(e) => e.stopPropagation()}
       role="dialog"
-      aria-label="Confirm delete mailbox"
+      aria-label="Confirm Delete Mailbox"
       aria-modal="true"
       className="fixed inset-0 z-50 flex items-center justify-center"
     >
@@ -25,7 +25,7 @@ export function ConfirmDeleteModal({
           <AlertTriangle className="h-5 w-5 text-[var(--color-error-text)]" />
         </div>
         <p className="text-sm text-[var(--color-text-secondary)] text-center mb-6">
-          Delete <span className="font-medium text-[var(--color-text-primary)]">{displayName}</span>? This cannot be undone.
+          Delete <span className="font-medium text-[var(--color-text-primary)]">{displayName}</span>? This Cannot Be Undone.
         </p>
         <div className="flex gap-3">
           <Button variant="ghost" className="flex-1" onClick={(e) => { e.stopPropagation(); onCancel(); }}>

--- a/apps/web/src/components/shared/ReadOnlyField.tsx
+++ b/apps/web/src/components/shared/ReadOnlyField.tsx
@@ -29,7 +29,7 @@ export function ReadOnlyField({ label, value, showCopy = false }: { label: strin
             type="button"
             onClick={handleCopy}
             className="px-3 py-2 rounded-r-lg bg-[var(--color-surface-3)] hover:bg-[var(--color-surface-4)] border border-[var(--color-border)] text-[var(--color-text-secondary)] transition-colors duration-150"
-            title="Copy to clipboard"
+            title="Copy To Clipboard"
           >
             {copied ? <Check className="h-3.5 w-3.5 text-[var(--color-success-text)]" /> : <Copy className="h-3.5 w-3.5" />}
           </button>

--- a/apps/web/src/components/views/ActionsView.tsx
+++ b/apps/web/src/components/views/ActionsView.tsx
@@ -49,7 +49,7 @@ export function ActionsView({
         <div>
           <h1 className="text-xl font-semibold text-[var(--color-text-primary)]">Actions</h1>
           <p className="text-sm text-[var(--color-text-secondary)] mt-0.5">
-            Review AI-proposed actions, execution results, audit trail, and expiry.
+            Review AI-Proposed Actions, Execution Results, Audit Trail, And Expiry.
           </p>
         </div>
         <Button variant="secondary" size="sm" onClick={onRefresh} disabled={busy}>
@@ -63,7 +63,7 @@ export function ActionsView({
         <div className="flex flex-col gap-1.5">
           <Label>Mailbox</Label>
           <Select value={applicationId} onChange={(e) => setApplicationId(e.target.value)} className="min-w-[180px]">
-            <option value="">All mailboxes</option>
+            <option value="">All Mailboxes</option>
             {applications.map((app) => (
               <option key={app.applicationId} value={app.applicationId}>{app.displayName}</option>
             ))}
@@ -72,7 +72,7 @@ export function ActionsView({
         <div className="flex flex-col gap-1.5">
           <Label>Status</Label>
           <Select value={status} onChange={(e) => setStatus(e.target.value as EmailActionStatus | '')} className="min-w-[140px]">
-            <option value="">All statuses</option>
+            <option value="">All Statuses</option>
             {(['pending', 'executing', 'succeeded', 'failed', 'expired', 'cancelled'] as EmailActionStatus[]).map((s) => (
               <option key={s} value={s}>{s.charAt(0).toUpperCase() + s.slice(1)}</option>
             ))}
@@ -86,7 +86,7 @@ export function ActionsView({
         <Card className="p-0 overflow-hidden">
           <CardHeader className="px-5 pt-5 pb-4 border-b border-[var(--color-border)] mb-0">
             <CardTitle>Action Items</CardTitle>
-            <span className="text-sm text-[var(--color-text-muted)]">{actions.length} loaded</span>
+            <span className="text-sm text-[var(--color-text-muted)]">{actions.length} Loaded</span>
           </CardHeader>
           <div className="divide-y divide-[var(--color-border)]">
             {actions.map((action) => (
@@ -105,7 +105,7 @@ export function ActionsView({
                     <div className="font-medium text-[var(--color-text-primary)] truncate">{action.title}</div>
                     <div className="text-sm text-[var(--color-text-secondary)] mt-0.5 line-clamp-1">{action.description}</div>
                     <div className="text-xs text-[var(--color-text-muted)] mt-1">
-                      {action.actionType} · expires {formatExpiryTimestamp(action.expiresAt)}
+                      {action.actionType} · Expires {formatExpiryTimestamp(action.expiresAt)}
                     </div>
                   </div>
                   <ActionStatusBadge status={action.status} />
@@ -113,7 +113,7 @@ export function ActionsView({
               </button>
             ))}
             {actions.length === 0 && (
-              <div className="px-5 py-12 text-center text-sm text-[var(--color-text-muted)]">No actions found.</div>
+              <div className="px-5 py-12 text-center text-sm text-[var(--color-text-muted)]">No Actions Found.</div>
             )}
           </div>
           {actionsCursor && (
@@ -153,7 +153,7 @@ export function ActionsView({
                         target="_blank"
                         rel="noreferrer"
                       >
-                        Open result →
+                        Open Result →
                       </a>
                     )}
                   </div>
@@ -198,14 +198,14 @@ export function ActionsView({
                     </div>
                   ))}
                   {executions.length === 0 && (
-                    <div className="text-sm text-[var(--color-text-muted)]">No execution attempts recorded.</div>
+                    <div className="text-sm text-[var(--color-text-muted)]">No Execution Attempts Recorded.</div>
                   )}
                 </div>
               </Card>
             </>
           ) : (
             <Card className="text-center text-[var(--color-text-muted)] text-sm py-16">
-              Select an action to view details.
+              Select An Action To View Details.
             </Card>
           )}
         </div>

--- a/apps/web/src/components/views/ContextAuditView.tsx
+++ b/apps/web/src/components/views/ContextAuditView.tsx
@@ -63,7 +63,7 @@ export function ContextAuditView({
             onChange={(e) => setApplicationId(e.target.value)}
             className="min-w-[180px]"
           >
-            <option value="">All mailboxes</option>
+            <option value="">All Mailboxes</option>
             {applications.map((app) => (
               <option key={app.applicationId} value={app.applicationId}>{app.displayName}</option>
             ))}
@@ -73,7 +73,7 @@ export function ContextAuditView({
             onChange={(e) => setStatus(e.target.value as ApplicationContextDocumentStatus | '')}
             className="min-w-[130px]"
           >
-            <option value="">All statuses</option>
+            <option value="">All Statuses</option>
             <option value="active">Active</option>
             <option value="deleted">Deleted</option>
             <option value="error">Error</option>
@@ -97,7 +97,7 @@ export function ContextAuditView({
                 <ContextIndexBadge enabled={selectedApplication.contextIndexingEnabled} />
               </div>
               <div className="text-sm text-[var(--color-text-secondary)] mt-0.5">
-                {selectedApplication.contextDocumentCount || 0} active docs · last indexed {formatTimestamp(selectedApplication.contextLastIndexedAt)}
+                {selectedApplication.contextDocumentCount || 0} Active Docs · Last Indexed {formatTimestamp(selectedApplication.contextLastIndexedAt)}
               </div>
             </div>
             <div className="flex flex-wrap gap-2 shrink-0">
@@ -128,7 +128,7 @@ export function ContextAuditView({
         <div>
           <CardHeader className="mb-3 px-0">
             <CardTitle>Indexed Documents</CardTitle>
-            <span className="text-sm text-[var(--color-text-muted)]">{documents.length} loaded</span>
+            <span className="text-sm text-[var(--color-text-muted)]">{documents.length} Loaded</span>
           </CardHeader>
           <div className="space-y-2.5">
             {documents.map((doc) => (
@@ -142,7 +142,7 @@ export function ContextAuditView({
             ))}
             {documents.length === 0 && (
               <div className="rounded-xl border border-[var(--color-border)] bg-[var(--color-surface-1)] px-5 py-10 text-center text-sm text-[var(--color-text-muted)]">
-                No context documents found.
+                No Context Documents Found.
               </div>
             )}
           </div>
@@ -168,7 +168,7 @@ export function ContextAuditView({
             ))}
             {deletionRuns.length === 0 && (
               <div className="rounded-xl border border-[var(--color-border)] bg-[var(--color-surface-1)] px-5 py-10 text-center text-sm text-[var(--color-text-muted)]">
-                No deletion history.
+                No Deletion History.
               </div>
             )}
           </div>

--- a/apps/web/src/components/views/MailboxesView.tsx
+++ b/apps/web/src/components/views/MailboxesView.tsx
@@ -88,7 +88,7 @@ export function MailboxesView({
           ))}
           {applications.length === 0 && (
             <Card className="text-center text-[var(--color-text-muted)] text-sm py-8">
-              No mailboxes yet. Add one below.
+              No Mailboxes Yet. Add One Below.
             </Card>
           )}
         </div>
@@ -129,7 +129,7 @@ export function MailboxesView({
           />
         ) : (
           <Card className="text-center text-[var(--color-text-muted)] py-16 text-sm">
-            Select or create a mailbox to get started.
+            Select Or Create A Mailbox To Get Started.
           </Card>
         )}
       </section>


### PR DESCRIPTION
Converts all user-visible text in apps/web/ from sentence case to Title Case (capitalize first letter of every word) for consistency with the existing convention used in buttons, card titles, and section headers.

Changes span 16 component files:
- SpaApp.tsx: 33 toast/notification messages and confirm dialog text
- MailboxCard, MailboxDetail, MailboxForm: labels, placeholders, field names, and fallback strings
- ContextSection, WatchSection, SenderFilterSection: inline labels, description text, and empty-state messages
- ContextAuditView, ActionsView, MailboxesView: filter options, counts, empty states, and description subtitles
- ConfirmDeleteModal, AuditLogsModal: aria-labels and body copy
- ReadOnlyField: tooltip title attribute
- ContextDocumentRow, ContextDeletionRunRow: dynamic suffix labels
- Unauthorized: body paragraph

Also adds a "Web UI Text Conventions" section to AGENTS.md documenting the Title Case rule and its exceptions (code tags, ALL CAPS via CSS, technical URI placeholders, and API-sourced dynamic content).