### PR TITLE
Show Auto-Renew Notice On Watch Expiry Metric

### DIFF
--- a/apps/web/src/components/mailboxes/MailboxDetail.tsx
+++ b/apps/web/src/components/mailboxes/MailboxDetail.tsx
@@ -112,7 +112,11 @@ export function MailboxDetail({
           <CardTitle>Processing</CardTitle>
         </CardHeader>
         <div className="grid grid-cols-1 md:grid-cols-3 gap-3">
-          <Metric label="Watch Expires" value={formatExpiryTimestamp(application.watchExpiresAt)} />
+          <Metric
+            label="Watch Expires"
+            value={formatExpiryTimestamp(application.watchExpiresAt)}
+            subtitle={application.watchExpiresAt ? 'Auto-Renews Automatically' : undefined}
+          />
           <Metric label="Last Summary" value={formatTimestamp(application.lastSummaryAt)} />
           <Metric
             label="Last Error"


### PR DESCRIPTION
Adds an "Auto-Renews Automatically" subtitle to the Watch Expires metric in the mailbox detail Processing card, so users know the subscription renews before it expires and no manual action is needed.