### PR TITLE
Add Per-Mailbox Time Zone For Calendar Events

### DIFF
--- a/apps/api/src/endpoints/user/application/POST.ts
+++ b/apps/api/src/endpoints/user/application/POST.ts
@@ -33,6 +33,7 @@ interface CreateApplicationRequest extends IRequest {
   clientSecret: string;
   gmailPubsubTopicName?: string | undefined;
   enabledFeatures?: string[] | undefined;
+  timeZone?: string | undefined;
 }
 
 interface CreateApplicationResponse extends IResponse {

--- a/apps/api/src/endpoints/user/application/PUT.ts
+++ b/apps/api/src/endpoints/user/application/PUT.ts
@@ -36,6 +36,7 @@ interface UpdateApplicationRequest extends IRequest {
   clientSecret?: string | undefined;
   gmailPubsubTopicName?: string | undefined;
   enabledFeatures?: string[] | undefined;
+  timeZone?: string | undefined;
   senderDomainFilters?: SenderDomainFilters | null | undefined;
 }
 

--- a/apps/web/components/types.ts
+++ b/apps/web/components/types.ts
@@ -27,6 +27,7 @@ export interface ConnectedApplication {
   connectionMethod: 'oauth2';
   status: 'draft' | 'connected' | 'error';
   enabledFeatures?: string[] | null;
+  timeZone?: string | null;
   senderDomainFilters?: SenderDomainFilters | null;
   gmailPubsubTopicName?: string | null;
   watchedFolders?: Array<{ id: string; name: string }> | null;

--- a/apps/web/src/components/actions/ActionPayloadDetails.tsx
+++ b/apps/web/src/components/actions/ActionPayloadDetails.tsx
@@ -11,7 +11,7 @@ export function ActionPayloadDetails({ action }: { action: EmailAction }) {
       <div className={cardClass}>
         <div className={titleClass}>Calendar Event</div>
         <div>{String(payload.eventTitle || action.title)}</div>
-        <div>{String(payload.startTime || '')} to {String(payload.endTime || '')}</div>
+        <div>{String(payload.startTime || '')} to {String(payload.endTime || '')}{payload.timeZone ? ` (${String(payload.timeZone)})` : ''}</div>
         {payload.location ? <div>{String(payload.location)}</div> : null}
       </div>
     );

--- a/apps/web/src/components/mailboxes/MailboxForm.tsx
+++ b/apps/web/src/components/mailboxes/MailboxForm.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useRef, useState } from 'react';
+import { useEffect, useMemo, useRef, useState } from 'react';
 import { ChevronDown } from 'lucide-react';
 import type { ProviderId } from '../../../components/types';
 import { OAUTH2_FEATURES, OAUTH2_FEATURE_SCOPES } from '../../../components/constants';
@@ -16,6 +16,11 @@ export interface ApplicationFormState {
   clientSecret: string;
   gmailPubsubTopicName: string;
   enabledFeatures: string[];
+  timeZone: string;
+}
+
+function getBrowserTimeZone(): string {
+  return Intl.DateTimeFormat().resolvedOptions().timeZone || 'UTC';
 }
 
 export const emptyForm: ApplicationFormState = {
@@ -25,6 +30,7 @@ export const emptyForm: ApplicationFormState = {
   clientSecret: '',
   gmailPubsubTopicName: '',
   enabledFeatures: [],
+  timeZone: getBrowserTimeZone(),
 };
 
 export function MailboxForm({
@@ -70,6 +76,12 @@ export function MailboxForm({
   const providerFeatures: [string, OAuth2Feature][] = (Object.entries(OAUTH2_FEATURES) as [string, OAuth2Feature][]).filter(
     ([featureId]) => (OAUTH2_FEATURE_SCOPES[featureId]?.[form.providerId] ?? []).length > 0,
   );
+
+  const timeZones: string[] = useMemo(() => {
+    const supportedValuesOf = (Intl as { supportedValuesOf?: (key: string) => string[] }).supportedValuesOf;
+    const supported: string[] = typeof supportedValuesOf === 'function' ? supportedValuesOf('timeZone') : ['UTC'];
+    return supported.includes(form.timeZone) ? supported : [form.timeZone, ...supported];
+  }, [form.timeZone]);
 
   return (
     <div
@@ -144,6 +156,16 @@ export function MailboxForm({
               ))}
             </div>
           )}
+          <div className="space-y-1.5 pt-1">
+            <p className="text-xs font-medium text-[var(--color-text-secondary)]">Time Zone</p>
+            <Select value={form.timeZone} onChange={(e) => update({ timeZone: e.target.value })} className="w-full">
+              {timeZones.map((tz) => (
+                <option key={tz} value={tz}>
+                  {tz}
+                </option>
+              ))}
+            </Select>
+          </div>
           <div className="flex gap-2 pt-1">
             <Button variant="primary" className="flex-1" onClick={onSave} loading={busy}>
               {form.applicationId ? 'Save Changes' : 'Create Mailbox'}

--- a/apps/web/src/hooks/useMailboxes.ts
+++ b/apps/web/src/hooks/useMailboxes.ts
@@ -51,6 +51,7 @@ export function useMailboxes({ setIsBusy, showNotice, onContextChanged }: UseMai
       clientSecret: '',
       gmailPubsubTopicName: app.gmailPubsubTopicName || '',
       enabledFeatures: app.enabledFeatures || [],
+      timeZone: app.timeZone || Intl.DateTimeFormat().resolvedOptions().timeZone,
     });
     setIsFormExpanded(true);
   };

--- a/apps/web/src/services/applicationService.ts
+++ b/apps/web/src/services/applicationService.ts
@@ -15,6 +15,7 @@ export async function saveApplication(form: ApplicationFormState): Promise<{ app
     ...(form.clientId ? { clientId: form.clientId } : {}),
     ...(form.clientSecret ? { clientSecret: form.clientSecret } : {}),
     enabledFeatures: form.enabledFeatures,
+    timeZone: form.timeZone,
     ...(form.providerId === 'google-gmail' ? { gmailPubsubTopicName: form.gmailPubsubTopicName } : {}),
   };
   return readJson<{ application: ConnectedApplication }>(

--- a/packages/backend-data/src/dao/ConnectedApplicationDAO.ts
+++ b/packages/backend-data/src/dao/ConnectedApplicationDAO.ts
@@ -16,7 +16,7 @@ import type {
   OAuth2Credentials,
   SenderDomainFilters,
 } from '@mail-otter/shared/model';
-import { TimestampUtil, UUIDUtil } from '@mail-otter/shared/utils';
+import { TimestampUtil, TimeZoneUtil, UUIDUtil } from '@mail-otter/shared/utils';
 
 class ConnectedApplicationDAO {
   protected readonly database: D1Queryable;
@@ -36,6 +36,7 @@ class ConnectedApplicationDAO {
     status: string,
     gmailPubsubTopicName?: string | null,
     enabledFeatures?: string[] | null,
+    timeZone?: string | null,
   ): Promise<ConnectedApplicationMetadata> {
     const now: number = TimestampUtil.getCurrentUnixTimestampInSeconds();
     const applicationId: string = UUIDUtil.getRandomUUID();
@@ -72,6 +73,9 @@ class ConnectedApplicationDAO {
     }
     if (enabledFeatures && enabledFeatures.length > 0) {
       await this.setProviderConfig(applicationId, 'oauth2_enabled_features', JSON.stringify(enabledFeatures), now);
+    }
+    if (timeZone) {
+      await this.setProviderConfig(applicationId, 'calendar_time_zone', TimeZoneUtil.normalize(timeZone), now);
     }
     const application: ConnectedApplicationMetadata | undefined = await this.getMetadataByIdForUser(applicationId, userEmail);
     if (!application) {
@@ -143,6 +147,7 @@ class ConnectedApplicationDAO {
     gmailPubsubTopicName?: string | null,
     enabledFeatures?: string[] | null,
     senderDomainFilters?: SenderDomainFilters | null,
+    timeZone?: string | null,
   ): Promise<ConnectedApplicationMetadata | undefined> {
     const now: number = TimestampUtil.getCurrentUnixTimestampInSeconds();
     const encrypted = await encryptData(JSON.stringify(credentials), this.masterKey);
@@ -174,6 +179,11 @@ class ConnectedApplicationDAO {
       await this.setProviderConfig(applicationId, 'sender_domain_filters', JSON.stringify(senderDomainFilters), now);
     } else if (senderDomainFilters !== undefined) {
       await this.deleteProviderConfig(applicationId, 'sender_domain_filters');
+    }
+    if (timeZone) {
+      await this.setProviderConfig(applicationId, 'calendar_time_zone', TimeZoneUtil.normalize(timeZone), now);
+    } else if (timeZone === null) {
+      await this.deleteProviderConfig(applicationId, 'calendar_time_zone');
     }
     return this.getMetadataByIdForUser(applicationId, userEmail);
   }
@@ -413,8 +423,9 @@ class ConnectedApplicationDAO {
         : row.status === CONNECTED_APPLICATION_STATUS_ERROR
           ? CONNECTED_APPLICATION_STATUS_ERROR
           : CONNECTED_APPLICATION_STATUS_DRAFT;
-    const [watchedFolders, gmailPubsubTopicName, enabledFeaturesJson, senderDomainFiltersJson]: [
+    const [watchedFolders, gmailPubsubTopicName, enabledFeaturesJson, senderDomainFiltersJson, timeZone]: [
       Array<{ folderPath: string; folderName: string }>,
+      string | null,
       string | null,
       string | null,
       string | null,
@@ -423,6 +434,7 @@ class ConnectedApplicationDAO {
       this.getProviderConfig(row.application_id, 'gmail_pubsub_topic_name'),
       this.getProviderConfig(row.application_id, 'oauth2_enabled_features'),
       this.getProviderConfig(row.application_id, 'sender_domain_filters'),
+      this.getProviderConfig(row.application_id, 'calendar_time_zone'),
     ]);
     return {
       applicationId: row.application_id,
@@ -435,6 +447,7 @@ class ConnectedApplicationDAO {
       contextIndexingEnabled: row.context_indexing_enabled !== 0,
       maxContextDocuments: row.max_context_documents ?? null,
       enabledFeatures: enabledFeaturesJson ? (JSON.parse(enabledFeaturesJson) as string[]) : null,
+      timeZone: timeZone ?? null,
       senderDomainFilters: senderDomainFiltersJson ? (JSON.parse(senderDomainFiltersJson) as SenderDomainFilters) : null,
       watchedFolders: watchedFolders.length > 0 ? watchedFolders.map((f) => ({ id: f.folderPath, name: f.folderName })) : null,
       lastErrorAcknowledgedAt: row.last_error_acknowledged_at ?? null,

--- a/packages/backend-services/src/action/ActionService.ts
+++ b/packages/backend-services/src/action/ActionService.ts
@@ -260,7 +260,7 @@ class ActionService {
       const eventTitle: string = ActionService.cleanText(ActionService.getString(parameters, 'eventTitle', 'title', 'summary') || title);
       const startTime: string = ActionService.getString(parameters, 'startTime', 'startDateTime', 'startsAt') || '';
       const endTime: string = ActionService.getString(parameters, 'endTime', 'endDateTime', 'endsAt') || '';
-      const timeZone: string = ActionService.getString(parameters, 'timeZone', 'timezone') || 'UTC';
+      const timeZone: string = ActionService.getString(parameters, 'timeZone', 'timezone') || input.application.timeZone || 'UTC';
       if (ActionService.isValidIsoDateTime(startTime) && ActionService.isValidIsoDateTime(endTime)) {
         return {
           actionType: EMAIL_ACTION_TYPE_CALENDAR_ADD_EVENT,
@@ -543,7 +543,7 @@ interface CreatedEmailAction {
 }
 
 interface CreateActionsForSummaryInput {
-  application: Pick<ConnectedApplication, 'applicationId' | 'userEmail' | 'providerId'>;
+  application: Pick<ConnectedApplication, 'applicationId' | 'userEmail' | 'providerId' | 'timeZone'>;
   processedMessage: ProcessedMessage;
   subject: string;
   from: string;

--- a/packages/backend-services/src/application/ApplicationService.ts
+++ b/packages/backend-services/src/application/ApplicationService.ts
@@ -52,6 +52,7 @@ class ApplicationService {
       CONNECTED_APPLICATION_STATUS_DRAFT,
       input.gmailPubsubTopicName || null,
       input.enabledFeatures || null,
+      input.timeZone || null,
     );
     return ApplicationResponseUtil.decorateApplication(application, env, raw);
   }
@@ -90,6 +91,7 @@ class ApplicationService {
       input.gmailPubsubTopicName || null,
       input.enabledFeatures,
       input.senderDomainFilters,
+      input.timeZone,
     );
     if (!application) {
       throw new BadRequestError('Connected application was not found.');
@@ -166,6 +168,7 @@ interface CreateUserApplicationInput {
   clientSecret: string;
   gmailPubsubTopicName?: string | undefined;
   enabledFeatures?: string[] | null | undefined;
+  timeZone?: string | null | undefined;
   senderDomainFilters?: SenderDomainFilters | null | undefined;
 }
 

--- a/packages/backend-services/src/email/EmailProcessingUtil.ts
+++ b/packages/backend-services/src/email/EmailProcessingUtil.ts
@@ -283,11 +283,12 @@ class EmailProcessingUtil {
     const maxChars: number = ConfigurationManager.getMaxEmailBodyChars(env);
     const bodyText: string = body || '(empty message body)';
     const input: string = EmailContentUtil.truncate(bodyText, maxChars);
-    const promptText: string = EmailSummaryUtil.buildEmailSummaryPromptText(subject, from, input, ragContext);
+    const timeZone: string | undefined = application.timeZone ?? undefined;
+    const promptText: string = EmailSummaryUtil.buildEmailSummaryPromptText(subject, from, input, ragContext, timeZone);
     let model: string = await EmailProcessingUtil.resolveSummaryModel(env, promptText);
     let result: EmailSummaryResult;
     try {
-      result = await EmailSummaryUtil.summarizeEmailWithUsage(env.AI, model, subject, from, input, ragContext);
+      result = await EmailSummaryUtil.summarizeEmailWithUsage(env.AI, model, subject, from, input, ragContext, timeZone);
     } catch (error: unknown) {
       if (!(error instanceof AiSummaryRetryableError)) throw error;
       await EmailProcessingUtil.recordSummaryFailureUsage(env, model, error, promptText);
@@ -296,7 +297,7 @@ class EmailProcessingUtil {
       console.warn(`AI summary failed with primary model ${model}, retrying with fallback ${fallbackModel}:`, error);
       model = fallbackModel;
       try {
-        result = await EmailSummaryUtil.summarizeEmailWithUsage(env.AI, model, subject, from, input, ragContext);
+        result = await EmailSummaryUtil.summarizeEmailWithUsage(env.AI, model, subject, from, input, ragContext, timeZone);
       } catch (fallbackError: unknown) {
         if (fallbackError instanceof AiSummaryRetryableError) {
           await EmailProcessingUtil.recordSummaryFailureUsage(env, model, fallbackError, promptText);

--- a/packages/backend-services/src/email/EmailSummaryUtil.ts
+++ b/packages/backend-services/src/email/EmailSummaryUtil.ts
@@ -1,5 +1,6 @@
 import { AiSummaryRetryableError } from '@mail-otter/backend-errors';
 import { EmailContentUtil } from '@mail-otter/provider-clients/email-content';
+import { TimeZoneUtil } from '@mail-otter/shared/utils';
 import type { EmailActionProposal } from '@mail-otter/shared/model';
 
 const SUMMARY_JSON_SCHEMA = {
@@ -62,8 +63,9 @@ class EmailSummaryUtil {
     from: string,
     body: string,
     ragContext?: string | undefined,
+    timeZone?: string | undefined,
   ): Promise<string> {
-    const result: EmailSummaryResult = await EmailSummaryUtil.summarizeEmailWithUsage(ai, model, subject, from, body, ragContext);
+    const result: EmailSummaryResult = await EmailSummaryUtil.summarizeEmailWithUsage(ai, model, subject, from, body, ragContext, timeZone);
     return result.summary;
   }
 
@@ -74,8 +76,9 @@ class EmailSummaryUtil {
     from: string,
     body: string,
     ragContext?: string | undefined,
+    timeZone?: string | undefined,
   ): Promise<EmailSummaryResult> {
-    const instructions: string = EmailSummaryUtil.buildSummaryInstructions();
+    const instructions: string = EmailSummaryUtil.buildSummaryInstructions(timeZone);
     const input: string = EmailSummaryUtil.buildSummaryInput(subject, from, body, ragContext);
 
     const request: AiTextGenerationRequest = {
@@ -118,20 +121,21 @@ class EmailSummaryUtil {
     return { summary: EmailSummaryUtil.renderHtmlSummary(summary), emailSummary: summary, actionProposals: summary.actions, usage };
   }
 
-  public static buildEmailSummaryPromptText(subject: string, from: string, body: string, ragContext?: string | undefined): string {
-    return [EmailSummaryUtil.buildSummaryInstructions(), EmailSummaryUtil.buildSummaryInput(subject, from, body, ragContext)].join('\n\n');
+  public static buildEmailSummaryPromptText(subject: string, from: string, body: string, ragContext?: string | undefined, timeZone?: string | undefined): string {
+    return [EmailSummaryUtil.buildSummaryInstructions(timeZone), EmailSummaryUtil.buildSummaryInput(subject, from, body, ragContext)].join('\n\n');
   }
 
-  private static buildSummaryInstructions(): string {
-    const currentDate: string = new Date().toISOString().slice(0, 10);
+  private static buildSummaryInstructions(timeZone?: string | undefined): string {
+    const zone: string = TimeZoneUtil.normalize(timeZone);
+    const currentDate: string = TimeZoneUtil.todayInZone(zone);
     return [
       'You are a helpful assistant that summarizes emails for a mailbox owner.',
-      `Today is ${currentDate}.`,
+      `Today is ${currentDate} in the mailbox owner's time zone ${zone}.`,
       'Return only JSON with this exact shape: {"gist":"one sentence","keyDetails":["short fact"],"actions":[{"type":"calendar.add_event|email.draft_reply|external.open_link|manual.todo","title":"short title","description":"what will happen","confidence":0.8,"parameters":{}}]}.',
       'Keep the gist to one sentence.',
       'Details must be short factual bullets copied from the email when possible.',
       'Actions are optional executable proposals; return an empty actions array when no safe action exists.',
-      "Use calendar.add_event when a calendar event is mentioned; resolve relative dates (e.g. 'tomorrow', 'next Friday') to absolute ISO 8601 datetimes using today's date; parameters must include eventTitle, startTime (ISO 8601), endTime (ISO 8601), timeZone, and optional location or notes.",
+      `Use calendar.add_event when a calendar event is mentioned; resolve relative dates (e.g. 'tomorrow', 'next Friday') to absolute ISO 8601 datetimes using today's date in ${zone}; parameters must include eventTitle, startTime (ISO 8601), endTime (ISO 8601), timeZone (use ${zone} unless the email explicitly states another time zone), and optional location or notes.`,
       'Use email.draft_reply when the owner should respond; parameters must include draftBody and optional draftSubject.',
       'Use external.open_link only for URLs present in the email; parameters must include url.',
       'Use manual.todo for useful actions that cannot be automated safely; parameters must include instructions.',

--- a/packages/shared/src/model/ConnectedApplication.ts
+++ b/packages/shared/src/model/ConnectedApplication.ts
@@ -24,6 +24,7 @@ interface ConnectedApplicationMetadata {
   contextIndexingEnabled: boolean;
   maxContextDocuments?: number | null | undefined;
   enabledFeatures?: string[] | null | undefined;
+  timeZone?: string | null | undefined;
   senderDomainFilters?: SenderDomainFilters | null | undefined;
   gmailPubsubTopicName?: string | null | undefined;
   watchedFolders?: Array<{ id: string; name: string }> | null | undefined;

--- a/packages/shared/src/utils/TimeZoneUtil.ts
+++ b/packages/shared/src/utils/TimeZoneUtil.ts
@@ -1,0 +1,24 @@
+const DEFAULT_TIME_ZONE = 'UTC';
+
+class TimeZoneUtil {
+  public static isValid(timeZone: string | null | undefined): boolean {
+    if (!timeZone || typeof timeZone !== 'string') return false;
+    try {
+      new Intl.DateTimeFormat('en-US', { timeZone });
+      return true;
+    } catch {
+      return false;
+    }
+  }
+
+  public static normalize(timeZone: string | null | undefined): string {
+    return TimeZoneUtil.isValid(timeZone) ? (timeZone as string).trim() : DEFAULT_TIME_ZONE;
+  }
+
+  public static todayInZone(timeZone: string | null | undefined, now: Date = new Date()): string {
+    const zone: string = TimeZoneUtil.normalize(timeZone);
+    return new Intl.DateTimeFormat('en-CA', { timeZone: zone, year: 'numeric', month: '2-digit', day: '2-digit' }).format(now);
+  }
+}
+
+export { TimeZoneUtil, DEFAULT_TIME_ZONE };

--- a/packages/shared/src/utils/index.ts
+++ b/packages/shared/src/utils/index.ts
@@ -1,5 +1,6 @@
 export * from './BaseUrlUtil';
 export * from './CryptoUtil';
 export * from './TimestampUtil';
+export * from './TimeZoneUtil';
 export * from './UUIDUtil';
 export * from './VoidUtil';

--- a/test/services/ActionService.test.ts
+++ b/test/services/ActionService.test.ts
@@ -451,6 +451,82 @@ describe('ActionService', () => {
       expect(result).toHaveLength(1);
     });
 
+    it('defaults calendar timeZone to the application timezone when the model omits it', async () => {
+      mockDeleteByProcessedMessageId.mockResolvedValue(undefined);
+      mockCreate.mockResolvedValue(makeAction({ actionType: 'calendar.add_event' }));
+
+      await ActionService.createActionsForSummary(
+        {
+          application: { applicationId: 'app-1', userEmail: 'user@example.com', providerId: 'google-gmail', timeZone: 'America/Los_Angeles' },
+          processedMessage: { processedMessageId: 'pm-1', providerMessageId: 'msg-1', providerThreadId: 'thread-1' } as never,
+          subject: 'Team sync',
+          from: 'organizer@example.com',
+          body: '',
+          callbackBaseUrl: 'https://example.com',
+          proposals: [{
+            type: 'calendar.add_event',
+            title: 'Team Sync',
+            description: 'Weekly standup',
+            parameters: { startTime: '2026-07-01T10:00:00', endTime: '2026-07-01T11:00:00' },
+          }],
+        },
+        makeEnv() as never,
+      );
+
+      expect(mockCreate).toHaveBeenCalledTimes(1);
+      expect(mockCreate.mock.calls[0][0].payload).toMatchObject({ type: 'calendar.add_event', timeZone: 'America/Los_Angeles' });
+    });
+
+    it('preserves an explicit model-provided timeZone over the application timezone', async () => {
+      mockDeleteByProcessedMessageId.mockResolvedValue(undefined);
+      mockCreate.mockResolvedValue(makeAction({ actionType: 'calendar.add_event' }));
+
+      await ActionService.createActionsForSummary(
+        {
+          application: { applicationId: 'app-1', userEmail: 'user@example.com', providerId: 'google-gmail', timeZone: 'America/Los_Angeles' },
+          processedMessage: { processedMessageId: 'pm-1', providerMessageId: 'msg-1', providerThreadId: 'thread-1' } as never,
+          subject: 'Team sync',
+          from: 'organizer@example.com',
+          body: '',
+          callbackBaseUrl: 'https://example.com',
+          proposals: [{
+            type: 'calendar.add_event',
+            title: 'Team Sync',
+            description: 'Weekly standup',
+            parameters: { startTime: '2026-07-01T10:00:00', endTime: '2026-07-01T11:00:00', timeZone: 'Europe/Berlin' },
+          }],
+        },
+        makeEnv() as never,
+      );
+
+      expect(mockCreate.mock.calls[0][0].payload).toMatchObject({ timeZone: 'Europe/Berlin' });
+    });
+
+    it('falls back to UTC for calendar timeZone when the application has none', async () => {
+      mockDeleteByProcessedMessageId.mockResolvedValue(undefined);
+      mockCreate.mockResolvedValue(makeAction({ actionType: 'calendar.add_event' }));
+
+      await ActionService.createActionsForSummary(
+        {
+          application: { applicationId: 'app-1', userEmail: 'user@example.com', providerId: 'google-gmail' },
+          processedMessage: { processedMessageId: 'pm-1', providerMessageId: 'msg-1', providerThreadId: 'thread-1' } as never,
+          subject: 'Team sync',
+          from: 'organizer@example.com',
+          body: '',
+          callbackBaseUrl: 'https://example.com',
+          proposals: [{
+            type: 'calendar.add_event',
+            title: 'Team Sync',
+            description: 'Weekly standup',
+            parameters: { startTime: '2026-07-01T10:00:00Z', endTime: '2026-07-01T11:00:00Z' },
+          }],
+        },
+        makeEnv() as never,
+      );
+
+      expect(mockCreate.mock.calls[0][0].payload).toMatchObject({ timeZone: 'UTC' });
+    });
+
     it('falls back to manual.todo for calendar.add_event with invalid dates', async () => {
       mockDeleteByProcessedMessageId.mockResolvedValue(undefined);
       mockCreate.mockResolvedValue(makeAction({ actionType: 'manual.todo' }));

--- a/test/services/ApplicationService.test.ts
+++ b/test/services/ApplicationService.test.ts
@@ -204,8 +204,8 @@ describe('ApplicationService', () => {
       );
 
       expect(mockUpdateForUser).toHaveBeenCalledOnce();
-      const lastArg = mockUpdateForUser.mock.calls[0]?.at(-1);
-      expect(lastArg).toEqual(filters);
+      const senderFiltersArg = mockUpdateForUser.mock.calls[0]?.[7];
+      expect(senderFiltersArg).toEqual(filters);
     });
 
     it('passes null senderDomainFilters to updateForUser when explicitly cleared', async () => {
@@ -224,8 +224,8 @@ describe('ApplicationService', () => {
         new Request('https://example.com'),
       );
 
-      const lastArg = mockUpdateForUser.mock.calls[0]?.at(-1);
-      expect(lastArg).toBeNull();
+      const senderFiltersArg = mockUpdateForUser.mock.calls[0]?.[7];
+      expect(senderFiltersArg).toBeNull();
     });
 
     it('passes undefined senderDomainFilters when field is omitted from input', async () => {
@@ -244,8 +244,8 @@ describe('ApplicationService', () => {
         new Request('https://example.com'),
       );
 
-      const lastArg = mockUpdateForUser.mock.calls[0]?.at(-1);
-      expect(lastArg).toBeUndefined();
+      const senderFiltersArg = mockUpdateForUser.mock.calls[0]?.[7];
+      expect(senderFiltersArg).toBeUndefined();
     });
 
     it('preserves connected status when credentials are unchanged', async () => {

--- a/test/utils/EmailProcessingUtil.test.ts
+++ b/test/utils/EmailProcessingUtil.test.ts
@@ -191,6 +191,7 @@ describe('EmailProcessingUtil', () => {
         'sender@example.com',
         'Please review the project update.',
         undefined,
+        undefined,
       );
       expect(incrementUsage).toHaveBeenCalledWith({
         usageDate: expect.any(String),
@@ -227,6 +228,7 @@ describe('EmailProcessingUtil', () => {
         'Project update',
         'sender@example.com',
         'Please review the project update.',
+        undefined,
         undefined,
       );
       expect(incrementUsage).toHaveBeenCalledWith({
@@ -267,6 +269,7 @@ describe('EmailProcessingUtil', () => {
         'sender@example.com',
         'Please review the project update.',
         undefined,
+        undefined,
       );
       expect(summarizeEmail).toHaveBeenNthCalledWith(
         2,
@@ -275,6 +278,7 @@ describe('EmailProcessingUtil', () => {
         'Project update',
         'sender@example.com',
         'Please review the project update.',
+        undefined,
         undefined,
       );
       expect(incrementUsage).toHaveBeenNthCalledWith(1, {

--- a/test/utils/EmailSummaryUtil.test.ts
+++ b/test/utils/EmailSummaryUtil.test.ts
@@ -193,6 +193,26 @@ describe('EmailSummaryUtil', () => {
       });
   });
 
+  describe('buildEmailSummaryPromptText', () => {
+    it('embeds the mailbox time zone and resolves today in that zone', () => {
+      const prompt = EmailSummaryUtil.buildEmailSummaryPromptText('Subject', 'sam@example.com', 'body', undefined, 'America/Los_Angeles');
+      expect(prompt).toContain('America/Los_Angeles');
+      const expectedToday = new Intl.DateTimeFormat('en-CA', {
+        timeZone: 'America/Los_Angeles',
+        year: 'numeric',
+        month: '2-digit',
+        day: '2-digit',
+      }).format(new Date());
+      expect(prompt).toContain(`Today is ${expectedToday}`);
+      expect(prompt).toContain('use America/Los_Angeles unless the email explicitly states another time zone');
+    });
+
+    it('falls back to UTC when no time zone is provided', () => {
+      const prompt = EmailSummaryUtil.buildEmailSummaryPromptText('Subject', 'sam@example.com', 'body');
+      expect(prompt).toContain("time zone UTC");
+    });
+  });
+
   it('uses Chat Completions totals as billed output tokens when reasoning details are present', async () => {
     const ai = {
       run: vi.fn().mockResolvedValue({

--- a/test/utils/TimeZoneUtil.test.ts
+++ b/test/utils/TimeZoneUtil.test.ts
@@ -1,0 +1,43 @@
+import { DEFAULT_TIME_ZONE, TimeZoneUtil } from '@mail-otter/shared/utils';
+import { describe, expect, it } from 'vitest';
+
+describe('TimeZoneUtil', () => {
+  describe('isValid', () => {
+    it('accepts a valid IANA time zone', () => {
+      expect(TimeZoneUtil.isValid('America/Los_Angeles')).toBe(true);
+      expect(TimeZoneUtil.isValid('UTC')).toBe(true);
+    });
+
+    it('rejects invalid, empty, or non-string values', () => {
+      expect(TimeZoneUtil.isValid('Not/A_Zone')).toBe(false);
+      expect(TimeZoneUtil.isValid('')).toBe(false);
+      expect(TimeZoneUtil.isValid(null)).toBe(false);
+      expect(TimeZoneUtil.isValid(undefined)).toBe(false);
+    });
+  });
+
+  describe('normalize', () => {
+    it('returns a valid zone unchanged', () => {
+      expect(TimeZoneUtil.normalize('Europe/Berlin')).toBe('Europe/Berlin');
+    });
+
+    it('falls back to UTC for invalid input', () => {
+      expect(TimeZoneUtil.normalize('garbage')).toBe(DEFAULT_TIME_ZONE);
+      expect(TimeZoneUtil.normalize(null)).toBe('UTC');
+    });
+  });
+
+  describe('todayInZone', () => {
+    it('computes the calendar date in the requested zone', () => {
+      // 2026-06-22T05:00:00Z is still 2026-06-21 in Los Angeles (UTC-7).
+      const instant = new Date('2026-06-22T05:00:00Z');
+      expect(TimeZoneUtil.todayInZone('America/Los_Angeles', instant)).toBe('2026-06-21');
+      expect(TimeZoneUtil.todayInZone('UTC', instant)).toBe('2026-06-22');
+    });
+
+    it('falls back to UTC for an invalid zone', () => {
+      const instant = new Date('2026-06-22T05:00:00Z');
+      expect(TimeZoneUtil.todayInZone('garbage', instant)).toBe('2026-06-22');
+    });
+  });
+});


### PR DESCRIPTION
The calendar.add_event action was already wired end-to-end, but events resolved relative dates against a UTC "today" and defaulted the event time zone to UTC. For any non-UTC user a "tomorrow 3pm" event landed at the wrong wall-clock time.

This adds a per-mailbox IANA time zone and threads it through the summarization and action-creation paths so events are created with the correct local time.

- Add `TimeZoneUtil` (IANA validation, UTC fallback, zone-local today) and a `timeZone` field on `ConnectedApplication`.
- Persist/read `calendar_time_zone` via the existing `provider_config` key/value pattern in `ConnectedApplicationDAO` (no migration).
- Accept optional `timeZone` on the create/update application endpoints and `ApplicationService`.
- Make the AI summary prompt time-zone aware: compute today in the mailbox zone and instruct the model to emit that zone.
- Default `calendar.add_event` payload `timeZone` from the application instead of the literal `UTC`.
- Add a Time Zone selector to the web mailbox form (defaults to the browser zone) and surface the zone in calendar action details.
- Add tests for `TimeZoneUtil`, the time-zone-aware prompt, and the calendar time-zone defaulting; update existing call-signature assertions.