### PR TITLE
Decompose SpaApp God Object And Add URL State Persistence

### DIFF
--- a/apps/web/src/SpaApp.tsx
+++ b/apps/web/src/SpaApp.tsx
@@ -1,18 +1,5 @@
-import { useCallback, useEffect, useMemo, useState } from 'react';
+import { useEffect, useState } from 'react';
 import Unauthorized from '../components/Unauthorized';
-import type {
-  ApplicationContextDeletionRun,
-  ApplicationContextDocument,
-  ApplicationContextDocumentStatus,
-  ConnectedApplication,
-  ContextAuditLog,
-  CurrentUser,
-  EmailAction,
-  EmailActionExecution,
-  EmailActionStatus,
-  SenderDomainFilters,
-} from '../components/types';
-import { apiFetch, fetchDocumentAuditLogs, readJson, providerMethod } from '../components/utils';
 import type { ActiveView } from './types';
 import { Header } from './components/layout/Header';
 import { NoticeBar } from './components/layout/NoticeBar';
@@ -21,518 +8,85 @@ import { ContextAuditView } from './components/views/ContextAuditView';
 import { ActionsView } from './components/views/ActionsView';
 import { ConfirmDeleteModal } from './components/modals/ConfirmDeleteModal';
 import { AuditLogsModal } from './components/modals/AuditLogsModal';
-import type { ApplicationFormState } from './components/mailboxes/MailboxForm';
-import { emptyForm } from './components/mailboxes/MailboxForm';
+import { NoticeContext } from './contexts/NoticeContext';
+import { UserContext } from './contexts/UserContext';
+import { MailboxCallbacksContext } from './contexts/MailboxCallbacksContext';
+import { useNotice } from './hooks/useNotice';
+import { useCurrentUser } from './hooks/useCurrentUser';
+import { useMailboxes } from './hooks/useMailboxes';
+import { useContextAudit } from './hooks/useContextAudit';
+import { useActions } from './hooks/useActions';
+import { useAuditLogs } from './hooks/useAuditLogs';
+import { getUrlParam, useSyncedUrl } from './hooks/useSyncedUrl';
+import type { ApplicationContextDocumentStatus, EmailActionStatus } from '../components/types';
 
-function getInitialNotice(): { type: 'success' | 'error'; text: string } | null {
-  const params = new URLSearchParams(window.location.search);
-  if (params.get('oauth2') === 'connected') return { type: 'success', text: 'OAuth2 Connection Completed.' };
-  if (params.get('oauth2') === 'error') return { type: 'error', text: params.get('message') || 'OAuth2 Connection Failed.' };
-  return null;
-}
+// Read URL params synchronously before first render so useState initializers can use them
+const initialView = getUrlParam('view', 'mailboxes') as ActiveView;
+const initialAppId = getUrlParam('appId', '');
+const initialStatus = getUrlParam('status', '');
+const initialActionId = getUrlParam('actionId', '');
 
 export default function SpaApp() {
-  const [user, setUser] = useState<CurrentUser | null>(null);
-  const [authorized, setAuthorized] = useState<boolean | null>(null);
-  const [applications, setApplications] = useState<ConnectedApplication[]>([]);
-  const [selectedApplicationId, setSelectedApplicationId] = useState('');
-  const [applicationForm, setApplicationForm] = useState<ApplicationFormState>(emptyForm);
-  const [isFormExpanded, setIsFormExpanded] = useState(false);
-  const [notice, setNotice] = useState<{ type: 'success' | 'error'; text: string } | null>(() => getInitialNotice());
+  const [activeView, setActiveView] = useState<ActiveView>(initialView);
   const [isBusy, setIsBusy] = useState(false);
-  const [watchWebhookUrl, setWatchWebhookUrl] = useState('');
-  const [activeView, setActiveView] = useState<ActiveView>('mailboxes');
 
-  // Context audit state
-  const [auditApplicationId, setAuditApplicationId] = useState('');
-  const [auditStatus, setAuditStatus] = useState<ApplicationContextDocumentStatus | ''>('');
-  const [contextDocuments, setContextDocuments] = useState<ApplicationContextDocument[]>([]);
-  const [contextDocumentsCursor, setContextDocumentsCursor] = useState<string | undefined>();
-  const [contextDeletionRuns, setContextDeletionRuns] = useState<ApplicationContextDeletionRun[]>([]);
-  const [contextDeletionRunsCursor, setContextDeletionRunsCursor] = useState<string | undefined>();
+  const { notice, showNotice } = useNotice();
+  const { user, authorized } = useCurrentUser();
+  const auditLogs = useAuditLogs({ showNotice });
 
-  // Actions state
-  const [actions, setActions] = useState<EmailAction[]>([]);
-  const [actionsCursor, setActionsCursor] = useState<string | undefined>();
-  const [actionApplicationId, setActionApplicationId] = useState('');
-  const [actionStatus, setActionStatus] = useState<EmailActionStatus | ''>('');
-  const [actionExecutions, setActionExecutions] = useState<EmailActionExecution[]>([]);
-  const [selectedActionId, setSelectedActionId] = useState('');
+  const contextAudit = useContextAudit({ showNotice });
+  const actions = useActions({ setIsBusy, showNotice });
 
-  // Folders & modals
-  const [availableFolders, setAvailableFolders] = useState<Array<{ id: string; name: string }> | null>(null);
-  const [loadingFolders, setLoadingFolders] = useState(false);
-  const [confirmDelete, setConfirmDelete] = useState<{ applicationId: string; displayName: string } | null>(null);
-  const [auditLogDocumentId, setAuditLogDocumentId] = useState<string | null>(null);
-  const [auditLogs, setAuditLogs] = useState<ContextAuditLog[]>([]);
-  const [auditLogsCursor, setAuditLogsCursor] = useState<string | undefined>();
-  const [loadingAuditLogs, setLoadingAuditLogs] = useState(false);
+  const mailboxes = useMailboxes({
+    setIsBusy,
+    showNotice,
+    onContextChanged: () => { contextAudit.loadContextAudit(); },
+  });
 
+  // Seed URL-provided values into their domains once on mount
   useEffect(() => {
-    setAvailableFolders(null);
-    setLoadingFolders(false);
-  }, [selectedApplicationId]);
-
-  const showNotice = useCallback((type: 'success' | 'error', text: string) => {
-    setNotice({ type, text });
-    window.setTimeout(() => setNotice(null), 6000);
+    if (initialView === 'context' && initialAppId) contextAudit.setAuditApplicationId(initialAppId);
+    if (initialView === 'context' && initialStatus) contextAudit.setAuditStatus(initialStatus as ApplicationContextDocumentStatus);
+    if (initialView === 'actions' && initialAppId) actions.setActionApplicationId(initialAppId);
+    if (initialView === 'actions' && initialStatus) actions.setActionStatus(initialStatus as EmailActionStatus);
+    if (initialView === 'actions' && initialActionId) actions.setSelectedActionId(initialActionId);
+    if (initialView === 'mailboxes' && initialAppId) mailboxes.setSelectedApplicationId(initialAppId);
   }, []);
 
-  // ── Data loaders ──────────────────────────────────────────────────────────
-
-  const loadApplications = useCallback(async () => {
-    const data = await readJson<{ applications: ConnectedApplication[] }>(await apiFetch('/user/applications'));
-    setApplications(data.applications);
-    setSelectedApplicationId((c) => c || data.applications[0]?.applicationId || '');
-  }, []);
-
-  const loadContextAudit = useCallback(async () => {
-    const dp = new URLSearchParams();
-    const xp = new URLSearchParams();
-    if (auditApplicationId) { dp.set('applicationId', auditApplicationId); xp.set('applicationId', auditApplicationId); }
-    if (auditStatus) dp.set('status', auditStatus);
-    const [docData, delData] = await Promise.all([
-      readJson<{ documents: ApplicationContextDocument[]; nextCursor?: string }>(await apiFetch(`/user/application/context/documents?${dp}`)),
-      readJson<{ deletionRuns: ApplicationContextDeletionRun[]; nextCursor?: string }>(await apiFetch(`/user/application/context/deletions?${xp}`)),
-    ]);
-    setContextDocuments(docData.documents);
-    setContextDocumentsCursor(docData.nextCursor);
-    setContextDeletionRuns(delData.deletionRuns);
-    setContextDeletionRunsCursor(delData.nextCursor);
-  }, [auditApplicationId, auditStatus]);
-
-  const loadActions = useCallback(async (append = false, cursor?: string) => {
-    const p = new URLSearchParams();
-    if (actionApplicationId) p.set('applicationId', actionApplicationId);
-    if (actionStatus) p.set('status', actionStatus);
-    if (cursor) p.set('cursor', cursor);
-    const data = await readJson<{ actions: EmailAction[]; nextCursor?: string }>(await apiFetch(`/user/actions?${p}`));
-    setActions((c) => (append ? [...c, ...data.actions] : data.actions));
-    setActionsCursor(data.nextCursor);
-    setSelectedActionId((c) => c || data.actions[0]?.actionId || '');
-  }, [actionApplicationId, actionStatus]);
-
+  // Load applications once the user is authorized
   useEffect(() => {
-    const load = async () => {
-      try {
-        const me = await readJson<CurrentUser>(await apiFetch('/user/me'));
-        setUser(me);
-        setAuthorized(true);
-        await loadApplications();
-      } catch {
-        setAuthorized(false);
-      }
-    };
-    load();
-  }, [loadApplications]);
+    if (authorized) {
+      mailboxes.loadApplications().catch(() => {});
+    }
+  }, [authorized]);
 
+  // Load view-specific data when the active view becomes visible
   useEffect(() => {
     if (authorized && activeView === 'context') {
-      loadContextAudit().catch((e: unknown) => showNotice('error', e instanceof Error ? e.message : 'Unable To Load Context.'));
+      contextAudit.loadContextAudit();
     }
-  }, [activeView, authorized, loadContextAudit, showNotice]);
+  }, [activeView, authorized]);
 
   useEffect(() => {
     if (authorized && activeView === 'actions') {
-      loadActions().catch((e: unknown) => showNotice('error', e instanceof Error ? e.message : 'Unable To Load Actions.'));
+      actions.loadActions();
     }
-  }, [activeView, authorized, loadActions, showNotice]);
+  }, [activeView, authorized]);
 
-  // ── Mutations ─────────────────────────────────────────────────────────────
+  // Sync current state back to the URL
+  const effectiveAppId =
+    activeView === 'mailboxes'
+      ? mailboxes.selectedApplicationId
+      : activeView === 'context'
+        ? contextAudit.auditApplicationId
+        : actions.actionApplicationId;
 
