### PR TITLE
Apply Title Case To Audit Log Event Labels

### DIFF
--- a/packages/backend-services/src/email/ContextService.ts
+++ b/packages/backend-services/src/email/ContextService.ts
@@ -210,7 +210,7 @@ class ContextService {
         userEmail,
         sourceDocumentId: doc.sourceDocumentId,
         eventType: CONTEXT_AUDIT_EVENT_DOCUMENT_DELETED,
-        eventLabel: 'Document deleted from context index',
+        eventLabel: 'Document Deleted From Context Index',
         severity: CONTEXT_AUDIT_LOG_SEVERITY_INFO,
       })),
     );

--- a/packages/backend-services/src/email/EmailContextUtil.ts
+++ b/packages/backend-services/src/email/EmailContextUtil.ts
@@ -45,7 +45,7 @@ class EmailContextUtil {
         userEmail: input.application.userEmail,
         sourceDocumentId: input.sourceDocumentId,
         eventType: CONTEXT_AUDIT_EVENT_CONTEXT_INDEXED,
-        eventLabel: 'Email document indexed into context',
+        eventLabel: 'Email Document Indexed Into Context',
         eventData: {
           indexedTextChars: auditMetadata.indexedTextChars,
           sourceProviderId: input.application.providerId,
@@ -69,7 +69,7 @@ class EmailContextUtil {
           userEmail: input.application.userEmail,
           sourceDocumentId: input.sourceDocumentId,
           eventType: CONTEXT_AUDIT_EVENT_EMBEDDING_GENERATED,
-          eventLabel: 'AI embedding generated',
+          eventLabel: 'AI Embedding Generated',
           eventData: { embeddingModel },
           severity: CONTEXT_AUDIT_LOG_SEVERITY_INFO,
         });
@@ -100,7 +100,7 @@ class EmailContextUtil {
           userEmail: input.application.userEmail,
           sourceDocumentId: input.sourceDocumentId,
           eventType: CONTEXT_AUDIT_EVENT_RAG_QUERIED,
-          eventLabel: 'Relevant context retrieved',
+          eventLabel: 'Relevant Context Retrieved',
           eventData: { ragChars: ragContext.length },
           severity: CONTEXT_AUDIT_LOG_SEVERITY_INFO,
         });
@@ -116,7 +116,7 @@ class EmailContextUtil {
           userEmail: input.application.userEmail,
           sourceDocumentId: input.sourceDocumentId,
           eventType: CONTEXT_AUDIT_EVENT_ERROR,
-          eventLabel: 'Context indexing or retrieval failed',
+          eventLabel: 'Context Indexing Or Retrieval Failed',
           eventData: { error: error instanceof Error ? error.message : String(error) },
           severity: CONTEXT_AUDIT_LOG_SEVERITY_WARNING,
         });

--- a/packages/backend-services/src/email/EmailProcessingUtil.ts
+++ b/packages/backend-services/src/email/EmailProcessingUtil.ts
@@ -553,7 +553,7 @@ class EmailProcessingUtil {
       userEmail: application.userEmail,
       sourceDocumentId,
       eventType: CONTEXT_AUDIT_EVENT_PROCESSING_STARTED,
-      eventLabel: 'Email processing started',
+      eventLabel: 'Email Processing Started',
       eventData: retryAttempt != null && retryAttempt > 1 ? { attempt: retryAttempt } : undefined,
       severity: CONTEXT_AUDIT_LOG_SEVERITY_INFO,
     });
@@ -573,7 +573,7 @@ class EmailProcessingUtil {
       userEmail: application.userEmail,
       sourceDocumentId,
       eventType: CONTEXT_AUDIT_EVENT_SUMMARY_GENERATED,
-      eventLabel: 'AI summary generated',
+      eventLabel: 'AI Summary Generated',
       eventData: retryAttempt != null && retryAttempt > 1 ? { attempt: retryAttempt } : undefined,
       severity: CONTEXT_AUDIT_LOG_SEVERITY_INFO,
     });
@@ -594,7 +594,7 @@ class EmailProcessingUtil {
       userEmail: application.userEmail,
       sourceDocumentId,
       eventType: CONTEXT_AUDIT_EVENT_ACTION_CREATED,
-      eventLabel: `Actions created from AI summary`,
+      eventLabel: 'Actions Created From AI Summary',
       eventData: {
         actionCount: actions.length,
         actionTypes: actions.map((a) => a.action.actionType),
@@ -618,7 +618,7 @@ class EmailProcessingUtil {
       userEmail: application.userEmail,
       sourceDocumentId,
       eventType: CONTEXT_AUDIT_EVENT_SUMMARY_SENT,
-      eventLabel: 'Summary email sent',
+      eventLabel: 'Summary Email Sent',
       eventData: retryAttempt != null && retryAttempt > 1 ? { attempt: retryAttempt } : undefined,
       severity: CONTEXT_AUDIT_LOG_SEVERITY_INFO,
     });
@@ -639,7 +639,7 @@ class EmailProcessingUtil {
       userEmail: application.userEmail,
       sourceDocumentId,
       eventType: CONTEXT_AUDIT_EVENT_ERROR,
-      eventLabel: 'Email processing error',
+      eventLabel: 'Email Processing Error',
       eventData: {
         error: error.message,
         errorType: error.constructor?.name,


### PR DESCRIPTION
Convert all `eventLabel` string literals in `EmailProcessingUtil`, `EmailContextUtil`, and `ContextService` from sentence case to Title Case to match the Web UI Text Conventions in CLAUDE.md.

Affected labels (10 total):
- Email Processing Started
- AI Summary Generated
- Actions Created From AI Summary
- Summary Email Sent
- Email Processing Error
- Email Document Indexed Into Context
- AI Embedding Generated
- Relevant Context Retrieved
- Context Indexing Or Retrieval Failed
- Document Deleted From Context Index

The `AuditLogsModal` fallback map already used Title Case; these backend changes make newly stored D1 records consistent with it.