### PR TITLE
Prevent Api Routes Being Intercepted By Spa Handler

### DIFF
--- a/apps/api/wrangler.template.jsonc
+++ b/apps/api/wrangler.template.jsonc
@@ -29,6 +29,7 @@
   "assets": {
     "directory": "./apps/web/dist/",
     "not_found_handling": "single-page-application",
+    "run_worker_first": ["/api/*"],
   },
   "durable_objects": {
     "bindings": [


### PR DESCRIPTION
`not_found_handling: single-page-application` (added in 8a74809) causes Cloudflare Workers Assets to serve `index.html` for any unmatched path — including `/api/*` routes — before the Worker's fetch handler runs. This made action callback links (e.g. `/api/actions/:actionId?token=...`) render the homepage instead of the action confirmation page.

Adding `run_worker_first: ["/api/*"]` tells Assets to invoke the Worker first for all `/api/*` requests, so Hono's router handles them correctly. All other paths (like `/user/*`) continue to be served by Assets with the SPA not-found handler intact.