### PR TITLE
Add Dismiss Button For Processing And Context Errors

### DIFF
--- a/apps/api/src/endpoints/index.ts
+++ b/apps/api/src/endpoints/index.ts
@@ -6,6 +6,7 @@ import { CreateApplicationRoute as OriginalCreateApplicationRoute } from './user
 import { UpdateApplicationRoute as OriginalUpdateApplicationRoute } from './user/application/PUT';
 import { DeleteApplicationRoute as OriginalDeleteApplicationRoute } from './user/application/DELETE';
 import { UpdateApplicationContextRoute as OriginalUpdateApplicationContextRoute } from './user/application/context/PUT';
+import { DismissApplicationErrorRoute as OriginalDismissApplicationErrorRoute } from './user/application/dismiss-error/POST';
 import { DeleteApplicationContextDocumentsRoute as OriginalDeleteApplicationContextDocumentsRoute } from './user/application/context/delete-documents/POST';
 import { ListApplicationContextDocumentsRoute as OriginalListApplicationContextDocumentsRoute } from './user/application/context/documents/GET';
 import { ListApplicationContextDeletionRunsRoute as OriginalListApplicationContextDeletionRunsRoute } from './user/application/context/deletions/GET';
@@ -32,6 +33,7 @@ export const CreateApplicationRoute: any = OriginalCreateApplicationRoute;
 export const UpdateApplicationRoute: any = OriginalUpdateApplicationRoute;
 export const DeleteApplicationRoute: any = OriginalDeleteApplicationRoute;
 export const UpdateApplicationContextRoute: any = OriginalUpdateApplicationContextRoute;
+export const DismissApplicationErrorRoute: any = OriginalDismissApplicationErrorRoute;
 export const DeleteApplicationContextDocumentsRoute: any = OriginalDeleteApplicationContextDocumentsRoute;
 export const ListApplicationContextDocumentsRoute: any = OriginalListApplicationContextDocumentsRoute;
 export const ListApplicationContextDeletionRunsRoute: any = OriginalListApplicationContextDeletionRunsRoute;

--- a/apps/api/src/endpoints/user/application/dismiss-error/POST.ts
+++ b/apps/api/src/endpoints/user/application/dismiss-error/POST.ts
@@ -1,0 +1,47 @@
+import { IUserRoute } from '@/endpoints/IUserRoute';
+import type { IUserEnv, IRequest, IResponse, RouteContext } from '@/endpoints/IUserRoute';
+import { ApplicationService } from '@mail-otter/backend-services/application';
+import type { ApplicationResponse } from '@mail-otter/backend-services/application';
+
+class DismissApplicationErrorRoute extends IUserRoute<
+  DismissApplicationErrorRequest,
+  DismissApplicationErrorResponse,
+  IUserEnv
+> {
+  schema = {
+    tags: ['Applications'],
+    summary: 'Acknowledge and dismiss a processing or context error',
+    responses: {
+      '200': {
+        description: 'Error acknowledged',
+      },
+    },
+  };
+
+  protected async handleRequest(
+    request: DismissApplicationErrorRequest,
+    env: IUserEnv,
+    cxt: RouteContext<IUserEnv>,
+  ): Promise<DismissApplicationErrorResponse> {
+    return {
+      application: await ApplicationService.acknowledgeApplicationError(
+        this.getAuthenticatedUserEmailAddress(cxt),
+        request.applicationId,
+        request.errorType,
+        env,
+        request.raw,
+      ),
+    };
+  }
+}
+
+interface DismissApplicationErrorRequest extends IRequest {
+  applicationId: string;
+  errorType: 'processing' | 'context';
+}
+
+interface DismissApplicationErrorResponse extends IResponse {
+  application: ApplicationResponse;
+}
+
+export { DismissApplicationErrorRoute };

