### PR TITLE
Remove OtterSum- Prefix From Outlook Summary Subject

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -164,12 +164,12 @@ Public API routes:
 
 The Microsoft Graph API returns `internetMessageHeaders` on messages when requested via `$select`, but **does not support `$filter`** on this property. Using `$filter=internetMessageHeaders/any(...)` returns a 400 error.
 
-This affects `OutlookProviderUtil.findSummaryMessageInFolder` in `packages/provider-clients/src/OutlookProviderUtil.ts`. The workaround is to embed a unique UUID marker in the reply subject (e.g., `[OtterSum-<uuid>]`) and filter on `contains(subject, 'OtterSum-<uuid>')` instead — `$filter` on `subject` IS supported.
+This affects `OutlookProviderUtil.findSummaryMessageInFolder` in `packages/provider-clients/src/OutlookProviderUtil.ts`. The workaround is to embed a unique hex marker in the reply subject (e.g., `[<marker>] Re: ...`) and filter on `startswith(subject, '[<marker>]')` instead — `$filter` on `subject` IS supported.
 
 When modifying `sendSelfSummaryReply` or related Outlook message-finding logic:
-- Use `crypto.randomUUID()` to generate a unique marker
-- Set the marker in the subject when sending replies
-- Use `contains(subject, ...)` for the `$filter` parameter
+- Derive the marker via `deriveMessageMarker` (SHA-256 of the message ID, first 8 bytes as hex)
+- Set the marker in the subject when sending replies as `[${marker}] Re: ${originalSubject}`
+- Use `startswith(subject, '[${marker}]')` for the `$filter` parameter
 - The `X-Mail-Otter-Summary` header is still set on outgoing messages for identification during message reads (via `$select`), just not for filtering
 
 ### Outlook Summary Email Sink Flow

--- a/packages/provider-clients/src/OutlookProviderUtil.ts
+++ b/packages/provider-clients/src/OutlookProviderUtil.ts
@@ -244,7 +244,7 @@ class OutlookProviderUtil {
         },
         body: JSON.stringify({
           message: {
-            subject: `[OtterSum-${marker}] Re: ${originalSubject}`,
+            subject: `[${marker}] Re: ${originalSubject}`,
             body: {
               contentType: 'html',
               content: summary,
@@ -276,8 +276,8 @@ class OutlookProviderUtil {
     url.searchParams.set(
       '$filter',
       marker
-        ? `startswith(subject, '[OtterSum-${marker}]')`
-        : `startswith(subject, '[OtterSum-')`,
+        ? `startswith(subject, '[${marker}]')`
+        : `startswith(subject, '[')`,
     );
     url.searchParams.set('$top', '1');
     url.searchParams.set('$select', 'id');

--- a/test/utils/OutlookProviderUtil.test.ts
+++ b/test/utils/OutlookProviderUtil.test.ts
@@ -47,13 +47,13 @@ describe('OutlookProviderUtil', () => {
       // Step 1: inbox idempotency check uses deterministic marker, no $orderby
       const inboxUrl = fetchMock.mock.calls[0][0] as string;
       expect(inboxUrl).toContain('/me/mailFolders/inbox/messages');
-      expect(inboxUrl).toContain(encodeURIComponent(`[OtterSum-${EXPECTED_MARKER}]`));
+      expect(inboxUrl).toContain(encodeURIComponent(`[${EXPECTED_MARKER}]`));
       expect(inboxUrl).not.toContain('orderby');
 
       // Step 2: sent items idempotency check uses same deterministic marker
       const sentItemsCheckUrl = fetchMock.mock.calls[1][0] as string;
       expect(sentItemsCheckUrl).toContain('/me/mailFolders/sentitems/messages');
-      expect(sentItemsCheckUrl).toContain(encodeURIComponent(`[OtterSum-${EXPECTED_MARKER}]`));
+      expect(sentItemsCheckUrl).toContain(encodeURIComponent(`[${EXPECTED_MARKER}]`));
       expect(sentItemsCheckUrl).not.toContain('orderby');
 
       // Step 3: reply with sink address
@@ -69,7 +69,7 @@ describe('OutlookProviderUtil', () => {
 
       expect(replyHeaders['Content-Type']).toBe('application/json');
       expect(replyHeaders['Authorization']).toBe('Bearer test-access-token');
-      expect(parsedBody.message.subject).toBe(`[OtterSum-${EXPECTED_MARKER}] Re: `);
+      expect(parsedBody.message.subject).toBe(`[${EXPECTED_MARKER}] Re: `);
       expect(parsedBody.message.body).toEqual({
         contentType: 'html',
         content: htmlSummary,
@@ -84,7 +84,7 @@ describe('OutlookProviderUtil', () => {
       // Step 4: find sent summary message by same marker, no $orderby
       const findUrl = fetchMock.mock.calls[3][0] as string;
       expect(findUrl).toContain('/me/mailFolders/sentitems/messages');
-      expect(findUrl).toContain(encodeURIComponent(`[OtterSum-${EXPECTED_MARKER}]`));
+      expect(findUrl).toContain(encodeURIComponent(`[${EXPECTED_MARKER}]`));
       expect(findUrl).toContain(encodeURIComponent('$top') + '=1');
       expect(findUrl).not.toContain('orderby');
 
@@ -126,7 +126,7 @@ describe('OutlookProviderUtil', () => {
       expect(fetchMock).toHaveBeenCalledTimes(2);
       const inboxUrl = fetchMock.mock.calls[0][0] as string;
       expect(inboxUrl).toContain('/me/mailFolders/inbox/messages');
-      expect(inboxUrl).toContain(encodeURIComponent(`[OtterSum-${EXPECTED_MARKER}]`));
+      expect(inboxUrl).toContain(encodeURIComponent(`[${EXPECTED_MARKER}]`));
     });
 
     it('deletes stale Sent Items copy when summary already exists in inbox', async () => {


### PR DESCRIPTION
The `[OtterSum-<marker>]` bracket in Outlook summary reply subjects exposed an internal product name in users' inboxes. The prefix was purely technical — used by the Microsoft Graph `startswith` filter for idempotency checks.

Replace it with `[<marker>]` (the bare 16-char hex marker), which is equally unique and keeps the filtering mechanism intact without leaking naming.

Updates subject construction, $filter query strings, all test assertions, and the AGENTS.md gotchas section.