### PR TITLE
Add Audit Log Modal Deeplink Via logDocId URL Param

### DIFF
--- a/apps/web/src/SpaApp.tsx
+++ b/apps/web/src/SpaApp.tsx
@@ -25,6 +25,7 @@ const initialView = getUrlParam('view', 'mailboxes') as ActiveView;
 const initialAppId = getUrlParam('appId', '');
 const initialStatus = getUrlParam('status', '');
 const initialActionId = getUrlParam('actionId', '');
+const initialLogDocId = getUrlParam('logDocId', '');
 
 export default function SpaApp() {
   const [activeView, setActiveView] = useState<ActiveView>(initialView);
@@ -51,6 +52,7 @@ export default function SpaApp() {
     if (initialView === 'actions' && initialStatus) actions.setActionStatus(initialStatus as EmailActionStatus);
     if (initialView === 'actions' && initialActionId) actions.setSelectedActionId(initialActionId);
     if (initialView === 'mailboxes' && initialAppId) mailboxes.setSelectedApplicationId(initialAppId);
+    if (initialView === 'context' && initialLogDocId) auditLogs.openAuditLogs(initialLogDocId);
   }, []);
 
   // Load applications once the user is authorized
@@ -86,6 +88,7 @@ export default function SpaApp() {
     appId: effectiveAppId,
     status: activeView === 'context' ? contextAudit.auditStatus : activeView === 'actions' ? actions.actionStatus : '',
     actionId: activeView === 'actions' ? actions.selectedActionId : '',
+    logDocId: activeView === 'context' ? (auditLogs.auditLogDocumentId ?? '') : '',
   });
 
   if (authorized === null) {


### PR DESCRIPTION
Adds `logDocId` to the URL state so opening the document audit logs modal in the RAG Context view produces a shareable/bookmarkable URL.

- Read `initialLogDocId` at module level alongside other URL seeds
- Mount effect auto-opens the modal via `auditLogs.openAuditLogs()` when `view=context&logDocId=<id>` is present on load
- `useSyncedUrl` now writes `logDocId` while the modal is open and clears it automatically when the modal closes (`auditLogDocumentId` becomes null → empty string → omitted from URL)

No changes to `useAuditLogs`, `AuditLogsModal`, or `ContextAuditView`.