### PR TITLE
Use Double Glob For Api Routes In run_worker_first

### DIFF
--- a/apps/api/wrangler.template.jsonc
+++ b/apps/api/wrangler.template.jsonc
@@ -29,7 +29,7 @@
   "assets": {
     "directory": "./apps/web/dist/",
     "not_found_handling": "single-page-application",
-    "run_worker_first": ["/api/*"],
+    "run_worker_first": ["/api/**"],
   },
   "durable_objects": {
     "bindings": [


### PR DESCRIPTION
`run_worker_first: ["/api/*"]` uses a single-segment glob that does not cross `/` boundaries, so nested paths like `/api/actions/:actionId` were still intercepted by Cloudflare Assets and served as index.html.

Replace with `"/api/**"` so the double-glob matches across all path segments, routing every `/api/` request to the Worker first.