--- a/apps/api/src/workers/MailOtterWorker.ts
+++ b/apps/api/src/workers/MailOtterWorker.ts
@@ -6,6 +6,7 @@ import {
   CreateOAuth2AuthorizationRoute,
   DeleteApplicationRoute,
   DeleteApplicationContextDocumentsRoute,
+  DismissApplicationErrorRoute,
   ExecuteActionCallbackRoute,
   ExecuteUserEmailActionRoute,
   GetActionConfirmationRoute,
@@ -84,6 +85,7 @@ class MailOtterWorker extends AbstractEntrypointWorker {
     openapi.put('/user/application', UpdateApplicationRoute);
     openapi.delete('/user/application', DeleteApplicationRoute);
     openapi.put('/user/application/context', UpdateApplicationContextRoute);
+    openapi.post('/user/application/dismiss-error', DismissApplicationErrorRoute);
     openapi.post('/user/application/context/delete-documents', DeleteApplicationContextDocumentsRoute);
     openapi.get('/user/application/context/documents', ListApplicationContextDocumentsRoute);
     openapi.get('/user/application/context/deletions', ListApplicationContextDeletionRunsRoute);

--- a/apps/web/src/SpaApp.tsx
+++ b/apps/web/src/SpaApp.tsx
@@ -398,6 +398,24 @@ export default function SpaApp() {
     }
   };
 
+  const dismissError = async (applicationId: string, errorType: 'processing' | 'context') => {
+    setIsBusy(true);
+    try {
+      const data = await readJson<{ application: ConnectedApplication }>(
+        await apiFetch('/user/application/dismiss-error', {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({ applicationId, errorType }),
+        }),
+      );
+      setApplications((c) => c.map((a) => (a.applicationId === data.application.applicationId ? data.application : a)));
+    } catch (e) {
+      showNotice('error', e instanceof Error ? e.message : 'Unable To Dismiss Error.');
+    } finally {
+      setIsBusy(false);
+    }
+  };
+
   const loadMoreContextDocuments = async () => {
     if (!contextDocumentsCursor) return;
     const p = new URLSearchParams();
@@ -562,6 +580,8 @@ export default function SpaApp() {
           onUpdateMaxContextDocuments={updateMaxContextDocuments}
           onOpenContextAudit={(id) => { setAuditApplicationId(id); setActiveView('context'); }}
           onDeleteContextDocuments={deleteContextDocuments}
+          onDismissProcessingError={(id) => dismissError(id, 'processing')}
+          onDismissContextError={(id) => dismissError(id, 'context')}
           isFormExpanded={isFormExpanded}
           setIsFormExpanded={setIsFormExpanded}
         />

--- a/apps/web/src/components/mailboxes/ContextSection.tsx
+++ b/apps/web/src/components/mailboxes/ContextSection.tsx
@@ -12,6 +12,7 @@ export function ContextSection({
   onUpdateMaxContextDocuments,
   onOpenContextAudit,
   onDeleteContextDocuments,
+  onDismissContextError,
 }: {
   application: ConnectedApplication;
   user: CurrentUser;
@@ -20,6 +21,7 @@ export function ContextSection({
   onUpdateMaxContextDocuments: (max: number | null) => void;
   onOpenContextAudit: () => void;
   onDeleteContextDocuments: () => void;
+  onDismissContextError: () => void;
 }) {
   return (
     <Card>
@@ -64,6 +66,7 @@ export function ContextSection({
           value={application.contextLastError || 'None'}
           tone={application.contextLastError ? 'error' : 'muted'}
           subtitle={application.contextLastError ? formatTimestamp(application.contextLastErrorAt) : undefined}
+          onDismiss={application.contextLastError ? onDismissContextError : undefined}
         />
       </div>
 

--- a/apps/web/src/components/mailboxes/MailboxDetail.tsx
+++ b/apps/web/src/components/mailboxes/MailboxDetail.tsx
@@ -29,6 +29,8 @@ export function MailboxDetail({
   onUpdateMaxContextDocuments,
   onOpenContextAudit,
   onDeleteContextDocuments,
+  onDismissProcessingError,
+  onDismissContextError,
 }: {
   application: ConnectedApplication;
   watchWebhookUrl: string;
@@ -48,6 +50,8 @@ export function MailboxDetail({
   onUpdateMaxContextDocuments: (max: number | null) => void;
   onOpenContextAudit: () => void;
   onDeleteContextDocuments: () => void;
+  onDismissProcessingError: () => void;
+  onDismissContextError: () => void;
 }) {
   return (
     <div className="space-y-4 animate-fade-in-up">
@@ -115,6 +119,7 @@ export function MailboxDetail({
             value={application.lastError || 'None'}
             tone={application.lastError ? 'error' : 'muted'}
             subtitle={application.lastError ? formatTimestamp(application.lastErrorAt) : undefined}
+            onDismiss={application.lastError ? onDismissProcessingError : undefined}
           />
         </div>
       </Card>
@@ -128,6 +133,7 @@ export function MailboxDetail({
         onUpdateMaxContextDocuments={onUpdateMaxContextDocuments}
         onOpenContextAudit={onOpenContextAudit}
         onDeleteContextDocuments={onDeleteContextDocuments}
+        onDismissContextError={onDismissContextError}
       />
 
       {/* Sender filter rules */}

--- a/apps/web/src/components/shared/Metric.tsx
+++ b/apps/web/src/components/shared/Metric.tsx
@@ -1,13 +1,34 @@
 import { cn } from '../../lib/utils';
 
-export function Metric({ label, value, tone = 'muted', subtitle }: { label: string; value: string; tone?: 'muted' | 'error'; subtitle?: string }) {
+export function Metric({
+  label,
+  value,
+  tone = 'muted',
+  subtitle,
+  onDismiss,
+}: {
+  label: string;
+  value: string;
+  tone?: 'muted' | 'error';
+  subtitle?: string;
+  onDismiss?: () => void;
+}) {
   return (
-    <div className="rounded-xl border border-[var(--color-border)] bg-[var(--color-surface-2)] p-4 min-w-0">
+    <div className="rounded-xl border border-[var(--color-border)] bg-[var(--color-surface-2)] p-4 min-w-0 relative">
       <div className="text-xs uppercase tracking-wide text-[var(--color-text-muted)]">{label}</div>
       <div className={cn('mt-1.5 text-sm break-words', tone === 'error' ? 'text-[var(--color-error-text)]' : 'text-[var(--color-text-primary)]')}>
         {value}
       </div>
       {subtitle && <div className="mt-0.5 text-xs text-[var(--color-text-muted)]">{subtitle}</div>}
+      {onDismiss && tone === 'error' && (
+        <button
+          onClick={onDismiss}
+          title="Dismiss Error"
+          className="absolute top-2 right-2 text-[var(--color-text-muted)] hover:text-[var(--color-text-primary)] leading-none text-base"
+        >
+          ×
+        </button>
+      )}
     </div>
   );
 }

--- a/apps/web/src/components/views/MailboxesView.tsx
+++ b/apps/web/src/components/views/MailboxesView.tsx
@@ -30,6 +30,8 @@ export function MailboxesView({
   onUpdateMaxContextDocuments,
   onOpenContextAudit,
   onDeleteContextDocuments,
+  onDismissProcessingError,
+  onDismissContextError,
   isFormExpanded,
   setIsFormExpanded,
 }: {
@@ -57,6 +59,8 @@ export function MailboxesView({
   onUpdateMaxContextDocuments: (id: string, max: number | null) => void;
   onOpenContextAudit: (id: string) => void;
   onDeleteContextDocuments: (id: string) => void;
+  onDismissProcessingError: (id: string) => void;
+  onDismissContextError: (id: string) => void;
   isFormExpanded: boolean;
   setIsFormExpanded: (v: boolean) => void;
 }) {
@@ -126,6 +130,8 @@ export function MailboxesView({
             onUpdateMaxContextDocuments={(max) => onUpdateMaxContextDocuments(selectedApplication.applicationId, max)}
             onOpenContextAudit={() => onOpenContextAudit(selectedApplication.applicationId)}
             onDeleteContextDocuments={() => onDeleteContextDocuments(selectedApplication.applicationId)}
+            onDismissProcessingError={() => onDismissProcessingError(selectedApplication.applicationId)}
+            onDismissContextError={() => onDismissContextError(selectedApplication.applicationId)}
           />
         ) : (
           <Card className="text-center text-[var(--color-text-muted)] py-16 text-sm">

--- a/migrations/0015_application_error_acknowledgment.sql
+++ b/migrations/0015_application_error_acknowledgment.sql
@@ -1,0 +1,2 @@
+ALTER TABLE connected_applications ADD COLUMN last_error_acknowledged_at INTEGER;
+ALTER TABLE connected_applications ADD COLUMN context_last_error_acknowledged_at INTEGER;

--- a/packages/backend-data/src/dao/ConnectedApplicationDAO.ts
+++ b/packages/backend-data/src/dao/ConnectedApplicationDAO.ts
@@ -84,7 +84,7 @@ class ConnectedApplicationDAO {
     const rows: ConnectedApplicationInternal[] = await this.database
       .prepare(
         `
-          SELECT application_id, user_email, provider_email, display_name, provider_id, connection_method, encrypted_credentials, credentials_iv, status, context_indexing_enabled, max_context_documents, created_at, updated_at
+          SELECT application_id, user_email, provider_email, display_name, provider_id, connection_method, encrypted_credentials, credentials_iv, status, context_indexing_enabled, max_context_documents, last_error_acknowledged_at, context_last_error_acknowledged_at, created_at, updated_at
           FROM connected_applications
           WHERE user_email = ?
           ORDER BY updated_at DESC, created_at DESC
@@ -387,7 +387,7 @@ class ConnectedApplicationDAO {
     const row: ConnectedApplicationInternal | null = await this.database
       .prepare(
         `
-          SELECT application_id, user_email, provider_email, display_name, provider_id, connection_method, encrypted_credentials, credentials_iv, status, context_indexing_enabled, max_context_documents, created_at, updated_at
+          SELECT application_id, user_email, provider_email, display_name, provider_id, connection_method, encrypted_credentials, credentials_iv, status, context_indexing_enabled, max_context_documents, last_error_acknowledged_at, context_last_error_acknowledged_at, created_at, updated_at
           FROM connected_applications
           WHERE application_id = ?${whereUser}
           LIMIT 1
@@ -437,10 +437,30 @@ class ConnectedApplicationDAO {
       enabledFeatures: enabledFeaturesJson ? (JSON.parse(enabledFeaturesJson) as string[]) : null,
       senderDomainFilters: senderDomainFiltersJson ? (JSON.parse(senderDomainFiltersJson) as SenderDomainFilters) : null,
       watchedFolders: watchedFolders.length > 0 ? watchedFolders.map((f) => ({ id: f.folderPath, name: f.folderName })) : null,
+      lastErrorAcknowledgedAt: row.last_error_acknowledged_at ?? null,
+      contextLastErrorAcknowledgedAt: row.context_last_error_acknowledged_at ?? null,
       createdAt: row.created_at,
       updatedAt: row.updated_at,
       gmailPubsubTopicName: gmailPubsubTopicName ?? undefined,
     };
+  }
+
+  public async acknowledgeErrorForUser(
+    applicationId: string,
+    userEmail: string,
+    errorType: 'processing' | 'context',
+  ): Promise<ConnectedApplicationMetadata | undefined> {
+    const now: number = TimestampUtil.getCurrentUnixTimestampInSeconds();
+    const column: string = errorType === 'processing' ? 'last_error_acknowledged_at' : 'context_last_error_acknowledged_at';
+    await executeD1WithRetry(
+      (): Promise<D1Result> =>
+        this.database
+          .prepare(`UPDATE connected_applications SET ${column} = ?, updated_at = ? WHERE application_id = ? AND user_email = ?`)
+          .bind(now, now, applicationId, userEmail)
+          .run(),
+      'acknowledge application error',
+    );
+    return this.getMetadataByIdForUser(applicationId, userEmail);
   }
 }
 

--- a/packages/backend-services/src/application/ApplicationResponseUtil.ts
+++ b/packages/backend-services/src/application/ApplicationResponseUtil.ts
@@ -22,6 +22,18 @@ class ApplicationResponseUtil {
     const latestError: ProcessedMessage | undefined = await processedMessageDAO.getLatestErrorForApplication(application.applicationId);
     const contextSummary: ApplicationContextSummary = await contextDAO.getSummaryByApplication(application.applicationId);
     const baseUrl: string = BaseUrlUtil.getBaseUrl(raw);
+    const processingErrorText: string | null | undefined = subscription?.lastError || latestError?.errorMessage;
+    const processingErrorAt: number | null = subscription?.lastError ? subscription.updatedAt : (latestError?.errorMessage ? latestError.updatedAt : null);
+    const processingAcknowledged: boolean =
+      application.lastErrorAcknowledgedAt != null &&
+      processingErrorAt != null &&
+      processingErrorAt <= application.lastErrorAcknowledgedAt;
+
+    const contextAcknowledged: boolean =
+      application.contextLastErrorAcknowledgedAt != null &&
+      contextSummary.lastErrorAt != null &&
+      contextSummary.lastErrorAt <= application.contextLastErrorAcknowledgedAt;
+
     return {
       ...application,
       oauth2RedirectUri: `${baseUrl}/api/oauth2/callback/${application.applicationId}`,
@@ -31,13 +43,13 @@ class ApplicationResponseUtil {
       watchStatus: subscription?.status,
       watchExpiresAt: subscription?.expiresAt,
       lastSummaryAt: latestMessage?.summarySentAt,
-      lastError: subscription?.lastError || latestError?.errorMessage,
-      lastErrorAt: subscription?.lastError ? subscription.updatedAt : (latestError?.errorMessage ? latestError.updatedAt : null),
+      lastError: processingAcknowledged ? null : processingErrorText,
+      lastErrorAt: processingAcknowledged ? null : processingErrorAt,
       contextDocumentCount: contextSummary.documentCount,
       contextLastIndexedAt: contextSummary.lastIndexedAt,
       contextLastDeleteAcceptedAt: contextSummary.lastDeleteAcceptedAt,
-      contextLastError: contextSummary.lastError,
-      contextLastErrorAt: contextSummary.lastErrorAt,
+      contextLastError: contextAcknowledged ? null : contextSummary.lastError,
+      contextLastErrorAt: contextAcknowledged ? null : contextSummary.lastErrorAt,
     };
   }
 }

--- a/packages/backend-services/src/application/ApplicationService.ts
+++ b/packages/backend-services/src/application/ApplicationService.ts
@@ -138,6 +138,21 @@ class ApplicationService {
     await applicationDAO.deleteForUser(applicationId, userEmail);
   }
 
+  public static async acknowledgeApplicationError(
+    userEmail: string,
+    applicationId: string,
+    errorType: 'processing' | 'context',
+    env: ApplicationServiceEnv,
+    raw: Request,
+  ): Promise<ApplicationResponse> {
+    const applicationDAO: ConnectedApplicationDAO = await ApplicationService.createApplicationDAO(env);
+    const application: ConnectedApplicationMetadata | undefined = await applicationDAO.acknowledgeErrorForUser(applicationId, userEmail, errorType);
+    if (!application) {
+      throw new BadRequestError('Connected application was not found.');
+    }
+    return ApplicationResponseUtil.decorateApplication(application, env, raw);
+  }
+
   private static async createApplicationDAO(env: ApplicationServiceEnv): Promise<ConnectedApplicationDAO> {
     const masterKey: string = await env.AES_ENCRYPTION_KEY_SECRET.get();
     return new ConnectedApplicationDAO(env.DB, masterKey);

--- a/packages/shared/src/model/ConnectedApplication.ts
+++ b/packages/shared/src/model/ConnectedApplication.ts
@@ -34,11 +34,13 @@ interface ConnectedApplicationMetadata {
   lastSummaryAt?: number | null | undefined;
   lastError?: string | null | undefined;
   lastErrorAt?: number | null | undefined;
+  lastErrorAcknowledgedAt?: number | null | undefined;
   contextDocumentCount?: number | undefined;
   contextLastIndexedAt?: number | null | undefined;
   contextLastDeleteAcceptedAt?: number | null | undefined;
   contextLastError?: string | null | undefined;
   contextLastErrorAt?: number | null | undefined;
+  contextLastErrorAcknowledgedAt?: number | null | undefined;
   createdAt: number;
   updatedAt: number;
 }
@@ -59,6 +61,8 @@ interface ConnectedApplicationInternal {
   status: ConnectedApplicationStatus;
   context_indexing_enabled: number;
   max_context_documents: number | null;
+  last_error_acknowledged_at: number | null;
+  context_last_error_acknowledged_at: number | null;
   created_at: number;
   updated_at: number;
 }


### PR DESCRIPTION
Adds timestamp-based error acknowledgment so users can dismiss stale processing and context errors from the mailbox detail panel. A dismiss (×) button appears on each error metric when an error is present; clicking it records the current time in two new DB columns (`last_error_acknowledged_at`, `context_last_error_acknowledged_at`) on `connected_applications`. The response util suppresses any error whose timestamp is at or before the acknowledged time, so new errors surfacing after dismissal still appear.

Changes:
- migrations/0015: add two acknowledgment timestamp columns
- ConnectedApplicationInternal/Metadata: add the new fields
- ConnectedApplicationDAO: update SELECT queries, add acknowledgeErrorForUser()
- ApplicationResponseUtil: filter errors against acknowledgment timestamps
- ApplicationService: add acknowledgeApplicationError()
- New endpoint POST /user/application/dismiss-error
- Metric component: optional onDismiss prop renders × button when tone=error
- SpaApp/MailboxesView/MailboxDetail/ContextSection: wire dismiss callbacks