-  const resetForm = () => {
-    setApplicationForm(emptyForm);
-    setIsFormExpanded(false);
-  };
-
-  const editApplication = (app: ConnectedApplication) => {
-    setApplicationForm({
-      applicationId: app.applicationId,
-      displayName: app.displayName,
-      providerId: app.providerId,
-      clientId: '',
-      clientSecret: '',
-      gmailPubsubTopicName: app.gmailPubsubTopicName || '',
-      enabledFeatures: app.enabledFeatures || [],
-    });
-    setIsFormExpanded(true);
-  };
-
-  const saveApplication = async () => {
-    setIsBusy(true);
-    try {
-      const payload = {
-        applicationId: applicationForm.applicationId,
-        displayName: applicationForm.displayName,
-        providerId: applicationForm.providerId,
-        connectionMethod: providerMethod[applicationForm.providerId],
-        ...(applicationForm.clientId ? { clientId: applicationForm.clientId } : {}),
-        ...(applicationForm.clientSecret ? { clientSecret: applicationForm.clientSecret } : {}),
-        enabledFeatures: applicationForm.enabledFeatures,
-        ...(applicationForm.providerId === 'google-gmail' ? { gmailPubsubTopicName: applicationForm.gmailPubsubTopicName } : {}),
-      };
-      const res = await apiFetch('/user/application', {
-        method: applicationForm.applicationId ? 'PUT' : 'POST',
-        headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify(payload),
-      });
-      const data = await readJson<{ application: ConnectedApplication }>(res);
-      showNotice('success', applicationForm.applicationId ? 'Mailbox Updated.' : 'Mailbox Created.');
-      resetForm();
-      await loadApplications();
-      setSelectedApplicationId(data.application.applicationId);
-    } catch (e) {
-      showNotice('error', e instanceof Error ? e.message : 'Unable To Save Mailbox.');
-    } finally {
-      setIsBusy(false);
-    }
-  };
-
-  const deleteApplication = async (applicationId: string) => {
-    setIsBusy(true);
-    try {
-      await readJson<{ success: boolean }>(
-        await apiFetch('/user/application', {
-          method: 'DELETE',
-          headers: { 'Content-Type': 'application/json' },
-          body: JSON.stringify({ applicationId }),
-        }),
-      );
-      showNotice('success', 'Mailbox Deleted.');
-      setSelectedApplicationId('');
-      setWatchWebhookUrl('');
-      await loadApplications();
-    } catch (e) {
-      showNotice('error', e instanceof Error ? e.message : 'Unable To Delete Mailbox.');
-    } finally {
-      setIsBusy(false);
-    }
-  };
-
-  const startOAuth2 = async (applicationId: string) => {
-    setIsBusy(true);
-    try {
-      const data = await readJson<{ authorizationUrl: string }>(
-        await apiFetch('/user/application/oauth2/authorize', {
-          method: 'POST',
-          headers: { 'Content-Type': 'application/json' },
-          body: JSON.stringify({ applicationId }),
-        }),
-      );
-      window.location.assign(data.authorizationUrl);
-    } catch (e) {
-      showNotice('error', e instanceof Error ? e.message : 'Unable To Start OAuth2.');
-      setIsBusy(false);
-    }
-  };
-
-  const startWatch = async (applicationId: string) => {
-    setIsBusy(true);
-    try {
-      const data = await readJson<{ message: string; webhookUrl: string }>(
-        await apiFetch('/user/application/watch', {
-          method: 'POST',
-          headers: { 'Content-Type': 'application/json' },
-          body: JSON.stringify({ applicationId }),
-        }),
-      );
-      setWatchWebhookUrl(data.webhookUrl);
-      await loadApplications();
-      showNotice('success', data.message);
-    } catch (e) {
-      showNotice('error', e instanceof Error ? e.message : 'Unable To Start Watch.');
-    } finally {
-      setIsBusy(false);
-    }
-  };
-
-  const stopWatch = async (applicationId: string) => {
-    setIsBusy(true);
-    try {
-      const data = await readJson<{ message: string }>(
-        await apiFetch('/user/application/stop', {
-          method: 'POST',
-          headers: { 'Content-Type': 'application/json' },
-          body: JSON.stringify({ applicationId }),
-        }),
-      );
-      setWatchWebhookUrl('');
-      await loadApplications();
-      showNotice('success', data.message);
-    } catch (e) {
-      showNotice('error', e instanceof Error ? e.message : 'Unable To Stop Watch.');
-    } finally {
-      setIsBusy(false);
-    }
-  };
-
-  const updateContextIndexing = async (applicationId: string, contextIndexingEnabled: boolean) => {
-    setIsBusy(true);
-    try {
-      const data = await readJson<{ application: ConnectedApplication }>(
-        await apiFetch('/user/application/context', {
-          method: 'PUT',
-          headers: { 'Content-Type': 'application/json' },
-          body: JSON.stringify({ applicationId, contextIndexingEnabled }),
-        }),
-      );
-      setApplications((c) => c.map((a) => (a.applicationId === data.application.applicationId ? data.application : a)));
-      showNotice('success', contextIndexingEnabled ? 'Context Indexing Enabled.' : 'Context Indexing Disabled.');
-      if (activeView === 'context') await loadContextAudit();
-    } catch (e) {
-      showNotice('error', e instanceof Error ? e.message : 'Unable To Update Context Setting.');
-    } finally {
-      setIsBusy(false);
-    }
-  };
-
-  const updateMaxContextDocuments = async (applicationId: string, maxContextDocuments: number | null) => {
-    setIsBusy(true);
-    try {
-      const data = await readJson<{ application: ConnectedApplication }>(
-        await apiFetch('/user/application/context', {
-          method: 'PUT',
-          headers: { 'Content-Type': 'application/json' },
-          body: JSON.stringify({ applicationId, maxContextDocuments }),
-        }),
-      );
-      setApplications((c) => c.map((a) => (a.applicationId === data.application.applicationId ? data.application : a)));
-      showNotice('success', maxContextDocuments != null ? `Document Limit Set To ${maxContextDocuments}.` : 'Document Limit Reset.');
-    } catch (e) {
-      showNotice('error', e instanceof Error ? e.message : 'Unable To Update Document Limit.');
-    } finally {
-      setIsBusy(false);
-    }
-  };
-
-  const loadFolders = async (applicationId: string) => {
-    setLoadingFolders(true);
-    try {
-      const data = await readJson<{ folders: Array<{ id: string; name: string }> }>(
-        await apiFetch(`/user/application/folders?applicationId=${encodeURIComponent(applicationId)}`),
-      );
-      setAvailableFolders(data.folders);
-    } catch (e) {
-      showNotice('error', e instanceof Error ? e.message : 'Unable To Load Folders.');
-    } finally {
-      setLoadingFolders(false);
-    }
-  };
-
-  const updateWatchedFolderIds = async (applicationId: string, folderIds: string[] | null) => {
-    setIsBusy(true);
-    try {
-      const folderNames: Record<string, string> = {};
-      if (folderIds && availableFolders) {
-        for (const id of folderIds) {
-          const folder = availableFolders.find((f) => f.id === id);
-          if (folder) folderNames[id] = folder.name;
-        }
-      }
-      const data = await readJson<{ application: ConnectedApplication }>(
-        await apiFetch('/user/application/watch-settings', {
-          method: 'PUT',
-          headers: { 'Content-Type': 'application/json' },
-          body: JSON.stringify({ applicationId, folderIds, folderNames }),
-        }),
-      );
-      setApplications((c) => c.map((a) => (a.applicationId === data.application.applicationId ? data.application : a)));
-    } catch (e) {
-      showNotice('error', e instanceof Error ? e.message : 'Unable To Update Watch Folders.');
-    } finally {
-      setIsBusy(false);
-    }
-  };
-
-  const updateSenderFilters = async (applicationId: string, filters: SenderDomainFilters) => {
-    const app = applications.find((a) => a.applicationId === applicationId);
-    if (!app) return;
-    setIsBusy(true);
-    try {
-      const data = await readJson<{ application: ConnectedApplication }>(
-        await apiFetch('/user/application', {
-          method: 'PUT',
-          headers: { 'Content-Type': 'application/json' },
-          body: JSON.stringify({
-            applicationId: app.applicationId,
-            displayName: app.displayName,
-            providerId: app.providerId,
-            connectionMethod: providerMethod[app.providerId],
-            enabledFeatures: app.enabledFeatures,
-            ...(app.providerId === 'google-gmail' ? { gmailPubsubTopicName: app.gmailPubsubTopicName } : {}),
-            senderDomainFilters: filters,
-          }),
-        }),
-      );
-      setApplications((c) => c.map((a) => (a.applicationId === data.application.applicationId ? data.application : a)));
-      showNotice('success', 'Sender Filter Rules Updated.');
-    } catch (e) {
-      showNotice('error', e instanceof Error ? e.message : 'Unable To Update Sender Filters.');
-    } finally {
-      setIsBusy(false);
-    }
-  };
-
-  const deleteContextDocuments = async (applicationId: string) => {
-    const app = applications.find((a) => a.applicationId === applicationId);
-    if (!window.confirm(`Delete All Indexed Documents For ${app?.displayName || 'This Mailbox'}?`)) return;
-    setIsBusy(true);
-    try {
-      const data = await readJson<{ deletionRun: ApplicationContextDeletionRun }>(
-        await apiFetch('/user/application/context/delete-documents', {
-          method: 'POST',
-          headers: { 'Content-Type': 'application/json' },
-          body: JSON.stringify({ applicationId }),
-        }),
-      );
-      await loadApplications();
-      if (activeView === 'context') await loadContextAudit();
-      showNotice(
-        data.deletionRun.status === 'accepted' ? 'success' : 'error',
-        data.deletionRun.status === 'accepted' ? 'Context Documents Deletion Accepted.' : data.deletionRun.errorMessage || 'Context Deletion Failed.',
-      );
-    } catch (e) {
-      showNotice('error', e instanceof Error ? e.message : 'Unable To Delete Context Documents.');
-    } finally {
-      setIsBusy(false);
-    }
-  };
-
-  const dismissError = async (applicationId: string, errorType: 'processing' | 'context') => {
-    setIsBusy(true);
-    try {
-      const data = await readJson<{ application: ConnectedApplication }>(
-        await apiFetch('/user/application/dismiss-error', {
-          method: 'POST',
-          headers: { 'Content-Type': 'application/json' },
-          body: JSON.stringify({ applicationId, errorType }),
-        }),
-      );
-      setApplications((c) => c.map((a) => (a.applicationId === data.application.applicationId ? data.application : a)));
-    } catch (e) {
-      showNotice('error', e instanceof Error ? e.message : 'Unable To Dismiss Error.');
-    } finally {
-      setIsBusy(false);
-    }
-  };
-
-  const loadMoreContextDocuments = async () => {
-    if (!contextDocumentsCursor) return;
-    const p = new URLSearchParams();
-    if (auditApplicationId) p.set('applicationId', auditApplicationId);
-    if (auditStatus) p.set('status', auditStatus);
-    p.set('cursor', contextDocumentsCursor);
-    const data = await readJson<{ documents: ApplicationContextDocument[]; nextCursor?: string }>(
-      await apiFetch(`/user/application/context/documents?${p}`),
-    );
-    setContextDocuments((c) => [...c, ...data.documents]);
-    setContextDocumentsCursor(data.nextCursor);
-  };
-
-  const loadMoreContextDeletions = async () => {
-    if (!contextDeletionRunsCursor) return;
-    const p = new URLSearchParams();
-    if (auditApplicationId) p.set('applicationId', auditApplicationId);
-    p.set('cursor', contextDeletionRunsCursor);
-    const data = await readJson<{ deletionRuns: ApplicationContextDeletionRun[]; nextCursor?: string }>(
-      await apiFetch(`/user/application/context/deletions?${p}`),
-    );
-    setContextDeletionRuns((c) => [...c, ...data.deletionRuns]);
-    setContextDeletionRunsCursor(data.nextCursor);
-  };
-
-  const loadActionExecutions = async (actionId: string) => {
-    setSelectedActionId(actionId);
-    try {
-      const data = await readJson<{ executions: EmailActionExecution[] }>(
-        await apiFetch(`/user/actions/${encodeURIComponent(actionId)}/executions`),
-      );
-      setActionExecutions(data.executions);
-    } catch (e) {
-      showNotice('error', e instanceof Error ? e.message : 'Unable To Load Action Audit.');
-    }
-  };
-
-  const executeAction = async (actionId: string) => {
-    setIsBusy(true);
-    try {
-      const data = await readJson<{ action: EmailAction }>(
-        await apiFetch(`/user/actions/${encodeURIComponent(actionId)}/execute`, { method: 'POST' }),
-      );
-      setActions((c) => c.map((a) => (a.actionId === data.action.actionId ? data.action : a)));
-      await loadActionExecutions(actionId);
-      showNotice(data.action.status === 'succeeded' ? 'success' : 'error', data.action.result?.summary || data.action.errorMessage || data.action.status);
-    } catch (e) {
-      showNotice('error', e instanceof Error ? e.message : 'Unable To Execute Action.');
-    } finally {
-      setIsBusy(false);
-    }
-  };
-
-  const openContextDocumentInProvider = async (contextDocumentId: string) => {
-    try {
-      const data = await readJson<{ url: string }>(
-        await apiFetch(`/user/application/context/document/${encodeURIComponent(contextDocumentId)}/provider-link`),
-      );
-      window.open(data.url, '_blank', 'noopener,noreferrer');
-    } catch (e) {
-      showNotice('error', e instanceof Error ? e.message : 'Unable To Open Provider Document.');
-    }
-  };
-
-  const viewDocumentAuditLogs = async (contextDocumentId: string) => {
-    setAuditLogDocumentId(contextDocumentId);
-    setAuditLogs([]);
-    setAuditLogsCursor(undefined);
-    setLoadingAuditLogs(true);
-    try {
-      const data = await fetchDocumentAuditLogs(contextDocumentId);
-      setAuditLogs(data.logs);
-      setAuditLogsCursor(data.nextCursor ?? undefined);
-    } catch (e) {
-      showNotice('error', e instanceof Error ? e.message : 'Unable To Load Audit Logs.');
-      setAuditLogDocumentId(null);
-    } finally {
-      setLoadingAuditLogs(false);
-    }
-  };
-
-  const loadMoreAuditLogs = async () => {
-    if (!auditLogDocumentId || !auditLogsCursor || loadingAuditLogs) return;
-    setLoadingAuditLogs(true);
-    try {
-      const data = await fetchDocumentAuditLogs(auditLogDocumentId, auditLogsCursor);
-      setAuditLogs((p) => [...p, ...data.logs]);
-      setAuditLogsCursor(data.nextCursor ?? undefined);
-    } catch (e) {
-      showNotice('error', e instanceof Error ? e.message : 'Unable To Load More Audit Logs.');
-    } finally {
-      setLoadingAuditLogs(false);
-    }
-  };
-
-  const refreshAuditLogs = useCallback(async () => {
-    if (!auditLogDocumentId) return;
-    setLoadingAuditLogs(true);
-    try {
-      const data = await fetchDocumentAuditLogs(auditLogDocumentId);
-      setAuditLogs(data.logs);
-      setAuditLogsCursor(data.nextCursor ?? undefined);
-    } catch (e) {
-      showNotice('error', e instanceof Error ? e.message : 'Unable To Refresh Audit Logs.');
-    } finally {
-      setLoadingAuditLogs(false);
-    }
-  }, [auditLogDocumentId, showNotice]);
-
-  // ── Derived ───────────────────────────────────────────────────────────────
-
-  const selectedApplication = useMemo(
-    () => applications.find((a) => a.applicationId === selectedApplicationId),
-    [applications, selectedApplicationId],
-  );
-
-  // ── Render ────────────────────────────────────────────────────────────────
+  useSyncedUrl({
+    view: activeView,
+    appId: effectiveAppId,
+    status: activeView === 'context' ? contextAudit.auditStatus : activeView === 'actions' ? actions.actionStatus : '',
+    actionId: activeView === 'actions' ? actions.selectedActionId : '',
+  });
 
   if (authorized === null) {
     return (
@@ -544,112 +98,124 @@ export default function SpaApp() {
 
   if (!authorized || !user) return <Unauthorized />;
 
+  // Mailbox callbacks object — stable per interaction (recreated when isBusy or selectedApplication change)
+  const mailboxCallbacksValue = {
+    busy: isBusy,
+    onEdit: mailboxes.editApplication,
+    onDelete: () => {
+      if (mailboxes.selectedApplication) {
+        mailboxes.setConfirmDelete({
+          applicationId: mailboxes.selectedApplication.applicationId,
+          displayName: mailboxes.selectedApplication.displayName,
+        });
+      }
+    },
+    onStartOAuth2: mailboxes.startOAuth2,
+    onStartWatch: mailboxes.startWatch,
+    onStopWatch: mailboxes.stopWatch,
+    onLoadFolders: mailboxes.loadFolders,
+    onUpdateWatchedFolders: mailboxes.updateWatchedFolderIds,
+    onUpdateSenderFilters: mailboxes.updateSenderFilters,
+    onUpdateContextIndexing: mailboxes.updateContextIndexing,
+    onUpdateMaxContextDocuments: mailboxes.updateMaxContextDocuments,
+    onOpenContextAudit: (id: string) => { contextAudit.setAuditApplicationId(id); setActiveView('context'); },
+    onDeleteContextDocuments: mailboxes.deleteContextDocuments,
+    onDismissProcessingError: (id: string) => mailboxes.dismissError(id, 'processing'),
+    onDismissContextError: (id: string) => mailboxes.dismissError(id, 'context'),
+  };
+
   return (
-    <div className="min-h-screen bg-[var(--color-surface-base)] text-[var(--color-text-primary)]">
-      <Header activeView={activeView} onViewChange={setActiveView} userEmail={user.email} aiUsage={user.aiUsage} />
+    <NoticeContext.Provider value={{ showNotice }}>
+      <UserContext.Provider value={user}>
+        <div className="min-h-screen bg-[var(--color-surface-base)] text-[var(--color-text-primary)]">
+          <Header activeView={activeView} onViewChange={setActiveView} userEmail={user.email} aiUsage={user.aiUsage} />
 
-      {notice && <NoticeBar notice={notice} />}
+          {notice && <NoticeBar notice={notice} />}
 
-      {activeView === 'mailboxes' && (
-        <MailboxesView
-          applications={applications}
-          selectedApplicationId={selectedApplicationId}
-          onSelectApplication={setSelectedApplicationId}
-          user={user}
-          watchWebhookUrl={watchWebhookUrl}
-          availableFolders={availableFolders}
-          loadingFolders={loadingFolders}
-          busy={isBusy}
-          applicationForm={applicationForm}
-          setApplicationForm={setApplicationForm}
-          onSaveForm={saveApplication}
-          onCancelForm={resetForm}
-          onEditApplication={editApplication}
-          onDeleteApplication={() => {
-            if (selectedApplication) {
-              setConfirmDelete({ applicationId: selectedApplication.applicationId, displayName: selectedApplication.displayName });
-            }
-          }}
-          onStartOAuth2={startOAuth2}
-          onStartWatch={startWatch}
-          onStopWatch={stopWatch}
-          onLoadFolders={loadFolders}
-          onUpdateWatchedFolders={updateWatchedFolderIds}
-          onUpdateSenderFilters={updateSenderFilters}
-          onUpdateContextIndexing={updateContextIndexing}
-          onUpdateMaxContextDocuments={updateMaxContextDocuments}
-          onOpenContextAudit={(id) => { setAuditApplicationId(id); setActiveView('context'); }}
-          onDeleteContextDocuments={deleteContextDocuments}
-          onDismissProcessingError={(id) => dismissError(id, 'processing')}
-          onDismissContextError={(id) => dismissError(id, 'context')}
-          isFormExpanded={isFormExpanded}
-          setIsFormExpanded={setIsFormExpanded}
-        />
-      )}
+          <MailboxCallbacksContext.Provider value={mailboxCallbacksValue}>
+            {activeView === 'mailboxes' && (
+              <MailboxesView
+                applications={mailboxes.applications}
+                selectedApplicationId={mailboxes.selectedApplicationId}
+                onSelectApplication={mailboxes.setSelectedApplicationId}
+                watchWebhookUrl={mailboxes.watchWebhookUrl}
+                availableFolders={mailboxes.availableFolders}
+                loadingFolders={mailboxes.loadingFolders}
+                applicationForm={mailboxes.applicationForm}
+                setApplicationForm={mailboxes.setApplicationForm}
+                onSaveForm={mailboxes.saveApplication}
+                onCancelForm={mailboxes.resetForm}
+                isFormExpanded={mailboxes.isFormExpanded}
+                setIsFormExpanded={mailboxes.setIsFormExpanded}
+              />
+            )}
+          </MailboxCallbacksContext.Provider>
 
-      {activeView === 'context' && (
-        <ContextAuditView
-          applications={applications}
-          applicationId={auditApplicationId}
-          setApplicationId={setAuditApplicationId}
-          status={auditStatus}
-          setStatus={setAuditStatus}
-          documents={contextDocuments}
-          deletionRuns={contextDeletionRuns}
-          documentsCursor={contextDocumentsCursor}
-          deletionRunsCursor={contextDeletionRunsCursor}
-          onRefresh={loadContextAudit}
-          onLoadMoreDocuments={loadMoreContextDocuments}
-          onLoadMoreDeletions={loadMoreContextDeletions}
-          onOpenProviderDocument={openContextDocumentInProvider}
-          onViewLogs={viewDocumentAuditLogs}
-          onToggleIndexing={updateContextIndexing}
-          onDeleteDocuments={deleteContextDocuments}
-          busy={isBusy}
-        />
-      )}
+          {activeView === 'context' && (
+            <ContextAuditView
+              applications={mailboxes.applications}
+              applicationId={contextAudit.auditApplicationId}
+              setApplicationId={contextAudit.setAuditApplicationId}
+              status={contextAudit.auditStatus}
+              setStatus={contextAudit.setAuditStatus}
+              documents={contextAudit.contextDocuments}
+              deletionRuns={contextAudit.contextDeletionRuns}
+              documentsCursor={contextAudit.contextDocumentsCursor}
+              deletionRunsCursor={contextAudit.contextDeletionRunsCursor}
+              onRefresh={contextAudit.loadContextAudit}
+              onLoadMoreDocuments={contextAudit.loadMoreContextDocuments}
+              onLoadMoreDeletions={contextAudit.loadMoreContextDeletions}
+              onOpenProviderDocument={contextAudit.openContextDocumentInProvider}
+              onViewLogs={auditLogs.openAuditLogs}
+              onToggleIndexing={mailboxes.updateContextIndexing}
+              onDeleteDocuments={mailboxes.deleteContextDocuments}
+              busy={isBusy}
+            />
+          )}
 
-      {activeView === 'actions' && (
-        <ActionsView
-          applications={applications}
-          applicationId={actionApplicationId}
-          setApplicationId={setActionApplicationId}
-          status={actionStatus}
-          setStatus={setActionStatus}
-          actions={actions}
-          actionsCursor={actionsCursor}
-          selectedActionId={selectedActionId}
-          executions={actionExecutions}
-          onRefresh={() => loadActions()}
-          onLoadMore={() => loadActions(true, actionsCursor)}
-          onSelectAction={loadActionExecutions}
-          onExecuteAction={executeAction}
-          busy={isBusy}
-        />
-      )}
+          {activeView === 'actions' && (
+            <ActionsView
+              applications={mailboxes.applications}
+              applicationId={actions.actionApplicationId}
+              setApplicationId={actions.setActionApplicationId}
+              status={actions.actionStatus}
+              setStatus={actions.setActionStatus}
+              actions={actions.actions}
+              actionsCursor={actions.actionsCursor}
+              selectedActionId={actions.selectedActionId}
+              executions={actions.actionExecutions}
+              onRefresh={() => actions.loadActions()}
+              onLoadMore={() => actions.loadActions(true, actions.actionsCursor)}
+              onSelectAction={actions.loadActionExecutions}
+              onExecuteAction={actions.executeAction}
+              busy={isBusy}
+            />
+          )}
 
-      {confirmDelete && typeof document !== 'undefined' && (
-        <ConfirmDeleteModal
-          displayName={confirmDelete.displayName}
-          onConfirm={() => {
-            const { applicationId } = confirmDelete;
-            setConfirmDelete(null);
-            deleteApplication(applicationId);
-          }}
-          onCancel={() => setConfirmDelete(null)}
-        />
-      )}
+          {mailboxes.confirmDelete && typeof document !== 'undefined' && (
+            <ConfirmDeleteModal
+              displayName={mailboxes.confirmDelete.displayName}
+              onConfirm={() => {
+                const { applicationId } = mailboxes.confirmDelete!;
+                mailboxes.setConfirmDelete(null);
+                mailboxes.deleteApplication(applicationId);
+              }}
+              onCancel={() => mailboxes.setConfirmDelete(null)}
+            />
+          )}
 
-      {auditLogDocumentId && typeof document !== 'undefined' && (
-        <AuditLogsModal
-          logs={auditLogs}
-          cursor={auditLogsCursor}
-          loading={loadingAuditLogs}
-          onClose={() => { setAuditLogDocumentId(null); setAuditLogs([]); setAuditLogsCursor(undefined); }}
-          onLoadMore={loadMoreAuditLogs}
-          onRefresh={refreshAuditLogs}
-        />
-      )}
-    </div>
+          {auditLogs.auditLogDocumentId && typeof document !== 'undefined' && (
+            <AuditLogsModal
+              logs={auditLogs.auditLogs}
+              cursor={auditLogs.auditLogsCursor}
+              loading={auditLogs.loadingAuditLogs}
+              onClose={auditLogs.closeAuditLogs}
+              onLoadMore={auditLogs.loadMoreAuditLogs}
+              onRefresh={auditLogs.refreshAuditLogs}
+            />
+          )}
+        </div>
+      </UserContext.Provider>
+    </NoticeContext.Provider>
   );
 }

--- a/apps/web/src/components/mailboxes/ContextSection.tsx
+++ b/apps/web/src/components/mailboxes/ContextSection.tsx
@@ -1,28 +1,15 @@
-import type { ConnectedApplication, CurrentUser } from '../../../components/types';
+import type { ConnectedApplication } from '../../../components/types';
 import { formatTimestamp } from '../../../components/utils';
 import { Button } from '../ui/Button';
 import { Card, CardHeader, CardTitle } from '../ui/Card';
 import { Metric } from '../shared/Metric';
+import { useMailboxCallbacks } from '../../contexts/MailboxCallbacksContext';
+import { useCurrentUserData } from '../../contexts/UserContext';
 
-export function ContextSection({
-  application,
-  user,
-  busy,
-  onUpdateContextIndexing,
-  onUpdateMaxContextDocuments,
-  onOpenContextAudit,
-  onDeleteContextDocuments,
-  onDismissContextError,
-}: {
-  application: ConnectedApplication;
-  user: CurrentUser;
-  busy: boolean;
-  onUpdateContextIndexing: (enabled: boolean) => void;
-  onUpdateMaxContextDocuments: (max: number | null) => void;
-  onOpenContextAudit: () => void;
-  onDeleteContextDocuments: () => void;
-  onDismissContextError: () => void;
-}) {
+export function ContextSection({ application }: { application: ConnectedApplication }) {
+  const user = useCurrentUserData();
+  const { busy, onUpdateContextIndexing, onUpdateMaxContextDocuments, onOpenContextAudit, onDeleteContextDocuments, onDismissContextError } = useMailboxCallbacks();
+
   return (
     <Card>
       <CardHeader>
@@ -32,7 +19,7 @@ export function ContextSection({
             <input
               type="checkbox"
               checked={application.contextIndexingEnabled}
-              onChange={(e) => onUpdateContextIndexing(e.target.checked)}
+              onChange={(e) => onUpdateContextIndexing(application.applicationId, e.target.checked)}
               disabled={busy}
               className="h-4 w-4 accent-[var(--color-accent)] rounded"
             />
@@ -48,7 +35,7 @@ export function ContextSection({
               value={application.maxContextDocuments ?? ''}
               onChange={(e) => {
                 const val = e.target.value === '' ? null : Number(e.target.value);
-                onUpdateMaxContextDocuments(val);
+                onUpdateMaxContextDocuments(application.applicationId, val);
               }}
               disabled={busy}
               className="w-28 px-2 py-1 rounded-lg bg-[var(--color-surface-base)] border border-[var(--color-border)] text-[var(--color-text-primary)] text-sm focus:outline-none focus:border-[var(--color-accent)]"
@@ -66,18 +53,18 @@ export function ContextSection({
           value={application.contextLastError || 'None'}
           tone={application.contextLastError ? 'error' : 'muted'}
           subtitle={application.contextLastError ? formatTimestamp(application.contextLastErrorAt) : undefined}
-          onDismiss={application.contextLastError ? onDismissContextError : undefined}
+          onDismiss={application.contextLastError ? () => onDismissContextError(application.applicationId) : undefined}
         />
       </div>
 
       <div className="mt-4 flex flex-wrap gap-2">
-        <Button variant="secondary" size="sm" onClick={onOpenContextAudit}>
+        <Button variant="secondary" size="sm" onClick={() => onOpenContextAudit(application.applicationId)}>
           View RAG Context
         </Button>
         <Button
           variant="danger"
           size="sm"
-          onClick={onDeleteContextDocuments}
+          onClick={() => onDeleteContextDocuments(application.applicationId)}
           disabled={busy || (application.contextDocumentCount || 0) === 0}
         >
           Delete Indexed Documents

--- a/apps/web/src/components/mailboxes/MailboxDetail.tsx
+++ b/apps/web/src/components/mailboxes/MailboxDetail.tsx
@@ -1,4 +1,4 @@
-import type { ConnectedApplication, CurrentUser } from '../../../components/types';
+import type { ConnectedApplication } from '../../../components/types';
 import { formatTimestamp, formatExpiryTimestamp, providerLabels } from '../../../components/utils';
 import { ConnectionBadge, WatchBadge } from '../ui/Badge';
 import { Button } from '../ui/Button';
@@ -8,54 +8,23 @@ import { ReadOnlyField } from '../shared/ReadOnlyField';
 import { WatchSection } from './WatchSection';
 import { ContextSection } from './ContextSection';
 import { SenderFilterSection } from './SenderFilterSection';
-import type { SenderDomainFilters } from '../../../components/types';
+import { useMailboxCallbacks } from '../../contexts/MailboxCallbacksContext';
 
 export function MailboxDetail({
   application,
   watchWebhookUrl,
-  user,
   availableFolders,
   loadingFolders,
-  busy,
-  onEdit,
-  onDelete,
-  onStartOAuth2,
-  onStartWatch,
-  onStopWatch,
-  onLoadFolders,
-  onUpdateWatchedFolders,
-  onUpdateSenderFilters,
-  onUpdateContextIndexing,
-  onUpdateMaxContextDocuments,
-  onOpenContextAudit,
-  onDeleteContextDocuments,
-  onDismissProcessingError,
-  onDismissContextError,
 }: {
   application: ConnectedApplication;
   watchWebhookUrl: string;
-  user: CurrentUser;
   availableFolders: Array<{ id: string; name: string }> | null;
   loadingFolders: boolean;
-  busy: boolean;
-  onEdit: () => void;
-  onDelete: () => void;
-  onStartOAuth2: () => void;
-  onStartWatch: () => void;
-  onStopWatch: () => void;
-  onLoadFolders: () => void;
-  onUpdateWatchedFolders: (folderIds: string[] | null) => void;
-  onUpdateSenderFilters: (filters: SenderDomainFilters) => void;
-  onUpdateContextIndexing: (enabled: boolean) => void;
-  onUpdateMaxContextDocuments: (max: number | null) => void;
-  onOpenContextAudit: () => void;
-  onDeleteContextDocuments: () => void;
-  onDismissProcessingError: () => void;
-  onDismissContextError: () => void;
 }) {
+  const { busy, onEdit, onDelete, onStartOAuth2, onStartWatch, onStopWatch, onDismissProcessingError } = useMailboxCallbacks();
+
   return (
     <div className="space-y-4 animate-fade-in-up">
-      {/* Header card */}
       <Card>
         <div className="flex flex-col md:flex-row md:items-start justify-between gap-4">
           <div className="min-w-0">
@@ -70,7 +39,7 @@ export function MailboxDetail({
             <div className="text-xs text-[var(--color-text-muted)] mt-1">Updated {formatTimestamp(application.updatedAt)}</div>
           </div>
           <div className="flex gap-2 shrink-0">
-            <Button variant="secondary" size="sm" onClick={onEdit}>Edit</Button>
+            <Button variant="secondary" size="sm" onClick={() => onEdit(application)}>Edit</Button>
             <Button variant="danger" size="sm" onClick={onDelete} disabled={busy}>Delete</Button>
           </div>
         </div>
@@ -84,13 +53,18 @@ export function MailboxDetail({
         </div>
 
         <div className="mt-5 flex flex-wrap gap-2">
-          <Button variant={application.status === 'connected' ? 'secondary' : 'primary'} size="sm" onClick={onStartOAuth2} disabled={busy}>
+          <Button
+            variant={application.status === 'connected' ? 'secondary' : 'primary'}
+            size="sm"
+            onClick={() => onStartOAuth2(application.applicationId)}
+            disabled={busy}
+          >
             {application.status === 'connected' ? 'Re-Authorize OAuth2' : 'Authorize OAuth2'}
           </Button>
           <Button
             variant="secondary"
             size="sm"
-            onClick={onStartWatch}
+            onClick={() => onStartWatch(application.applicationId)}
             disabled={busy || application.status !== 'connected' || application.watchStatus === 'active'}
           >
             Start Watch
@@ -98,7 +72,7 @@ export function MailboxDetail({
           <Button
             variant="ghost"
             size="sm"
-            onClick={onStopWatch}
+            onClick={() => onStopWatch(application.applicationId)}
             disabled={busy || application.watchStatus !== 'active'}
           >
             Stop Watch
@@ -106,7 +80,6 @@ export function MailboxDetail({
         </div>
       </Card>
 
-      {/* Processing metrics */}
       <Card>
         <CardHeader>
           <CardTitle>Processing</CardTitle>
@@ -123,40 +96,14 @@ export function MailboxDetail({
             value={application.lastError || 'None'}
             tone={application.lastError ? 'error' : 'muted'}
             subtitle={application.lastError ? formatTimestamp(application.lastErrorAt) : undefined}
-            onDismiss={application.lastError ? onDismissProcessingError : undefined}
+            onDismiss={application.lastError ? () => onDismissProcessingError(application.applicationId) : undefined}
           />
         </div>
       </Card>
 
-      {/* Context indexing */}
-      <ContextSection
-        application={application}
-        user={user}
-        busy={busy}
-        onUpdateContextIndexing={onUpdateContextIndexing}
-        onUpdateMaxContextDocuments={onUpdateMaxContextDocuments}
-        onOpenContextAudit={onOpenContextAudit}
-        onDeleteContextDocuments={onDeleteContextDocuments}
-        onDismissContextError={onDismissContextError}
-      />
-
-      {/* Sender filter rules */}
-      <SenderFilterSection
-        filters={application.senderDomainFilters}
-        busy={busy}
-        onUpdate={onUpdateSenderFilters}
-      />
-
-      {/* Watch folders */}
-      <WatchSection
-        application={application}
-        availableFolders={availableFolders}
-        loadingFolders={loadingFolders}
-        busy={busy}
-        onLoadFolders={onLoadFolders}
-        onUpdateWatchedFolders={onUpdateWatchedFolders}
-      />
+      <ContextSection application={application} />
+      <SenderFilterSection application={application} />
+      <WatchSection application={application} availableFolders={availableFolders} loadingFolders={loadingFolders} />
     </div>
   );
 }
-

--- a/apps/web/src/components/mailboxes/MailboxForm.tsx
+++ b/apps/web/src/components/mailboxes/MailboxForm.tsx
@@ -6,6 +6,7 @@ import type { OAuth2Feature } from '../../../components/constants';
 import { Input, Select } from '../ui/Input';
 import { Button } from '../ui/Button';
 import { cn } from '../../lib/utils';
+import { FORM_HIGHLIGHT_TIMEOUT_MS } from '../../lib/constants';
 
 export interface ApplicationFormState {
   applicationId?: string;
@@ -51,7 +52,7 @@ export function MailboxForm({
     if (form.applicationId && form.applicationId !== prevApplicationId.current) {
       setIsHighlighted(true);
       formRef.current?.scrollIntoView({ behavior: 'smooth', block: 'nearest' });
-      const t = window.setTimeout(() => setIsHighlighted(false), 1500);
+      const t = window.setTimeout(() => setIsHighlighted(false), FORM_HIGHLIGHT_TIMEOUT_MS);
       return () => window.clearTimeout(t);
     }
     prevApplicationId.current = form.applicationId;

--- a/apps/web/src/components/mailboxes/SenderFilterSection.tsx
+++ b/apps/web/src/components/mailboxes/SenderFilterSection.tsx
@@ -1,8 +1,9 @@
 import { useState } from 'react';
-import type { SenderDomainFilters } from '../../../components/types';
+import type { ConnectedApplication, SenderDomainFilters } from '../../../components/types';
 import { Button } from '../ui/Button';
 import { Card, CardHeader, CardTitle } from '../ui/Card';
 import { Input } from '../ui/Input';
+import { useMailboxCallbacks } from '../../contexts/MailboxCallbacksContext';
 
 function RuleList({
   label,
@@ -68,21 +69,14 @@ function RuleList({
   );
 }
 
-export function SenderFilterSection({
-  filters,
-  busy,
-  onUpdate,
-}: {
-  filters: SenderDomainFilters | null | undefined;
-  busy: boolean;
-  onUpdate: (filters: SenderDomainFilters) => void;
-}) {
-  const current: SenderDomainFilters = filters ?? { includeRules: [], excludeRules: [] };
+export function SenderFilterSection({ application }: { application: ConnectedApplication }) {
+  const { busy, onUpdateSenderFilters } = useMailboxCallbacks();
+  const current: SenderDomainFilters = application.senderDomainFilters ?? { includeRules: [], excludeRules: [] };
 
-  const addInclude = (rule: string) => onUpdate({ ...current, includeRules: [...current.includeRules, rule] });
-  const removeInclude = (rule: string) => onUpdate({ ...current, includeRules: current.includeRules.filter((r) => r !== rule) });
-  const addExclude = (rule: string) => onUpdate({ ...current, excludeRules: [...current.excludeRules, rule] });
-  const removeExclude = (rule: string) => onUpdate({ ...current, excludeRules: current.excludeRules.filter((r) => r !== rule) });
+  const addInclude = (rule: string) => onUpdateSenderFilters(application.applicationId, { ...current, includeRules: [...current.includeRules, rule] });
+  const removeInclude = (rule: string) => onUpdateSenderFilters(application.applicationId, { ...current, includeRules: current.includeRules.filter((r) => r !== rule) });
+  const addExclude = (rule: string) => onUpdateSenderFilters(application.applicationId, { ...current, excludeRules: [...current.excludeRules, rule] });
+  const removeExclude = (rule: string) => onUpdateSenderFilters(application.applicationId, { ...current, excludeRules: current.excludeRules.filter((r) => r !== rule) });
 
   return (
     <Card>

--- a/apps/web/src/components/mailboxes/WatchSection.tsx
+++ b/apps/web/src/components/mailboxes/WatchSection.tsx
@@ -2,6 +2,7 @@ import { useState, useEffect } from 'react';
 import type { ConnectedApplication } from '../../../components/types';
 import { Button } from '../ui/Button';
 import { Card, CardHeader, CardTitle } from '../ui/Card';
+import { useMailboxCallbacks } from '../../contexts/MailboxCallbacksContext';
 
 const setsEqual = (a: string[] | null, b: string[] | null) => {
   if (a === null && b === null) return true;
@@ -13,17 +14,12 @@ export function WatchSection({
   application,
   availableFolders,
   loadingFolders,
-  busy,
-  onLoadFolders,
-  onUpdateWatchedFolders,
 }: {
   application: ConnectedApplication;
   availableFolders: Array<{ id: string; name: string }> | null;
   loadingFolders: boolean;
-  busy: boolean;
-  onLoadFolders: () => void;
-  onUpdateWatchedFolders: (folderIds: string[] | null) => void;
 }) {
+  const { busy, onLoadFolders, onUpdateWatchedFolders } = useMailboxCallbacks();
   const isOutlook = application.providerId === 'microsoft-outlook';
   const [pendingIds, setPendingIds] = useState<string[] | null>(null);
 
@@ -45,7 +41,7 @@ export function WatchSection({
         <Button
           variant="secondary"
           size="sm"
-          onClick={onLoadFolders}
+          onClick={() => onLoadFolders(application.applicationId)}
           loading={loadingFolders}
           disabled={busy || loadingFolders || application.status !== 'connected'}
         >
@@ -92,7 +88,7 @@ export function WatchSection({
               <Button
                 variant="primary"
                 size="sm"
-                onClick={() => onUpdateWatchedFolders(pendingIds)}
+                onClick={() => onUpdateWatchedFolders(application.applicationId, pendingIds)}
                 disabled={busy || isUnchanged}
               >
                 Save Folders

--- a/apps/web/src/components/modals/AuditLogsModal.tsx
+++ b/apps/web/src/components/modals/AuditLogsModal.tsx
@@ -1,9 +1,9 @@
-import { createPortal } from 'react-dom';
 import { X, RefreshCw } from 'lucide-react';
 import type { ContextAuditLog } from '../../../components/types';
 import { formatTimestamp } from '../../../components/utils';
 import { Button } from '../ui/Button';
 import { cn } from '../../lib/utils';
+import { ModalShell } from './ModalShell';
 
 const auditEventLabels: Record<string, string> = {
   processing_started: 'Processing Started',
@@ -34,80 +34,73 @@ export function AuditLogsModal({
   onLoadMore: () => void;
   onRefresh: () => void;
 }) {
-  return createPortal(
-    <div className="fixed inset-0 z-50 flex items-center justify-center" onClick={onClose}>
-      <div className="fixed inset-0 bg-black/60 animate-backdrop-in" />
-      <div
-        className="relative bg-[var(--color-surface-1)] border border-[var(--color-border-muted)] rounded-2xl w-full max-w-2xl max-h-[82vh] overflow-hidden shadow-2xl mx-4 animate-fade-in"
-        onClick={(e) => e.stopPropagation()}
-      >
-        <div className="flex items-center justify-between px-5 py-4 border-b border-[var(--color-border)]">
-          <h2 className="text-base font-semibold text-[var(--color-text-primary)]">Document Audit Logs</h2>
-          <div className="flex items-center gap-2">
-            <Button variant="secondary" size="sm" loading={loading} onClick={onRefresh}>
-              <RefreshCw className="h-3.5 w-3.5" />
-              Refresh
-            </Button>
-            <button
-              className="text-[var(--color-text-muted)] hover:text-[var(--color-text-primary)] transition-colors p-1 rounded-lg hover:bg-[var(--color-surface-3)]"
-              onClick={onClose}
-              aria-label="Close"
-            >
-              <X className="h-4 w-4" />
-            </button>
-          </div>
-        </div>
-
-        <div className="overflow-y-auto p-5 space-y-2.5 max-h-[calc(82vh-4rem)]">
-          {logs.length === 0 && !loading && (
-            <div className="text-center text-[var(--color-text-muted)] py-10 text-sm">No Audit Logs Found For This Document.</div>
-          )}
-          {logs.map((log, index) => {
-            const dotClass =
-              log.severity === 'error'
-                ? 'bg-[var(--color-error-text)]'
-                : log.severity === 'warning'
-                  ? 'bg-[var(--color-warning-text)]'
-                  : 'bg-[var(--color-success-text)]';
-            const attemptNumber = (log.eventData as { attempt?: number } | undefined)?.attempt;
-            return (
-              <div key={log.id} className="rounded-xl border border-[var(--color-border)] bg-[var(--color-surface-base)] p-4">
-                <div className="flex items-start gap-2.5">
-                  <span className={cn('inline-block w-2 h-2 rounded-full shrink-0 mt-1.5', dotClass)} />
-                  <div className="min-w-0 flex-1">
-                    <div className="text-sm font-medium text-[var(--color-text-primary)]">
-                      {log.eventLabel || auditEventLabels[log.eventType] || log.eventType}
-                      {attemptNumber != null && attemptNumber > 1 && (
-                        <span className="ml-2 text-[var(--color-text-muted)] font-normal">(Attempt {attemptNumber})</span>
-                      )}
-                    </div>
-                    <div className="text-xs text-[var(--color-text-muted)] mt-0.5 flex items-center gap-2 flex-wrap">
-                      <span className="inline-flex items-center justify-center w-5 h-5 rounded-full bg-[var(--color-surface-3)] text-[10px] font-medium">
-                        #{logs.length - index}
-                      </span>
-                      {formatTimestamp(log.createdAt)}
-                      <span className="px-1.5 py-0.5 rounded bg-[var(--color-surface-3)] text-[10px] uppercase tracking-wide">
-                        {log.eventType}
-                      </span>
-                    </div>
-                    {log.eventData != null && (
-                      <div className="mt-2 text-xs text-[var(--color-text-muted)] font-mono bg-[var(--color-surface-base)] border border-[var(--color-border)] rounded-lg p-2 overflow-x-auto">
-                        {typeof log.eventData === 'object' ? JSON.stringify(log.eventData, null, 1) : String(log.eventData)}
-                      </div>
-                    )}
-                  </div>
-                </div>
-              </div>
-            );
-          })}
-          {cursor && (
-            <Button variant="secondary" className="w-full" loading={loading} onClick={onLoadMore}>
-              Load More
-            </Button>
-          )}
+  return (
+    <ModalShell onClose={onClose} widthClass="w-full max-w-2xl max-h-[82vh] overflow-hidden mx-4" ariaLabel="Document Audit Logs">
+      <div className="flex items-center justify-between px-5 py-4 border-b border-[var(--color-border)]">
+        <h2 className="text-base font-semibold text-[var(--color-text-primary)]">Document Audit Logs</h2>
+        <div className="flex items-center gap-2">
+          <Button variant="secondary" size="sm" loading={loading} onClick={onRefresh}>
+            <RefreshCw className="h-3.5 w-3.5" />
+            Refresh
+          </Button>
+          <button
+            className="text-[var(--color-text-muted)] hover:text-[var(--color-text-primary)] transition-colors p-1 rounded-lg hover:bg-[var(--color-surface-3)]"
+            onClick={onClose}
+            aria-label="Close"
+          >
+            <X className="h-4 w-4" />
+          </button>
         </div>
       </div>
-    </div>,
-    document.body,
+
+      <div className="overflow-y-auto p-5 space-y-2.5 max-h-[calc(82vh-4rem)]">
+        {logs.length === 0 && !loading && (
+          <div className="text-center text-[var(--color-text-muted)] py-10 text-sm">No Audit Logs Found For This Document.</div>
+        )}
+        {logs.map((log, index) => {
+          const dotClass =
+            log.severity === 'error'
+              ? 'bg-[var(--color-error-text)]'
+              : log.severity === 'warning'
+                ? 'bg-[var(--color-warning-text)]'
+                : 'bg-[var(--color-success-text)]';
+          const attemptNumber = (log.eventData as { attempt?: number } | undefined)?.attempt;
+          return (
+            <div key={log.id} className="rounded-xl border border-[var(--color-border)] bg-[var(--color-surface-base)] p-4">
+              <div className="flex items-start gap-2.5">
+                <span className={cn('inline-block w-2 h-2 rounded-full shrink-0 mt-1.5', dotClass)} />
+                <div className="min-w-0 flex-1">
+                  <div className="text-sm font-medium text-[var(--color-text-primary)]">
+                    {log.eventLabel || auditEventLabels[log.eventType] || log.eventType}
+                    {attemptNumber != null && attemptNumber > 1 && (
+                      <span className="ml-2 text-[var(--color-text-muted)] font-normal">(Attempt {attemptNumber})</span>
+                    )}
+                  </div>
+                  <div className="text-xs text-[var(--color-text-muted)] mt-0.5 flex items-center gap-2 flex-wrap">
+                    <span className="inline-flex items-center justify-center w-5 h-5 rounded-full bg-[var(--color-surface-3)] text-[10px] font-medium">
+                      #{logs.length - index}
+                    </span>
+                    {formatTimestamp(log.createdAt)}
+                    <span className="px-1.5 py-0.5 rounded bg-[var(--color-surface-3)] text-[10px] uppercase tracking-wide">
+                      {log.eventType}
+                    </span>
+                  </div>
+                  {log.eventData != null && (
+                    <div className="mt-2 text-xs text-[var(--color-text-muted)] font-mono bg-[var(--color-surface-base)] border border-[var(--color-border)] rounded-lg p-2 overflow-x-auto">
+                      {typeof log.eventData === 'object' ? JSON.stringify(log.eventData, null, 1) : String(log.eventData)}
+                    </div>
+                  )}
+                </div>
+              </div>
+            </div>
+          );
+        })}
+        {cursor && (
+          <Button variant="secondary" className="w-full" loading={loading} onClick={onLoadMore}>
+            Load More
+          </Button>
+        )}
+      </div>
+    </ModalShell>
   );
 }

--- a/apps/web/src/components/modals/ConfirmDeleteModal.tsx
+++ b/apps/web/src/components/modals/ConfirmDeleteModal.tsx
@@ -1,6 +1,6 @@
-import { createPortal } from 'react-dom';
 import { AlertTriangle } from 'lucide-react';
 import { Button } from '../ui/Button';
+import { ModalShell } from './ModalShell';
 
 export function ConfirmDeleteModal({
   displayName,
@@ -11,16 +11,9 @@ export function ConfirmDeleteModal({
   onConfirm: () => void;
   onCancel: () => void;
 }) {
-  return createPortal(
-    <div
-      onClick={(e) => e.stopPropagation()}
-      role="dialog"
-      aria-label="Confirm Delete Mailbox"
-      aria-modal="true"
-      className="fixed inset-0 z-50 flex items-center justify-center"
-    >
-      <div className="fixed inset-0 bg-black/60 animate-backdrop-in" onClick={onCancel} />
-      <div className="relative bg-[var(--color-surface-1)] border border-[var(--color-border-muted)] rounded-2xl p-6 w-80 shadow-2xl animate-fade-in">
+  return (
+    <ModalShell onClose={onCancel} widthClass="w-80" ariaLabel="Confirm Delete Mailbox">
+      <div className="p-6">
         <div className="flex items-center justify-center w-10 h-10 rounded-full bg-[var(--color-error-bg)] mb-4 mx-auto">
           <AlertTriangle className="h-5 w-5 text-[var(--color-error-text)]" />
         </div>
@@ -31,16 +24,11 @@ export function ConfirmDeleteModal({
           <Button variant="ghost" className="flex-1" onClick={(e) => { e.stopPropagation(); onCancel(); }}>
             Cancel
           </Button>
-          <Button
-            variant="danger"
-            className="flex-1"
-            onClick={(e) => { e.stopPropagation(); onConfirm(); }}
-          >
+          <Button variant="danger" className="flex-1" onClick={(e) => { e.stopPropagation(); onConfirm(); }}>
             Delete
           </Button>
         </div>
       </div>
-    </div>,
-    document.body,
+    </ModalShell>
   );
 }

--- a/apps/web/src/components/modals/ModalShell.tsx
+++ b/apps/web/src/components/modals/ModalShell.tsx
@@ -1,0 +1,33 @@
+import { createPortal } from 'react-dom';
+import type { ReactNode } from 'react';
+
+export function ModalShell({
+  onClose,
+  children,
+  widthClass = 'w-80',
+  ariaLabel,
+}: {
+  onClose: () => void;
+  children: ReactNode;
+  widthClass?: string;
+  ariaLabel?: string;
+}) {
+  return createPortal(
+    <div
+      className="fixed inset-0 z-50 flex items-center justify-center"
+      onClick={onClose}
+      role="dialog"
+      aria-modal="true"
+      aria-label={ariaLabel}
+    >
+      <div className="fixed inset-0 bg-black/60 animate-backdrop-in" />
+      <div
+        className={`relative bg-[var(--color-surface-1)] border border-[var(--color-border-muted)] rounded-2xl shadow-2xl animate-fade-in ${widthClass}`}
+        onClick={(e) => e.stopPropagation()}
+      >
+        {children}
+      </div>
+    </div>,
+    document.body,
+  );
+}

--- a/apps/web/src/components/shared/FilterBar.tsx
+++ b/apps/web/src/components/shared/FilterBar.tsx
@@ -1,0 +1,11 @@
+import type { ReactNode } from 'react';
+import { Card } from '../ui/Card';
+
+export function FilterBar({ title, children }: { title?: string; children: ReactNode }) {
+  return (
+    <Card className="flex flex-col lg:flex-row lg:items-center justify-between gap-4 py-4">
+      {title && <h1 className="text-xl font-semibold text-[var(--color-text-primary)]">{title}</h1>}
+      <div className="flex flex-wrap items-center gap-3">{children}</div>
+    </Card>
+  );
+}

--- a/apps/web/src/components/shared/ReadOnlyField.tsx
+++ b/apps/web/src/components/shared/ReadOnlyField.tsx
@@ -2,6 +2,7 @@ import { useState } from 'react';
 import { Check, Copy } from 'lucide-react';
 import { Label } from '../ui/Input';
 import { cn } from '../../lib/utils';
+import { COPY_FEEDBACK_TIMEOUT_MS } from '../../lib/constants';
 
 export function ReadOnlyField({ label, value, showCopy = false }: { label: string; value: string; showCopy?: boolean }) {
   const [copied, setCopied] = useState(false);
@@ -9,7 +10,7 @@ export function ReadOnlyField({ label, value, showCopy = false }: { label: strin
   const handleCopy = () => {
     navigator.clipboard.writeText(value);
     setCopied(true);
-    setTimeout(() => setCopied(false), 1500);
+    setTimeout(() => setCopied(false), COPY_FEEDBACK_TIMEOUT_MS);
   };
 
   return (

--- a/apps/web/src/components/views/ActionsView.tsx
+++ b/apps/web/src/components/views/ActionsView.tsx
@@ -6,6 +6,7 @@ import { Button } from '../ui/Button';
 import { Card, CardHeader, CardTitle } from '../ui/Card';
 import { Select, Label } from '../ui/Input';
 import { Metric } from '../shared/Metric';
+import { FilterBar } from '../shared/FilterBar';
 import { ActionPayloadDetails } from '../actions/ActionPayloadDetails';
 import { cn } from '../../lib/utils';
 
@@ -44,7 +45,6 @@ export function ActionsView({
 
   return (
     <main className="max-w-7xl mx-auto px-6 py-8 space-y-5 animate-fade-in-up">
-      {/* Toolbar */}
       <div className="flex flex-col sm:flex-row sm:items-end justify-between gap-4">
         <div>
           <h1 className="text-xl font-semibold text-[var(--color-text-primary)]">Actions</h1>
@@ -58,8 +58,7 @@ export function ActionsView({
         </Button>
       </div>
 
-      {/* Filters */}
-      <Card className="flex flex-col sm:flex-row gap-4 py-4">
+      <FilterBar>
         <div className="flex flex-col gap-1.5">
           <Label>Mailbox</Label>
           <Select value={applicationId} onChange={(e) => setApplicationId(e.target.value)} className="min-w-[180px]">
@@ -78,11 +77,9 @@ export function ActionsView({
             ))}
           </Select>
         </div>
-      </Card>
+      </FilterBar>
 
-      {/* Content */}
       <div className="grid grid-cols-1 lg:grid-cols-[minmax(0,1fr)_400px] gap-5">
-        {/* Action list */}
         <Card className="p-0 overflow-hidden">
           <CardHeader className="px-5 pt-5 pb-4 border-b border-[var(--color-border)] mb-0">
             <CardTitle>Action Items</CardTitle>
@@ -95,9 +92,7 @@ export function ActionsView({
                 onClick={() => onSelectAction(action.actionId)}
                 className={cn(
                   'w-full text-left px-5 py-4 transition-colors duration-150',
-                  selectedActionId === action.actionId
-                    ? 'bg-[#0e2d22]'
-                    : 'hover:bg-[var(--color-surface-2)]',
+                  selectedActionId === action.actionId ? 'bg-[#0e2d22]' : 'hover:bg-[var(--color-surface-2)]',
                 )}
               >
                 <div className="flex items-start justify-between gap-3">
@@ -123,7 +118,6 @@ export function ActionsView({
           )}
         </Card>
 
-        {/* Detail panel */}
         <div className="space-y-4">
           {selectedAction ? (
             <>

--- a/apps/web/src/components/views/ContextAuditView.tsx
+++ b/apps/web/src/components/views/ContextAuditView.tsx
@@ -10,6 +10,7 @@ import { ContextIndexBadge } from '../ui/Badge';
 import { Button } from '../ui/Button';
 import { Card, CardHeader, CardTitle } from '../ui/Card';
 import { Select } from '../ui/Input';
+import { FilterBar } from '../shared/FilterBar';
 import { ContextDocumentRow } from '../context/ContextDocumentRow';
 import { ContextDeletionRunRow } from '../context/ContextDeletionRunRow';
 
@@ -54,38 +55,29 @@ export function ContextAuditView({
 
   return (
     <main className="max-w-7xl mx-auto px-6 py-8 space-y-5 animate-fade-in-up">
-      {/* Toolbar */}
-      <Card className="flex flex-col lg:flex-row lg:items-center justify-between gap-4 py-4">
-        <h1 className="text-xl font-semibold text-[var(--color-text-primary)]">RAG Context</h1>
-        <div className="flex flex-wrap items-center gap-3">
-          <Select
-            value={applicationId}
-            onChange={(e) => setApplicationId(e.target.value)}
-            className="min-w-[180px]"
-          >
-            <option value="">All Mailboxes</option>
-            {applications.map((app) => (
-              <option key={app.applicationId} value={app.applicationId}>{app.displayName}</option>
-            ))}
-          </Select>
-          <Select
-            value={status}
-            onChange={(e) => setStatus(e.target.value as ApplicationContextDocumentStatus | '')}
-            className="min-w-[130px]"
-          >
-            <option value="">All Statuses</option>
-            <option value="active">Active</option>
-            <option value="deleted">Deleted</option>
-            <option value="error">Error</option>
-          </Select>
-          <Button variant="secondary" size="sm" onClick={onRefresh} disabled={busy}>
-            <RefreshCw className="h-3.5 w-3.5" />
-            Refresh
-          </Button>
-        </div>
-      </Card>
+      <FilterBar title="RAG Context">
+        <Select value={applicationId} onChange={(e) => setApplicationId(e.target.value)} className="min-w-[180px]">
+          <option value="">All Mailboxes</option>
+          {applications.map((app) => (
+            <option key={app.applicationId} value={app.applicationId}>{app.displayName}</option>
+          ))}
+        </Select>
+        <Select
+          value={status}
+          onChange={(e) => setStatus(e.target.value as ApplicationContextDocumentStatus | '')}
+          className="min-w-[130px]"
+        >
+          <option value="">All Statuses</option>
+          <option value="active">Active</option>
+          <option value="deleted">Deleted</option>
+          <option value="error">Error</option>
+        </Select>
+        <Button variant="secondary" size="sm" onClick={onRefresh} disabled={busy}>
+          <RefreshCw className="h-3.5 w-3.5" />
+          Refresh
+        </Button>
+      </FilterBar>
 
-      {/* Selected mailbox quick-actions */}
       {selectedApplication && (
         <Card>
           <div className="flex flex-col md:flex-row md:items-center justify-between gap-4">
@@ -122,9 +114,7 @@ export function ContextAuditView({
         </Card>
       )}
 
-      {/* Two-column content */}
       <div className="grid grid-cols-1 xl:grid-cols-[minmax(0,1fr)_400px] gap-5">
-        {/* Documents */}
         <div>
           <CardHeader className="mb-3 px-0">
             <CardTitle>Indexed Documents</CardTitle>
@@ -153,7 +143,6 @@ export function ContextAuditView({
           )}
         </div>
 
-        {/* Deletion history */}
         <div>
           <CardHeader className="mb-3 px-0">
             <CardTitle>Deletion History</CardTitle>

--- a/apps/web/src/components/views/MailboxesView.tsx
+++ b/apps/web/src/components/views/MailboxesView.tsx
@@ -1,74 +1,45 @@
-import type { ConnectedApplication, CurrentUser, SenderDomainFilters } from '../../../components/types';
+import type { ConnectedApplication } from '../../../components/types';
 import { MailboxCard } from '../mailboxes/MailboxCard';
 import { MailboxDetail } from '../mailboxes/MailboxDetail';
 import type { ApplicationFormState } from '../mailboxes/MailboxForm';
 import { MailboxForm } from '../mailboxes/MailboxForm';
 import { Card } from '../ui/Card';
+import { useCurrentUserData } from '../../contexts/UserContext';
+import { useMailboxCallbacks } from '../../contexts/MailboxCallbacksContext';
 
 export function MailboxesView({
   applications,
   selectedApplicationId,
   onSelectApplication,
-  user,
   watchWebhookUrl,
   availableFolders,
   loadingFolders,
-  busy,
   applicationForm,
   setApplicationForm,
   onSaveForm,
   onCancelForm,
-  onEditApplication,
-  onDeleteApplication,
-  onStartOAuth2,
-  onStartWatch,
-  onStopWatch,
-  onLoadFolders,
-  onUpdateWatchedFolders,
-  onUpdateSenderFilters,
-  onUpdateContextIndexing,
-  onUpdateMaxContextDocuments,
-  onOpenContextAudit,
-  onDeleteContextDocuments,
-  onDismissProcessingError,
-  onDismissContextError,
   isFormExpanded,
   setIsFormExpanded,
 }: {
   applications: ConnectedApplication[];
   selectedApplicationId: string;
   onSelectApplication: (id: string) => void;
-  user: CurrentUser;
   watchWebhookUrl: string;
   availableFolders: Array<{ id: string; name: string }> | null;
   loadingFolders: boolean;
-  busy: boolean;
   applicationForm: ApplicationFormState;
   setApplicationForm: (form: ApplicationFormState) => void;
   onSaveForm: () => void;
   onCancelForm: () => void;
-  onEditApplication: (app: ConnectedApplication) => void;
-  onDeleteApplication: () => void;
-  onStartOAuth2: (id: string) => void;
-  onStartWatch: (id: string) => void;
-  onStopWatch: (id: string) => void;
-  onLoadFolders: (id: string) => void;
-  onUpdateWatchedFolders: (id: string, folderIds: string[] | null) => void;
-  onUpdateSenderFilters: (id: string, filters: SenderDomainFilters) => void;
-  onUpdateContextIndexing: (id: string, enabled: boolean) => void;
-  onUpdateMaxContextDocuments: (id: string, max: number | null) => void;
-  onOpenContextAudit: (id: string) => void;
-  onDeleteContextDocuments: (id: string) => void;
-  onDismissProcessingError: (id: string) => void;
-  onDismissContextError: (id: string) => void;
   isFormExpanded: boolean;
   setIsFormExpanded: (v: boolean) => void;
 }) {
+  const user = useCurrentUserData();
+  const { busy } = useMailboxCallbacks();
   const selectedApplication = applications.find((a) => a.applicationId === selectedApplicationId);
 
   return (
     <main className="max-w-7xl mx-auto px-6 py-8 grid grid-cols-1 lg:grid-cols-[340px_minmax(0,1fr)] gap-6 animate-fade-in-up">
-      {/* Sidebar */}
       <section className="space-y-3">
         <div className="flex items-center justify-between">
           <h1 className="text-xl font-semibold text-[var(--color-text-primary)]">Connected Mailboxes</h1>
@@ -108,30 +79,13 @@ export function MailboxesView({
         />
       </section>
 
-      {/* Detail panel */}
       <section>
         {selectedApplication ? (
           <MailboxDetail
             application={selectedApplication}
             watchWebhookUrl={watchWebhookUrl}
-            user={user}
             availableFolders={availableFolders}
             loadingFolders={loadingFolders}
-            busy={busy}
-            onEdit={() => onEditApplication(selectedApplication)}
-            onDelete={onDeleteApplication}
-            onStartOAuth2={() => onStartOAuth2(selectedApplication.applicationId)}
-            onStartWatch={() => onStartWatch(selectedApplication.applicationId)}
-            onStopWatch={() => onStopWatch(selectedApplication.applicationId)}
-            onLoadFolders={() => onLoadFolders(selectedApplication.applicationId)}
-            onUpdateWatchedFolders={(ids) => onUpdateWatchedFolders(selectedApplication.applicationId, ids)}
-            onUpdateSenderFilters={(filters) => onUpdateSenderFilters(selectedApplication.applicationId, filters)}
-            onUpdateContextIndexing={(enabled) => onUpdateContextIndexing(selectedApplication.applicationId, enabled)}
-            onUpdateMaxContextDocuments={(max) => onUpdateMaxContextDocuments(selectedApplication.applicationId, max)}
-            onOpenContextAudit={() => onOpenContextAudit(selectedApplication.applicationId)}
-            onDeleteContextDocuments={() => onDeleteContextDocuments(selectedApplication.applicationId)}
-            onDismissProcessingError={() => onDismissProcessingError(selectedApplication.applicationId)}
-            onDismissContextError={() => onDismissContextError(selectedApplication.applicationId)}
           />
         ) : (
           <Card className="text-center text-[var(--color-text-muted)] py-16 text-sm">

--- a/apps/web/src/contexts/MailboxCallbacksContext.tsx
+++ b/apps/web/src/contexts/MailboxCallbacksContext.tsx
@@ -1,0 +1,28 @@
+import { createContext, useContext } from 'react';
+import type { ConnectedApplication, SenderDomainFilters } from '../../components/types';
+
+export interface MailboxCallbacksContextValue {
+  busy: boolean;
+  onEdit: (app: ConnectedApplication) => void;
+  onDelete: () => void;
+  onStartOAuth2: (id: string) => void;
+  onStartWatch: (id: string) => void;
+  onStopWatch: (id: string) => void;
+  onLoadFolders: (id: string) => void;
+  onUpdateWatchedFolders: (id: string, folderIds: string[] | null) => void;
+  onUpdateSenderFilters: (id: string, filters: SenderDomainFilters) => void;
+  onUpdateContextIndexing: (id: string, enabled: boolean) => void;
+  onUpdateMaxContextDocuments: (id: string, max: number | null) => void;
+  onOpenContextAudit: (id: string) => void;
+  onDeleteContextDocuments: (id: string) => void;
+  onDismissProcessingError: (id: string) => void;
+  onDismissContextError: (id: string) => void;
+}
+
+export const MailboxCallbacksContext = createContext<MailboxCallbacksContextValue | null>(null);
+
+export function useMailboxCallbacks(): MailboxCallbacksContextValue {
+  const ctx = useContext(MailboxCallbacksContext);
+  if (!ctx) throw new Error('useMailboxCallbacks must be used inside MailboxCallbacksContext.Provider');
+  return ctx;
+}

--- a/apps/web/src/contexts/NoticeContext.tsx
+++ b/apps/web/src/contexts/NoticeContext.tsx
@@ -1,0 +1,13 @@
+import { createContext, useContext } from 'react';
+
+interface NoticeContextValue {
+  showNotice: (type: 'success' | 'error', text: string) => void;
+}
+
+export const NoticeContext = createContext<NoticeContextValue | null>(null);
+
+export function useShowNotice(): (type: 'success' | 'error', text: string) => void {
+  const ctx = useContext(NoticeContext);
+  if (!ctx) throw new Error('useShowNotice must be used inside NoticeContext.Provider');
+  return ctx.showNotice;
+}

--- a/apps/web/src/contexts/UserContext.tsx
+++ b/apps/web/src/contexts/UserContext.tsx
@@ -1,0 +1,10 @@
+import { createContext, useContext } from 'react';
+import type { CurrentUser } from '../../components/types';
+
+export const UserContext = createContext<CurrentUser | null>(null);
+
+export function useCurrentUserData(): CurrentUser {
+  const ctx = useContext(UserContext);
+  if (!ctx) throw new Error('useCurrentUserData must be used inside UserContext.Provider');
+  return ctx;
+}

--- a/apps/web/src/hooks/useActions.ts
+++ b/apps/web/src/hooks/useActions.ts
@@ -1,0 +1,70 @@
+import { useState } from 'react';
+import type { EmailAction, EmailActionExecution, EmailActionStatus } from '../../components/types';
+import * as actionSvc from '../services/actionService';
+
+interface UseActionsOptions {
+  setIsBusy: (v: boolean) => void;
+  showNotice: (type: 'success' | 'error', text: string) => void;
+}
+
+export function useActions({ setIsBusy, showNotice }: UseActionsOptions) {
+  const [actions, setActions] = useState<EmailAction[]>([]);
+  const [actionsCursor, setActionsCursor] = useState<string | undefined>();
+  const [actionApplicationId, setActionApplicationId] = useState('');
+  const [actionStatus, setActionStatus] = useState<EmailActionStatus | ''>('');
+  const [actionExecutions, setActionExecutions] = useState<EmailActionExecution[]>([]);
+  const [selectedActionId, setSelectedActionId] = useState('');
+
+  const loadActions = async (append = false, cursor?: string) => {
+    try {
+      const data = await actionSvc.loadActions(actionApplicationId, actionStatus, cursor);
+      setActions((c) => (append ? [...c, ...data.actions] : data.actions));
+      setActionsCursor(data.nextCursor);
+      setSelectedActionId((c) => c || data.actions[0]?.actionId || '');
+    } catch (e) {
+      showNotice('error', e instanceof Error ? e.message : 'Unable To Load Actions.');
+    }
+  };
+
+  const loadActionExecutions = async (actionId: string) => {
+    setSelectedActionId(actionId);
+    try {
+      const data = await actionSvc.loadActionExecutions(actionId);
+      setActionExecutions(data.executions);
+    } catch (e) {
+      showNotice('error', e instanceof Error ? e.message : 'Unable To Load Action Audit.');
+    }
+  };
+
+  const executeAction = async (actionId: string) => {
+    setIsBusy(true);
+    try {
+      const data = await actionSvc.executeAction(actionId);
+      setActions((c) => c.map((a) => (a.actionId === data.action.actionId ? data.action : a)));
+      await loadActionExecutions(actionId);
+      showNotice(
+        data.action.status === 'succeeded' ? 'success' : 'error',
+        data.action.result?.summary || data.action.errorMessage || data.action.status,
+      );
+    } catch (e) {
+      showNotice('error', e instanceof Error ? e.message : 'Unable To Execute Action.');
+    } finally {
+      setIsBusy(false);
+    }
+  };
+
+  return {
+    actions,
+    actionsCursor,
+    actionApplicationId,
+    setActionApplicationId,
+    actionStatus,
+    setActionStatus,
+    actionExecutions,
+    selectedActionId,
+    setSelectedActionId,
+    loadActions,
+    loadActionExecutions,
+    executeAction,
+  };
+}

--- a/apps/web/src/hooks/useAuditLogs.ts
+++ b/apps/web/src/hooks/useAuditLogs.ts
@@ -1,0 +1,76 @@
+import { useCallback, useState } from 'react';
+import type { ContextAuditLog } from '../../components/types';
+import { fetchDocumentAuditLogs } from '../services/userService';
+
+interface UseAuditLogsOptions {
+  showNotice: (type: 'success' | 'error', text: string) => void;
+}
+
+export function useAuditLogs({ showNotice }: UseAuditLogsOptions) {
+  const [auditLogDocumentId, setAuditLogDocumentId] = useState<string | null>(null);
+  const [auditLogs, setAuditLogs] = useState<ContextAuditLog[]>([]);
+  const [auditLogsCursor, setAuditLogsCursor] = useState<string | undefined>();
+  const [loadingAuditLogs, setLoadingAuditLogs] = useState(false);
+
+  const openAuditLogs = async (contextDocumentId: string) => {
+    setAuditLogDocumentId(contextDocumentId);
+    setAuditLogs([]);
+    setAuditLogsCursor(undefined);
+    setLoadingAuditLogs(true);
+    try {
+      const data = await fetchDocumentAuditLogs(contextDocumentId);
+      setAuditLogs(data.logs);
+      setAuditLogsCursor(data.nextCursor ?? undefined);
+    } catch (e) {
+      showNotice('error', e instanceof Error ? e.message : 'Unable To Load Audit Logs.');
+      setAuditLogDocumentId(null);
+    } finally {
+      setLoadingAuditLogs(false);
+    }
+  };
+
+  const closeAuditLogs = () => {
+    setAuditLogDocumentId(null);
+    setAuditLogs([]);
+    setAuditLogsCursor(undefined);
+  };
+
+  const loadMoreAuditLogs = async () => {
+    if (!auditLogDocumentId || !auditLogsCursor || loadingAuditLogs) return;
+    setLoadingAuditLogs(true);
+    try {
+      const data = await fetchDocumentAuditLogs(auditLogDocumentId, auditLogsCursor);
+      setAuditLogs((p) => [...p, ...data.logs]);
+      setAuditLogsCursor(data.nextCursor ?? undefined);
+    } catch (e) {
+      showNotice('error', e instanceof Error ? e.message : 'Unable To Load More Audit Logs.');
+    } finally {
+      setLoadingAuditLogs(false);
+    }
+  };
+
+  const refreshAuditLogs = useCallback(async () => {
+    if (!auditLogDocumentId) return;
+    setLoadingAuditLogs(true);
+    try {
+      const data = await fetchDocumentAuditLogs(auditLogDocumentId);
+      setAuditLogs(data.logs);
+      setAuditLogsCursor(data.nextCursor ?? undefined);
+    } catch (e) {
+      showNotice('error', e instanceof Error ? e.message : 'Unable To Refresh Audit Logs.');
+    } finally {
+      setLoadingAuditLogs(false);
+    }
+  }, [auditLogDocumentId, showNotice]);
+
+  return {
+    auditLogDocumentId,
+    auditLogs,
+    auditLogsCursor,
+    loadingAuditLogs,
+    openAuditLogs,
+    closeAuditLogs,
+    loadMoreAuditLogs,
+    refreshAuditLogs,
+  };
+}

--- a/apps/web/src/hooks/useContextAudit.ts
+++ b/apps/web/src/hooks/useContextAudit.ts
@@ -1,0 +1,74 @@
+import { useState } from 'react';
+import type { ApplicationContextDocument, ApplicationContextDeletionRun, ApplicationContextDocumentStatus } from '../../components/types';
+import * as contextSvc from '../services/contextService';
+
+interface UseContextAuditOptions {
+  showNotice: (type: 'success' | 'error', text: string) => void;
+}
+
+export function useContextAudit({ showNotice }: UseContextAuditOptions) {
+  const [auditApplicationId, setAuditApplicationId] = useState('');
+  const [auditStatus, setAuditStatus] = useState<ApplicationContextDocumentStatus | ''>('');
+  const [contextDocuments, setContextDocuments] = useState<ApplicationContextDocument[]>([]);
+  const [contextDocumentsCursor, setContextDocumentsCursor] = useState<string | undefined>();
+  const [contextDeletionRuns, setContextDeletionRuns] = useState<ApplicationContextDeletionRun[]>([]);
+  const [contextDeletionRunsCursor, setContextDeletionRunsCursor] = useState<string | undefined>();
+
+  const loadContextAudit = async () => {
+    try {
+      const data = await contextSvc.loadContextAudit(auditApplicationId, auditStatus);
+      setContextDocuments(data.documents);
+      setContextDocumentsCursor(data.documentsCursor);
+      setContextDeletionRuns(data.deletionRuns);
+      setContextDeletionRunsCursor(data.deletionRunsCursor);
+    } catch (e) {
+      showNotice('error', e instanceof Error ? e.message : 'Unable To Load Context.');
+    }
+  };
+
+  const loadMoreContextDocuments = async () => {
+    if (!contextDocumentsCursor) return;
+    try {
+      const data = await contextSvc.loadMoreDocuments(auditApplicationId, auditStatus, contextDocumentsCursor);
+      setContextDocuments((c) => [...c, ...data.documents]);
+      setContextDocumentsCursor(data.nextCursor);
+    } catch (e) {
+      showNotice('error', e instanceof Error ? e.message : 'Unable To Load More Documents.');
+    }
+  };
+
+  const loadMoreContextDeletions = async () => {
+    if (!contextDeletionRunsCursor) return;
+    try {
+      const data = await contextSvc.loadMoreDeletions(auditApplicationId, contextDeletionRunsCursor);
+      setContextDeletionRuns((c) => [...c, ...data.deletionRuns]);
+      setContextDeletionRunsCursor(data.nextCursor);
+    } catch (e) {
+      showNotice('error', e instanceof Error ? e.message : 'Unable To Load More Deletions.');
+    }
+  };
+
+  const openContextDocumentInProvider = async (contextDocumentId: string) => {
+    try {
+      const data = await contextSvc.openContextDocumentInProvider(contextDocumentId);
+      window.open(data.url, '_blank', 'noopener,noreferrer');
+    } catch (e) {
+      showNotice('error', e instanceof Error ? e.message : 'Unable To Open Provider Document.');
+    }
+  };
+
+  return {
+    auditApplicationId,
+    setAuditApplicationId,
+    auditStatus,
+    setAuditStatus,
+    contextDocuments,
+    contextDeletionRuns,
+    contextDocumentsCursor,
+    contextDeletionRunsCursor,
+    loadContextAudit,
+    loadMoreContextDocuments,
+    loadMoreContextDeletions,
+    openContextDocumentInProvider,
+  };
+}

--- a/apps/web/src/hooks/useCurrentUser.ts
+++ b/apps/web/src/hooks/useCurrentUser.ts
@@ -1,0 +1,19 @@
+import { useEffect, useState } from 'react';
+import type { CurrentUser } from '../../components/types';
+import { loadCurrentUser } from '../services/userService';
+
+export function useCurrentUser() {
+  const [user, setUser] = useState<CurrentUser | null>(null);
+  const [authorized, setAuthorized] = useState<boolean | null>(null);
+
+  useEffect(() => {
+    loadCurrentUser()
+      .then((me) => {
+        setUser(me);
+        setAuthorized(true);
+      })
+      .catch(() => setAuthorized(false));
+  }, []);
+
+  return { user, authorized };
+}

--- a/apps/web/src/hooks/useMailboxes.ts
+++ b/apps/web/src/hooks/useMailboxes.ts
@@ -1,0 +1,254 @@
+import { useMemo, useState } from 'react';
+import type { ConnectedApplication, SenderDomainFilters } from '../../components/types';
+import type { ApplicationFormState } from '../components/mailboxes/MailboxForm';
+import { emptyForm } from '../components/mailboxes/MailboxForm';
+import * as appSvc from '../services/applicationService';
+
+interface UseMailboxesOptions {
+  setIsBusy: (v: boolean) => void;
+  showNotice: (type: 'success' | 'error', text: string) => void;
+  onContextChanged?: () => void;
+}
+
+export function useMailboxes({ setIsBusy, showNotice, onContextChanged }: UseMailboxesOptions) {
+  const [applications, setApplications] = useState<ConnectedApplication[]>([]);
+  const [selectedApplicationId, setSelectedApplicationId] = useState('');
+  const [applicationForm, setApplicationForm] = useState<ApplicationFormState>(emptyForm);
+  const [isFormExpanded, setIsFormExpanded] = useState(false);
+  const [watchWebhookUrl, setWatchWebhookUrl] = useState('');
+  const [availableFolders, setAvailableFolders] = useState<Array<{ id: string; name: string }> | null>(null);
+  const [loadingFolders, setLoadingFolders] = useState(false);
+  const [confirmDelete, setConfirmDelete] = useState<{ applicationId: string; displayName: string } | null>(null);
+
+  const selectedApplication = useMemo(
+    () => applications.find((a) => a.applicationId === selectedApplicationId),
+    [applications, selectedApplicationId],
+  );
+
+  const selectApplication = (id: string) => {
+    setSelectedApplicationId(id);
+    setAvailableFolders(null);
+    setLoadingFolders(false);
+  };
+
+  const loadApplications = async () => {
+    const data = await appSvc.loadApplications();
+    setApplications(data.applications);
+    setSelectedApplicationId((c) => c || data.applications[0]?.applicationId || '');
+  };
+
+  const resetForm = () => {
+    setApplicationForm(emptyForm);
+    setIsFormExpanded(false);
+  };
+
+  const editApplication = (app: ConnectedApplication) => {
+    setApplicationForm({
+      applicationId: app.applicationId,
+      displayName: app.displayName,
+      providerId: app.providerId,
+      clientId: '',
+      clientSecret: '',
+      gmailPubsubTopicName: app.gmailPubsubTopicName || '',
+      enabledFeatures: app.enabledFeatures || [],
+    });
+    setIsFormExpanded(true);
+  };
+
+  const saveApplication = async () => {
+    setIsBusy(true);
+    try {
+      const data = await appSvc.saveApplication(applicationForm);
+      showNotice('success', applicationForm.applicationId ? 'Mailbox Updated.' : 'Mailbox Created.');
+      resetForm();
+      await loadApplications();
+      setSelectedApplicationId(data.application.applicationId);
+    } catch (e) {
+      showNotice('error', e instanceof Error ? e.message : 'Unable To Save Mailbox.');
+    } finally {
+      setIsBusy(false);
+    }
+  };
+
+  const deleteApplication = async (applicationId: string) => {
+    setIsBusy(true);
+    try {
+      await appSvc.deleteApplication(applicationId);
+      showNotice('success', 'Mailbox Deleted.');
+      setSelectedApplicationId('');
+      setWatchWebhookUrl('');
+      await loadApplications();
+    } catch (e) {
+      showNotice('error', e instanceof Error ? e.message : 'Unable To Delete Mailbox.');
+    } finally {
+      setIsBusy(false);
+    }
+  };
+
+  const startOAuth2 = async (applicationId: string) => {
+    setIsBusy(true);
+    try {
+      const data = await appSvc.startOAuth2(applicationId);
+      window.location.assign(data.authorizationUrl);
+    } catch (e) {
+      showNotice('error', e instanceof Error ? e.message : 'Unable To Start OAuth2.');
+      setIsBusy(false);
+    }
+  };
+
+  const startWatch = async (applicationId: string) => {
+    setIsBusy(true);
+    try {
+      const data = await appSvc.startWatch(applicationId);
+      setWatchWebhookUrl(data.webhookUrl);
+      await loadApplications();
+      showNotice('success', data.message);
+    } catch (e) {
+      showNotice('error', e instanceof Error ? e.message : 'Unable To Start Watch.');
+    } finally {
+      setIsBusy(false);
+    }
+  };
+
+  const stopWatch = async (applicationId: string) => {
+    setIsBusy(true);
+    try {
+      const data = await appSvc.stopWatch(applicationId);
+      setWatchWebhookUrl('');
+      await loadApplications();
+      showNotice('success', data.message);
+    } catch (e) {
+      showNotice('error', e instanceof Error ? e.message : 'Unable To Stop Watch.');
+    } finally {
+      setIsBusy(false);
+    }
+  };
+
+  const updateContextIndexing = async (applicationId: string, enabled: boolean) => {
+    setIsBusy(true);
+    try {
+      const data = await appSvc.updateContextIndexing(applicationId, enabled);
+      setApplications((c) => c.map((a) => (a.applicationId === data.application.applicationId ? data.application : a)));
+      showNotice('success', enabled ? 'Context Indexing Enabled.' : 'Context Indexing Disabled.');
+      onContextChanged?.();
+    } catch (e) {
+      showNotice('error', e instanceof Error ? e.message : 'Unable To Update Context Setting.');
+    } finally {
+      setIsBusy(false);
+    }
+  };
+
+  const updateMaxContextDocuments = async (applicationId: string, maxContextDocuments: number | null) => {
+    setIsBusy(true);
+    try {
+      const data = await appSvc.updateMaxContextDocuments(applicationId, maxContextDocuments);
+      setApplications((c) => c.map((a) => (a.applicationId === data.application.applicationId ? data.application : a)));
+      showNotice('success', maxContextDocuments != null ? `Document Limit Set To ${maxContextDocuments}.` : 'Document Limit Reset.');
+    } catch (e) {
+      showNotice('error', e instanceof Error ? e.message : 'Unable To Update Document Limit.');
+    } finally {
+      setIsBusy(false);
+    }
+  };
+
+  const loadFolders = async (applicationId: string) => {
+    setLoadingFolders(true);
+    try {
+      const data = await appSvc.loadFolders(applicationId);
+      setAvailableFolders(data.folders);
+    } catch (e) {
+      showNotice('error', e instanceof Error ? e.message : 'Unable To Load Folders.');
+    } finally {
+      setLoadingFolders(false);
+    }
+  };
+
+  const updateWatchedFolderIds = async (applicationId: string, folderIds: string[] | null) => {
+    setIsBusy(true);
+    try {
+      const data = await appSvc.updateWatchedFolderIds(applicationId, folderIds, availableFolders);
+      setApplications((c) => c.map((a) => (a.applicationId === data.application.applicationId ? data.application : a)));
+    } catch (e) {
+      showNotice('error', e instanceof Error ? e.message : 'Unable To Update Watch Folders.');
+    } finally {
+      setIsBusy(false);
+    }
+  };
+
+  const updateSenderFilters = async (applicationId: string, filters: SenderDomainFilters) => {
+    const app = applications.find((a) => a.applicationId === applicationId);
+    if (!app) return;
+    setIsBusy(true);
+    try {
+      const data = await appSvc.updateSenderFilters(app, filters);
+      setApplications((c) => c.map((a) => (a.applicationId === data.application.applicationId ? data.application : a)));
+      showNotice('success', 'Sender Filter Rules Updated.');
+    } catch (e) {
+      showNotice('error', e instanceof Error ? e.message : 'Unable To Update Sender Filters.');
+    } finally {
+      setIsBusy(false);
+    }
+  };
+
+  const deleteContextDocuments = async (applicationId: string) => {
+    const app = applications.find((a) => a.applicationId === applicationId);
+    if (!window.confirm(`Delete All Indexed Documents For ${app?.displayName || 'This Mailbox'}?`)) return;
+    setIsBusy(true);
+    try {
+      const data = await appSvc.deleteContextDocuments(applicationId);
+      await loadApplications();
+      onContextChanged?.();
+      showNotice(
+        data.deletionRun.status === 'accepted' ? 'success' : 'error',
+        data.deletionRun.status === 'accepted' ? 'Context Documents Deletion Accepted.' : data.deletionRun.errorMessage || 'Context Deletion Failed.',
+      );
+    } catch (e) {
+      showNotice('error', e instanceof Error ? e.message : 'Unable To Delete Context Documents.');
+    } finally {
+      setIsBusy(false);
+    }
+  };
+
+  const dismissError = async (applicationId: string, errorType: 'processing' | 'context') => {
+    setIsBusy(true);
+    try {
+      const data = await appSvc.dismissError(applicationId, errorType);
+      setApplications((c) => c.map((a) => (a.applicationId === data.application.applicationId ? data.application : a)));
+    } catch (e) {
+      showNotice('error', e instanceof Error ? e.message : 'Unable To Dismiss Error.');
+    } finally {
+      setIsBusy(false);
+    }
+  };
+
+  return {
+    applications,
+    selectedApplicationId,
+    selectedApplication,
+    setSelectedApplicationId: selectApplication,
+    applicationForm,
+    setApplicationForm,
+    isFormExpanded,
+    setIsFormExpanded,
+    watchWebhookUrl,
+    availableFolders,
+    loadingFolders,
+    confirmDelete,
+    setConfirmDelete,
+    loadApplications,
+    resetForm,
+    editApplication,
+    saveApplication,
+    deleteApplication,
+    startOAuth2,
+    startWatch,
+    stopWatch,
+    updateContextIndexing,
+    updateMaxContextDocuments,
+    loadFolders,
+    updateWatchedFolderIds,
+    updateSenderFilters,
+    deleteContextDocuments,
+    dismissError,
+  };
+}

--- a/apps/web/src/hooks/useNotice.ts
+++ b/apps/web/src/hooks/useNotice.ts
@@ -1,0 +1,25 @@
+import { useCallback, useRef, useState } from 'react';
+import { NOTICE_TIMEOUT_MS } from '../lib/constants';
+
+function getInitialNotice(): { type: 'success' | 'error'; text: string } | null {
+  const params = new URLSearchParams(window.location.search);
+  if (params.get('oauth2') === 'connected') return { type: 'success', text: 'OAuth2 Connection Completed.' };
+  if (params.get('oauth2') === 'error') return { type: 'error', text: params.get('message') || 'OAuth2 Connection Failed.' };
+  return null;
+}
+
+export function useNotice() {
+  const [notice, setNotice] = useState<{ type: 'success' | 'error'; text: string } | null>(() => getInitialNotice());
+  const timerRef = useRef<ReturnType<typeof window.setTimeout> | null>(null);
+
+  const showNotice = useCallback((type: 'success' | 'error', text: string) => {
+    if (timerRef.current !== null) window.clearTimeout(timerRef.current);
+    setNotice({ type, text });
+    timerRef.current = window.setTimeout(() => {
+      setNotice(null);
+      timerRef.current = null;
+    }, NOTICE_TIMEOUT_MS);
+  }, []);
+
+  return { notice, showNotice };
+}

--- a/apps/web/src/hooks/useSyncedUrl.ts
+++ b/apps/web/src/hooks/useSyncedUrl.ts
@@ -1,0 +1,32 @@
+import { useEffect } from 'react';
+
+/**
+ * Reads a URL search param synchronously from window.location.search.
+ * Call this inside useState lazy initializers so it runs before the first render.
+ */
+export function getUrlParam(key: string, defaultValue: string): string {
+  const params = new URLSearchParams(window.location.search);
+  return params.get(key) || defaultValue;
+}
+
+/**
+ * Syncs a record of key/value pairs into the URL search string via
+ * history.replaceState on every render. Empty values are omitted.
+ *
+ * Uses replaceState (not pushState) intentionally — filter changes and view
+ * switches do not create browser history entries.
+ */
+export function useSyncedUrl(params: Record<string, string>): void {
+  useEffect(() => {
+    const sp = new URLSearchParams();
+    for (const [k, v] of Object.entries(params)) {
+      if (v) sp.set(k, v);
+    }
+    const query = sp.toString();
+    const next = query ? `?${query}` : window.location.pathname;
+    const current = window.location.search || '';
+    if (current !== (query ? `?${query}` : '')) {
+      history.replaceState(null, '', next);
+    }
+  });
+}

--- a/apps/web/src/lib/constants.ts
+++ b/apps/web/src/lib/constants.ts
@@ -1,0 +1,3 @@
+export const NOTICE_TIMEOUT_MS = 6000;
+export const COPY_FEEDBACK_TIMEOUT_MS = 1500;
+export const FORM_HIGHLIGHT_TIMEOUT_MS = 1500;

--- a/apps/web/src/services/actionService.ts
+++ b/apps/web/src/services/actionService.ts
@@ -1,0 +1,26 @@
+import type { EmailAction, EmailActionExecution, EmailActionStatus } from '../../components/types';
+import { apiFetch, readJson } from '../../components/utils';
+
+export async function loadActions(
+  applicationId: string,
+  status: EmailActionStatus | '',
+  cursor?: string,
+): Promise<{ actions: EmailAction[]; nextCursor?: string }> {
+  const p = new URLSearchParams();
+  if (applicationId) p.set('applicationId', applicationId);
+  if (status) p.set('status', status);
+  if (cursor) p.set('cursor', cursor);
+  return readJson<{ actions: EmailAction[]; nextCursor?: string }>(await apiFetch(`/user/actions?${p}`));
+}
+
+export async function loadActionExecutions(actionId: string): Promise<{ executions: EmailActionExecution[] }> {
+  return readJson<{ executions: EmailActionExecution[] }>(
+    await apiFetch(`/user/actions/${encodeURIComponent(actionId)}/executions`),
+  );
+}
+
+export async function executeAction(actionId: string): Promise<{ action: EmailAction }> {
+  return readJson<{ action: EmailAction }>(
+    await apiFetch(`/user/actions/${encodeURIComponent(actionId)}/execute`, { method: 'POST' }),
+  );
+}

--- a/apps/web/src/services/applicationService.ts
+++ b/apps/web/src/services/applicationService.ts
@@ -1,0 +1,164 @@
+import type { ConnectedApplication, SenderDomainFilters } from '../../components/types';
+import { apiFetch, readJson, providerMethod } from '../../components/utils';
+import type { ApplicationFormState } from '../components/mailboxes/MailboxForm';
+
+export async function loadApplications(): Promise<{ applications: ConnectedApplication[] }> {
+  return readJson<{ applications: ConnectedApplication[] }>(await apiFetch('/user/applications'));
+}
+
+export async function saveApplication(form: ApplicationFormState): Promise<{ application: ConnectedApplication }> {
+  const payload = {
+    applicationId: form.applicationId,
+    displayName: form.displayName,
+    providerId: form.providerId,
+    connectionMethod: providerMethod[form.providerId],
+    ...(form.clientId ? { clientId: form.clientId } : {}),
+    ...(form.clientSecret ? { clientSecret: form.clientSecret } : {}),
+    enabledFeatures: form.enabledFeatures,
+    ...(form.providerId === 'google-gmail' ? { gmailPubsubTopicName: form.gmailPubsubTopicName } : {}),
+  };
+  return readJson<{ application: ConnectedApplication }>(
+    await apiFetch('/user/application', {
+      method: form.applicationId ? 'PUT' : 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(payload),
+    }),
+  );
+}
+
+export async function deleteApplication(applicationId: string): Promise<void> {
+  await readJson<{ success: boolean }>(
+    await apiFetch('/user/application', {
+      method: 'DELETE',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ applicationId }),
+    }),
+  );
+}
+
+export async function startOAuth2(applicationId: string): Promise<{ authorizationUrl: string }> {
+  return readJson<{ authorizationUrl: string }>(
+    await apiFetch('/user/application/oauth2/authorize', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ applicationId }),
+    }),
+  );
+}
+
+export async function startWatch(applicationId: string): Promise<{ message: string; webhookUrl: string }> {
+  return readJson<{ message: string; webhookUrl: string }>(
+    await apiFetch('/user/application/watch', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ applicationId }),
+    }),
+  );
+}
+
+export async function stopWatch(applicationId: string): Promise<{ message: string }> {
+  return readJson<{ message: string }>(
+    await apiFetch('/user/application/stop', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ applicationId }),
+    }),
+  );
+}
+
+export async function updateContextIndexing(
+  applicationId: string,
+  contextIndexingEnabled: boolean,
+): Promise<{ application: ConnectedApplication }> {
+  return readJson<{ application: ConnectedApplication }>(
+    await apiFetch('/user/application/context', {
+      method: 'PUT',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ applicationId, contextIndexingEnabled }),
+    }),
+  );
+}
+
+export async function updateMaxContextDocuments(
+  applicationId: string,
+  maxContextDocuments: number | null,
+): Promise<{ application: ConnectedApplication }> {
+  return readJson<{ application: ConnectedApplication }>(
+    await apiFetch('/user/application/context', {
+      method: 'PUT',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ applicationId, maxContextDocuments }),
+    }),
+  );
+}
+
+export async function loadFolders(applicationId: string): Promise<{ folders: Array<{ id: string; name: string }> }> {
+  return readJson<{ folders: Array<{ id: string; name: string }> }>(
+    await apiFetch(`/user/application/folders?applicationId=${encodeURIComponent(applicationId)}`),
+  );
+}
+
+export async function updateWatchedFolderIds(
+  applicationId: string,
+  folderIds: string[] | null,
+  availableFolders: Array<{ id: string; name: string }> | null,
+): Promise<{ application: ConnectedApplication }> {
+  const folderNames: Record<string, string> = {};
+  if (folderIds && availableFolders) {
+    for (const id of folderIds) {
+      const folder = availableFolders.find((f) => f.id === id);
+      if (folder) folderNames[id] = folder.name;
+    }
+  }
+  return readJson<{ application: ConnectedApplication }>(
+    await apiFetch('/user/application/watch-settings', {
+      method: 'PUT',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ applicationId, folderIds, folderNames }),
+    }),
+  );
+}
+
+export async function updateSenderFilters(
+  app: ConnectedApplication,
+  filters: SenderDomainFilters,
+): Promise<{ application: ConnectedApplication }> {
+  return readJson<{ application: ConnectedApplication }>(
+    await apiFetch('/user/application', {
+      method: 'PUT',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        applicationId: app.applicationId,
+        displayName: app.displayName,
+        providerId: app.providerId,
+        connectionMethod: providerMethod[app.providerId],
+        enabledFeatures: app.enabledFeatures,
+        ...(app.providerId === 'google-gmail' ? { gmailPubsubTopicName: app.gmailPubsubTopicName } : {}),
+        senderDomainFilters: filters,
+      }),
+    }),
+  );
+}
+
+export async function deleteContextDocuments(applicationId: string): Promise<{ deletionRun: import('../../components/types').ApplicationContextDeletionRun }> {
+  return readJson<{ deletionRun: import('../../components/types').ApplicationContextDeletionRun }>(
+    await apiFetch('/user/application/context/delete-documents', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ applicationId }),
+    }),
+  );
+}
+
+export async function dismissError(
+  applicationId: string,
+  errorType: 'processing' | 'context',
+): Promise<{ application: ConnectedApplication }> {
+  return readJson<{ application: ConnectedApplication }>(
+    await apiFetch('/user/application/dismiss-error', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ applicationId, errorType }),
+    }),
+  );
+}

--- a/apps/web/src/services/contextService.ts
+++ b/apps/web/src/services/contextService.ts
@@ -1,0 +1,59 @@
+import type { ApplicationContextDocument, ApplicationContextDeletionRun, ApplicationContextDocumentStatus } from '../../components/types';
+import { apiFetch, readJson } from '../../components/utils';
+
+export async function loadContextAudit(
+  applicationId: string,
+  status: ApplicationContextDocumentStatus | '',
+): Promise<{
+  documents: ApplicationContextDocument[];
+  documentsCursor?: string;
+  deletionRuns: ApplicationContextDeletionRun[];
+  deletionRunsCursor?: string;
+}> {
+  const dp = new URLSearchParams();
+  const xp = new URLSearchParams();
+  if (applicationId) { dp.set('applicationId', applicationId); xp.set('applicationId', applicationId); }
+  if (status) dp.set('status', status);
+  const [docData, delData] = await Promise.all([
+    readJson<{ documents: ApplicationContextDocument[]; nextCursor?: string }>(await apiFetch(`/user/application/context/documents?${dp}`)),
+    readJson<{ deletionRuns: ApplicationContextDeletionRun[]; nextCursor?: string }>(await apiFetch(`/user/application/context/deletions?${xp}`)),
+  ]);
+  return {
+    documents: docData.documents,
+    documentsCursor: docData.nextCursor,
+    deletionRuns: delData.deletionRuns,
+    deletionRunsCursor: delData.nextCursor,
+  };
+}
+
+export async function loadMoreDocuments(
+  applicationId: string,
+  status: ApplicationContextDocumentStatus | '',
+  cursor: string,
+): Promise<{ documents: ApplicationContextDocument[]; nextCursor?: string }> {
+  const p = new URLSearchParams();
+  if (applicationId) p.set('applicationId', applicationId);
+  if (status) p.set('status', status);
+  p.set('cursor', cursor);
+  return readJson<{ documents: ApplicationContextDocument[]; nextCursor?: string }>(
+    await apiFetch(`/user/application/context/documents?${p}`),
+  );
+}
+
+export async function loadMoreDeletions(
+  applicationId: string,
+  cursor: string,
+): Promise<{ deletionRuns: ApplicationContextDeletionRun[]; nextCursor?: string }> {
+  const p = new URLSearchParams();
+  if (applicationId) p.set('applicationId', applicationId);
+  p.set('cursor', cursor);
+  return readJson<{ deletionRuns: ApplicationContextDeletionRun[]; nextCursor?: string }>(
+    await apiFetch(`/user/application/context/deletions?${p}`),
+  );
+}
+
+export async function openContextDocumentInProvider(contextDocumentId: string): Promise<{ url: string }> {
+  return readJson<{ url: string }>(
+    await apiFetch(`/user/application/context/document/${encodeURIComponent(contextDocumentId)}/provider-link`),
+  );
+}

--- a/apps/web/src/services/userService.ts
+++ b/apps/web/src/services/userService.ts
@@ -1,0 +1,8 @@
+import type { CurrentUser } from '../../components/types';
+import { apiFetch, readJson, fetchDocumentAuditLogs } from '../../components/utils';
+
+export async function loadCurrentUser(): Promise<CurrentUser> {
+  return readJson<CurrentUser>(await apiFetch('/user/me'));
+}
+
+export { fetchDocumentAuditLogs };


### PR DESCRIPTION
SpaApp.tsx shrank from ~655 lines to ~155 lines by extracting all state and API logic into single-responsibility layers:

- **Service layer** (`src/services/`): Pure async functions wrapping apiFetch/readJson with no React state — applicationService, contextService, actionService, userService
- **Custom hooks** (`src/hooks/`): Six domain hooks — useNotice, useCurrentUser, useMailboxes, useContextAudit, useActions, useAuditLogs
- **React Context** (`src/contexts/`): NoticeContext, UserContext, and MailboxCallbacksContext eliminate deep prop drilling; MailboxesView props shrink from 28 to 12, MailboxDetail from 18 to 4
- **URL state** (`src/hooks/useSyncedUrl.ts`): getUrlParam() + useSyncedUrl() persist view, appId, status, and actionId into the URL via history.replaceState so users can bookmark or share their position and return to it on reload
- **UI abstractions**: ModalShell unifies portal/backdrop boilerplate across both modals; FilterBar unifies the filter toolbar card in context and actions views
- **Constants** (`src/lib/constants.ts`): NOTICE_TIMEOUT_MS, COPY_FEEDBACK_TIMEOUT_MS, FORM_HIGHLIGHT_TIMEOUT_MS replace magic literals