### PR TITLE
Fix GET /user/application/integrations 500 Error

### DIFF
--- a/apps/api/src/endpoints/user/application/integrations/GET.ts
+++ b/apps/api/src/endpoints/user/application/integrations/GET.ts
@@ -21,16 +21,14 @@ class ListIntegrationsRoute extends IUserRoute<ListIntegrationsRequest, ListInte
   ): Promise<ListIntegrationsResponse> {
     const integrations = await ApplicationService.listIntegrations(
       this.getAuthenticatedUserEmailAddress(cxt),
-      request.applicationId,
+      this.getQueryParam(request, 'applicationId') ?? '',
       env,
     );
     return { integrations };
   }
 }
 
-interface ListIntegrationsRequest extends IRequest {
-  applicationId: string;
-}
+type ListIntegrationsRequest = IRequest;
 
 interface ListIntegrationsResponse extends IResponse {
   integrations: OutboundIntegration[];

--- a/packages/shared/src/schema/input.ts
+++ b/packages/shared/src/schema/input.ts
@@ -106,6 +106,10 @@ const ApplicationFoldersQuerySchema = z.object({
   applicationId: UuidSchema,
 });
 
+const ApplicationIntegrationsQuerySchema = z.object({
+  applicationId: UuidSchema,
+});
+
 const UpdateApplicationWatchSettingsBodySchema = z.object({
   applicationId: UuidSchema,
   folderIds: z.array(nonEmptyStringSchema('folderIds', 512)).nullable(),
@@ -176,6 +180,7 @@ const RequestInputSchemas: Record<string, RequestInputSchema> = {
   'POST /user/actions/:actionId/execute': {},
   'POST /user/application/oauth2/authorize': { body: OAuth2AuthorizeBodySchema },
   'GET /user/application/folders': { query: ApplicationFoldersQuerySchema },
+  'GET /user/application/integrations': { query: ApplicationIntegrationsQuerySchema },
   'PUT /user/application/watch-settings': { body: UpdateApplicationWatchSettingsBodySchema },
   'POST /user/application/watch': { body: WatchApplicationBodySchema },
   'POST /user/application/stop': { body: StopApplicationBodySchema },


### PR DESCRIPTION
The list integrations endpoint read `request.applicationId` as if it were a request body field. For GET requests the body is always empty, so the value was always `undefined`. This `undefined` flowed into `ApplicationIntegrationDAO.listByApplicationId` and then into a D1 `.bind()` call, producing `D1_TYPE_ERROR: Type 'undefined' not supported for value 'undefined'` and a 500 response.

Fixed by reading `applicationId` from the query string via `this.getQueryParam()`, matching the pattern used by all other GET endpoints in the codebase (folders, context/documents, actions). Also added `ApplicationIntegrationsQuerySchema` to `RequestInputSchemas` so a missing or malformed `applicationId` returns a 400 before reaching D1.