### PR TITLE
Add AI-Powered Rule Suggestions

### DIFF
--- a/apps/api/src/endpoints/index.ts
+++ b/apps/api/src/endpoints/index.ts
@@ -28,6 +28,7 @@ import { DeleteIntegrationRoute as OriginalDeleteIntegrationRoute } from './user
 import { TestIntegrationRoute as OriginalTestIntegrationRoute } from './user/application/integrations/test/POST';
 import { GetApplicationRulesRoute as OriginalGetApplicationRulesRoute } from './user/application/rules/GET';
 import { UpdateApplicationRulesRoute as OriginalUpdateApplicationRulesRoute } from './user/application/rules/PUT';
+import { SuggestApplicationRuleRoute as OriginalSuggestApplicationRuleRoute } from './user/application/rules/suggest/POST';
 import { OAuth2CallbackRoute as OriginalOAuth2CallbackRoute } from './api/oauth2/callback/GET';
 import { GetActionConfirmationRoute as OriginalGetActionConfirmationRoute } from './api/actions/GET';
 import { ExecuteActionCallbackRoute as OriginalExecuteActionCallbackRoute } from './api/actions/execute/POST';
@@ -69,3 +70,4 @@ export const DeleteIntegrationRoute: any = OriginalDeleteIntegrationRoute;
 export const TestIntegrationRoute: any = OriginalTestIntegrationRoute;
 export const GetApplicationRulesRoute: any = OriginalGetApplicationRulesRoute;
 export const UpdateApplicationRulesRoute: any = OriginalUpdateApplicationRulesRoute;
+export const SuggestApplicationRuleRoute: any = OriginalSuggestApplicationRuleRoute;

--- a/apps/api/src/endpoints/user/application/rules/suggest/POST.ts
+++ b/apps/api/src/endpoints/user/application/rules/suggest/POST.ts
@@ -1,0 +1,46 @@
+import { IUserRoute } from '@/endpoints/IUserRoute';
+import type { IUserEnv, IRequest, IResponse, RouteContext } from '@/endpoints/IUserRoute';
+import { ApplicationService } from '@mail-otter/backend-services/application';
+import type { EmailProcessingRule } from '@mail-otter/shared/model';
+
+class SuggestApplicationRuleRoute extends IUserRoute<SuggestApplicationRuleRequest, SuggestApplicationRuleResponse, SuggestApplicationRuleEnv> {
+  schema = {
+    tags: ['Rules'],
+    summary: 'Generate an email processing rule from a natural language description',
+    responses: {
+      '200': {
+        description: 'Suggested rule',
+      },
+    },
+  };
+
+  protected async handleRequest(
+    request: SuggestApplicationRuleRequest,
+    env: SuggestApplicationRuleEnv,
+    cxt: RouteContext<SuggestApplicationRuleEnv>,
+  ): Promise<SuggestApplicationRuleResponse> {
+    const rule = await ApplicationService.suggestRule(
+      this.getAuthenticatedUserEmailAddress(cxt),
+      request.applicationId,
+      request.description,
+      env,
+    );
+    return { rule };
+  }
+}
+
+interface SuggestApplicationRuleRequest extends IRequest {
+  applicationId: string;
+  description: string;
+}
+
+interface SuggestApplicationRuleResponse extends IResponse {
+  rule: Omit<EmailProcessingRule, 'ruleId'>;
+}
+
+interface SuggestApplicationRuleEnv extends IUserEnv {
+  AI: Ai;
+  AI_SUMMARY_MODEL?: string | undefined;
+}
+
+export { SuggestApplicationRuleRoute };

--- a/apps/api/src/workers/MailOtterWorker.ts
+++ b/apps/api/src/workers/MailOtterWorker.ts
@@ -6,6 +6,7 @@ import {
   CreateApplicationRoute,
   GetApplicationRulesRoute,
   UpdateApplicationRulesRoute,
+  SuggestApplicationRuleRoute,
   ListIntegrationsRoute,
   CreateIntegrationRoute,
   UpdateIntegrationRoute,
@@ -110,6 +111,7 @@ class MailOtterWorker extends AbstractEntrypointWorker {
     openapi.post('/user/application/stop', StopApplicationWatchRoute);
     openapi.get('/user/application/rules', GetApplicationRulesRoute);
     openapi.put('/user/application/rules', UpdateApplicationRulesRoute);
+    openapi.post('/user/application/rules/suggest', SuggestApplicationRuleRoute);
     openapi.get('/user/application/integrations', ListIntegrationsRoute);
     openapi.post('/user/application/integration', CreateIntegrationRoute);
     openapi.put('/user/application/integration', UpdateIntegrationRoute);

--- a/apps/web/src/components/mailboxes/RulesSection.tsx
+++ b/apps/web/src/components/mailboxes/RulesSection.tsx
@@ -4,6 +4,7 @@ import { Button } from '../ui/Button';
 import { Card, CardHeader, CardTitle } from '../ui/Card';
 import { Input } from '../ui/Input';
 import { useMailboxCallbacks } from '../../contexts/MailboxCallbacksContext';
+import { suggestRule as apiSuggestRule } from '../../services/applicationService';
 
 const MAX_RULES = 20;
 const MAX_MATCHERS = 5;
@@ -220,6 +221,115 @@ function AddRuleForm({ onAdd, onCancel }: { onAdd: (rule: EmailProcessingRule) =
   );
 }
 
+type SuggestState =
+  | { phase: 'idle' }
+  | { phase: 'loading' }
+  | { phase: 'preview'; rule: Omit<EmailProcessingRule, 'ruleId'>; description: string }
+  | { phase: 'error'; message: string; description: string };
+
+function SuggestRuleForm({
+  applicationId,
+  onAdd,
+  onCancel,
+}: {
+  applicationId: string;
+  onAdd: (rule: EmailProcessingRule) => void;
+  onCancel: () => void;
+}) {
+  const [description, setDescription] = useState('');
+  const [state, setState] = useState<SuggestState>({ phase: 'idle' });
+
+  const generate = async (desc: string) => {
+    setState({ phase: 'loading' });
+    try {
+      const { rule } = await apiSuggestRule(applicationId, desc);
+      setState({ phase: 'preview', rule, description: desc });
+    } catch (e) {
+      const message = e instanceof Error ? e.message : 'Could Not Generate A Rule. Try Rephrasing Your Description.';
+      setState({ phase: 'error', message, description: desc });
+    }
+  };
+
+  const handleGenerate = () => {
+    if (!description.trim()) return;
+    generate(description.trim());
+  };
+
+  const handleRegenerate = () => {
+    if (state.phase === 'preview' || state.phase === 'error') {
+      generate(state.description);
+    }
+  };
+
+  const handleAccept = () => {
+    if (state.phase !== 'preview') return;
+    onAdd({ ...state.rule, ruleId: crypto.randomUUID() });
+  };
+
+  return (
+    <div className="border border-[var(--color-border)] rounded-lg p-4 flex flex-col gap-3 bg-[var(--color-surface-raised)]">
+      <div className="flex flex-col gap-1">
+        <label className="text-xs font-medium text-[var(--color-text-secondary)]">Describe A Rule</label>
+        <div className="flex gap-2">
+          <Input
+            type="text"
+            placeholder="e.g. Skip newsletters from Substack"
+            value={description}
+            onChange={(e) => {
+              setDescription(e.target.value);
+              if (state.phase === 'preview' || state.phase === 'error') setState({ phase: 'idle' });
+            }}
+            className="text-sm flex-1"
+            maxLength={500}
+            disabled={state.phase === 'loading'}
+            onKeyDown={(e) => { if (e.key === 'Enter' && description.trim() && state.phase !== 'loading') handleGenerate(); }}
+          />
+          <Button
+            variant="primary"
+            size="sm"
+            onClick={handleGenerate}
+            disabled={!description.trim() || state.phase === 'loading'}
+          >
+            {state.phase === 'loading' ? 'Generating…' : 'Generate'}
+          </Button>
+        </div>
+      </div>
+
+      {state.phase === 'error' && (
+        <p className="text-xs text-red-500">{state.message}</p>
+      )}
+
+      {state.phase === 'preview' && (
+        <div className="border border-[var(--color-border)] rounded-lg p-3 flex flex-col gap-1 bg-[var(--color-surface-base)]">
+          <div className="flex items-center gap-2 flex-wrap">
+            <span className={`text-[10px] font-medium px-1.5 py-0.5 rounded uppercase ${ACTION_BADGE_COLORS[state.rule.action.type]}`}>
+              {ACTION_LABELS[state.rule.action.type]}
+            </span>
+            <span className="text-sm font-medium text-[var(--color-text-primary)]">{state.rule.name}</span>
+          </div>
+          <p className="text-xs text-[var(--color-text-muted)]">{formatConditionSummary({ ...state.rule, ruleId: '' })}</p>
+          {state.rule.action.type === 'prepend_instruction' && state.rule.action.instruction && (
+            <p className="text-xs text-[var(--color-text-secondary)] italic">"{state.rule.action.instruction}"</p>
+          )}
+        </div>
+      )}
+
+      <div className="flex gap-2 justify-end">
+        <Button variant="secondary" size="sm" onClick={onCancel}>Cancel</Button>
+        {state.phase === 'preview' && (
+          <>
+            <Button variant="secondary" size="sm" onClick={handleRegenerate}>Regenerate</Button>
+            <Button variant="primary" size="sm" onClick={handleAccept}>Add Rule</Button>
+          </>
+        )}
+        {state.phase === 'error' && (
+          <Button variant="secondary" size="sm" onClick={handleRegenerate}>Retry</Button>
+        )}
+      </div>
+    </div>
+  );
+}
+
 function RuleRow({
   rule,
   index,
@@ -293,15 +403,17 @@ function RuleRow({
   );
 }
 
+type FormMode = 'none' | 'manual' | 'suggest';
+
 export function RulesSection({ application }: { application: ConnectedApplication }) {
   const { busy, onUpdateRules } = useMailboxCallbacks();
-  const [showForm, setShowForm] = useState(false);
+  const [formMode, setFormMode] = useState<FormMode>('none');
   const rules = application.emailProcessingRules ?? [];
 
   const save = (updated: EmailProcessingRule[]) => onUpdateRules(application.applicationId, updated);
 
   const addRule = (rule: EmailProcessingRule) => {
-    setShowForm(false);
+    setFormMode('none');
     save([...rules, rule]);
   };
 
@@ -317,6 +429,8 @@ export function RulesSection({ application }: { application: ConnectedApplicatio
     [updated[index], updated[target]] = [updated[target], updated[index]];
     save(updated);
   };
+
+  const canAddMore = rules.length < MAX_RULES;
 
   return (
     <Card>
@@ -345,17 +459,32 @@ export function RulesSection({ application }: { application: ConnectedApplicatio
           ))}
         </div>
       )}
-      {!showForm && rules.length === 0 && (
+      {formMode === 'none' && rules.length === 0 && (
         <p className="text-xs text-[var(--color-text-muted)] mb-3">No Rules Configured.</p>
       )}
-      {showForm ? (
-        <AddRuleForm onAdd={addRule} onCancel={() => setShowForm(false)} />
-      ) : rules.length < MAX_RULES ? (
-        <Button variant="secondary" size="sm" onClick={() => setShowForm(true)} disabled={busy}>
-          Add Rule
-        </Button>
-      ) : (
-        <p className="text-xs text-[var(--color-text-muted)]">Maximum {MAX_RULES} Rules Reached.</p>
+      {formMode === 'manual' && (
+        <AddRuleForm onAdd={addRule} onCancel={() => setFormMode('none')} />
+      )}
+      {formMode === 'suggest' && (
+        <SuggestRuleForm
+          applicationId={application.applicationId}
+          onAdd={addRule}
+          onCancel={() => setFormMode('none')}
+        />
+      )}
+      {formMode === 'none' && (
+        canAddMore ? (
+          <div className="flex gap-2">
+            <Button variant="secondary" size="sm" onClick={() => setFormMode('manual')} disabled={busy}>
+              Add Rule
+            </Button>
+            <Button variant="secondary" size="sm" onClick={() => setFormMode('suggest')} disabled={busy}>
+              Generate With AI
+            </Button>
+          </div>
+        ) : (
+          <p className="text-xs text-[var(--color-text-muted)]">Maximum {MAX_RULES} Rules Reached.</p>
+        )
       )}
     </Card>
   );

--- a/apps/web/src/services/applicationService.ts
+++ b/apps/web/src/services/applicationService.ts
@@ -230,3 +230,16 @@ export async function updateRules(
     }),
   );
 }
+
+export async function suggestRule(
+  applicationId: string,
+  description: string,
+): Promise<{ rule: Omit<EmailProcessingRule, 'ruleId'> }> {
+  return readJson<{ rule: Omit<EmailProcessingRule, 'ruleId'> }>(
+    await apiFetch('/user/application/rules/suggest', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ applicationId, description }),
+    }),
+  );
+}

--- a/packages/backend-services/src/application/ApplicationService.ts
+++ b/packages/backend-services/src/application/ApplicationService.ts
@@ -14,6 +14,7 @@ import type {
 } from '@mail-otter/shared/model';
 import { ConfigurationManager } from '@mail-otter/backend-runtime/config';
 import { EmailContextUtil } from '../email/EmailContextUtil';
+import { EmailRuleSuggestionUtil } from '../email/EmailRuleSuggestionUtil';
 import { IntegrationService } from '../integration/IntegrationService';
 import type { IntegrationServiceEnv } from '../integration/IntegrationService';
 import { WatchService } from '../subscription/WatchService';
@@ -247,6 +248,17 @@ class ApplicationService {
     return updated;
   }
 
+  public static async suggestRule(
+    userEmail: string,
+    applicationId: string,
+    description: string,
+    env: SuggestRuleEnv,
+  ): Promise<Omit<EmailProcessingRule, 'ruleId'>> {
+    await ApplicationService.assertApplicationOwnership(userEmail, applicationId, env);
+    const model = ConfigurationManager.getEmailSummaryModel(env);
+    return EmailRuleSuggestionUtil.suggest(env.AI, model, description);
+  }
+
   private static async assertApplicationOwnership(
     userEmail: string,
     applicationId: string,
@@ -288,6 +300,11 @@ interface ApplicationServiceEnv {
   MAX_APPLICATIONS_PER_USER?: string | undefined;
 }
 
+interface SuggestRuleEnv extends ApplicationServiceEnv {
+  AI: Ai;
+  AI_SUMMARY_MODEL?: string | undefined;
+}
+
 interface DeleteUserApplicationEnv extends ApplicationServiceEnv, WatchServiceEnv {
   EMAIL_CONTEXT_INDEX?: Vectorize | undefined;
 }
@@ -318,6 +335,7 @@ export type {
   CreateIntegrationInput,
   CreateUserApplicationInput,
   DeleteUserApplicationEnv,
+  SuggestRuleEnv,
   UpdateIntegrationInput,
   UpdateUserApplicationInput,
   UpdateWatchedFolderIdsInput,

--- a/packages/backend-services/src/email/EmailRuleSuggestionUtil.ts
+++ b/packages/backend-services/src/email/EmailRuleSuggestionUtil.ts
@@ -1,0 +1,222 @@
+import { BadRequestError } from '@mail-otter/backend-errors';
+import type { EmailProcessingRule, EmailRuleAction, EmailRuleCondition } from '@mail-otter/shared/model';
+import { EmailRuleActionSchema, EmailRuleConditionSchema } from '@mail-otter/shared/schema';
+
+const SUGGESTION_JSON_SCHEMA = {
+  type: 'object',
+  additionalProperties: false,
+  required: ['name', 'enabled', 'conditions', 'action'],
+  properties: {
+    name: { type: 'string' },
+    enabled: { type: 'boolean' },
+    conditions: {
+      type: 'object',
+      required: ['operator', 'matchers'],
+      properties: {
+        operator: { type: 'string', enum: ['all', 'any'] },
+        matchers: {
+          type: 'array',
+          items: {
+            type: 'object',
+            required: ['field', 'op', 'value'],
+            properties: {
+              field: { type: 'string', enum: ['from', 'subject', 'body'] },
+              op: { type: 'string', enum: ['contains', 'not_contains', 'matches_sender'] },
+              value: { type: 'string' },
+            },
+          },
+        },
+      },
+    },
+    action: {
+      type: 'object',
+      required: ['type'],
+      properties: {
+        type: { type: 'string', enum: ['skip', 'skip_actions', 'prepend_instruction'] },
+        instruction: { type: 'string' },
+      },
+    },
+  },
+} as const;
+
+const JSON_MODE_SUPPORTED_MODELS: ReadonlySet<string> = new Set<string>([
+  '@cf/openai/gpt-oss-120b',
+  '@cf/openai/gpt-oss-20b',
+  '@cf/meta/llama-3.1-8b-instruct-fast',
+  '@cf/meta/llama-3.1-70b-instruct',
+  '@cf/meta/llama-3.3-70b-instruct-fp8-fast',
+  '@cf/meta/llama-3-8b-instruct',
+  '@cf/meta/llama-3.1-8b-instruct',
+  '@cf/meta/llama-3.2-11b-vision-instruct',
+  '@hf/nousresearch/hermes-2-pro-mistral-7b',
+  '@hf/thebloke/deepseek-coder-6.7b-instruct-awq',
+  '@cf/deepseek-ai/deepseek-r1-distill-qwen-32b',
+]);
+
+const SYSTEM_PROMPT = `You are a rule configuration assistant for an email processing system.
+Generate a single email processing rule as JSON based on the user's description.
+
+Rule schema:
+{
+  "name": "concise rule name (1-100 chars)",
+  "enabled": true,
+  "conditions": {
+    "operator": "all" | "any",
+    "matchers": [
+      { "field": "from" | "subject" | "body", "op": "contains" | "not_contains" | "matches_sender", "value": "string" }
+    ]
+  },
+  "action": {
+    "type": "skip" | "skip_actions" | "prepend_instruction",
+    "instruction": "string (only required for prepend_instruction)"
+  }
+}
+
+Rules:
+- matches_sender is only valid on field "from". Use @domain.com to match all senders from a domain, or user@example.com to match a specific address.
+- contains / not_contains do case-insensitive substring matching on any field.
+- operator "all" means ALL matchers must match (AND logic); "any" means at least one must match (OR logic).
+- skip: skip the email entirely, no AI summarization.
+- skip_actions: summarize the email but do not create action proposals.
+- prepend_instruction: add extra instructions to the AI summarization prompt.
+
+Return only the JSON object with no explanation or markdown.`;
+
+interface ValidatedSuggestedRule {
+  name: string;
+  enabled: boolean;
+  conditions: EmailRuleCondition;
+  action: EmailRuleAction;
+}
+
+class EmailRuleSuggestionUtil {
+  public static async suggest(
+    ai: Ai,
+    model: string,
+    description: string,
+  ): Promise<Omit<EmailProcessingRule, 'ruleId'>> {
+    const request: Record<string, unknown> = {
+      messages: [
+        { role: 'system', content: SYSTEM_PROMPT },
+        { role: 'user', content: description },
+      ],
+      max_tokens: 512,
+      temperature: 0.2,
+    };
+
+    if (JSON_MODE_SUPPORTED_MODELS.has(model)) {
+      request['response_format'] = {
+        type: 'json_schema',
+        json_schema: {
+          name: 'email_rule',
+          schema: SUGGESTION_JSON_SCHEMA,
+          strict: true,
+        },
+      };
+    }
+
+    const result = await (ai as unknown as { run: (...args: unknown[]) => Promise<unknown> }).run(model, request);
+    const text = EmailRuleSuggestionUtil.extractText(result);
+    if (!text) {
+      throw new BadRequestError('Could not generate a rule from that description. Try rephrasing.');
+    }
+
+    const parsed = EmailRuleSuggestionUtil.parseJson(text);
+    if (!parsed) {
+      throw new BadRequestError('Could not generate a rule from that description. Try rephrasing.');
+    }
+
+    const validated = EmailRuleSuggestionUtil.validateRule(parsed);
+    if (!validated) {
+      throw new BadRequestError('Could not generate a valid rule from that description. Try rephrasing.');
+    }
+
+    return validated;
+  }
+
+  private static validateRule(parsed: unknown): ValidatedSuggestedRule | undefined {
+    if (!parsed || typeof parsed !== 'object') return undefined;
+    const p = parsed as Record<string, unknown>;
+
+    const name = p['name'];
+    const enabled = p['enabled'];
+    if (typeof name !== 'string' || name.trim().length < 1 || name.length > 100) return undefined;
+    if (typeof enabled !== 'boolean') return undefined;
+
+    // Coerce matches_sender on non-from fields before schema validation, since
+    // the shared schema enforces the constraint as a Zod refinement.
+    const conditions = EmailRuleSuggestionUtil.sanitizeConditions(p['conditions']);
+    const condResult = EmailRuleConditionSchema.safeParse(conditions);
+    if (!condResult.success) return undefined;
+
+    const actionResult = EmailRuleActionSchema.safeParse(p['action']);
+    if (!actionResult.success) return undefined;
+
+    return { name: name.trim(), enabled, conditions: condResult.data, action: actionResult.data };
+  }
+
+  private static sanitizeConditions(conditions: unknown): unknown {
+    if (!conditions || typeof conditions !== 'object') return conditions;
+    const c = conditions as Record<string, unknown>;
+    if (!Array.isArray(c['matchers'])) return conditions;
+    return {
+      ...c,
+      matchers: c['matchers'].map((m: unknown) => {
+        if (!m || typeof m !== 'object') return m;
+        const matcher = m as Record<string, unknown>;
+        if (matcher['op'] === 'matches_sender' && matcher['field'] !== 'from') {
+          return { ...matcher, op: 'contains' };
+        }
+        return matcher;
+      }),
+    };
+  }
+
+  private static extractText(result: unknown): string | undefined {
+    if (typeof result === 'string') return result;
+    if (!result || typeof result !== 'object') return undefined;
+    const r = result as Record<string, unknown>;
+    if (typeof r['response'] === 'string') return r['response'];
+    if (typeof r['output_text'] === 'string') return r['output_text'];
+    if (Array.isArray(r['choices'])) {
+      const first = r['choices'][0];
+      if (first && typeof first === 'object') {
+        const msg = (first as Record<string, unknown>)['message'];
+        if (msg && typeof msg === 'object' && typeof (msg as Record<string, unknown>)['content'] === 'string') {
+          return (msg as Record<string, unknown>)['content'] as string;
+        }
+      }
+    }
+    return undefined;
+  }
+
+  private static parseJson(text: string): unknown {
+    try {
+      return JSON.parse(text);
+    } catch {
+      // try to extract a JSON object embedded in prose
+    }
+    const start = text.indexOf('{');
+    if (start === -1) return undefined;
+    let depth = 0;
+    let inString = false;
+    let escaped = false;
+    for (let i = start; i < text.length; i++) {
+      const ch = text[i]!;
+      if (escaped) { escaped = false; continue; }
+      if (ch === '\\') { escaped = true; continue; }
+      if (ch === '"') { inString = !inString; continue; }
+      if (inString) continue;
+      if (ch === '{') depth++;
+      if (ch === '}') {
+        depth--;
+        if (depth === 0) {
+          try { return JSON.parse(text.slice(start, i + 1)); } catch { return undefined; }
+        }
+      }
+    }
+    return undefined;
+  }
+}
+
+export { EmailRuleSuggestionUtil };

--- a/packages/backend-services/src/email/index.ts
+++ b/packages/backend-services/src/email/index.ts
@@ -3,6 +3,7 @@ export * from './AiUsageUtil';
 export * from './EmailContextUtil';
 export * from './EmailProcessingUtil';
 export * from './EmailRulesUtil';
+export * from './EmailRuleSuggestionUtil';
 export * from './EmailSummaryUtil';
 export * from './SenderFilterUtil';
 export * from './WorkersAiErrorUtil';

--- a/packages/shared/src/schema/input.ts
+++ b/packages/shared/src/schema/input.ts
@@ -176,6 +176,11 @@ const UpdateApplicationRulesBodySchema = z.object({
   rules: z.array(EmailProcessingRuleSchema).max(MAX_EMAIL_PROCESSING_RULES, `Maximum ${MAX_EMAIL_PROCESSING_RULES} rules per application.`),
 });
 
+const SuggestApplicationRuleBodySchema = z.object({
+  applicationId: UuidSchema,
+  description: nonEmptyStringSchema('description', 500),
+});
+
 const RequestInputSchemas: Record<string, RequestInputSchema> = {
   'POST /user/application': { body: CreateApplicationBodySchema },
   'PUT /user/application': { body: UpdateApplicationBodySchema },
@@ -196,6 +201,7 @@ const RequestInputSchemas: Record<string, RequestInputSchema> = {
   'POST /user/application/stop': { body: StopApplicationBodySchema },
   'GET /user/application/rules': { query: ApplicationRulesQuerySchema },
   'PUT /user/application/rules': { body: UpdateApplicationRulesBodySchema },
+  'POST /user/application/rules/suggest': { body: SuggestApplicationRuleBodySchema },
   'GET /api/oauth2/callback/:applicationId': { query: OAuth2CallbackQuerySchema },
   'GET /api/actions/:actionId': { query: EmailActionCallbackQuerySchema },
   'POST /api/actions/:actionId/execute': { query: EmailActionCallbackQuerySchema },
@@ -206,5 +212,5 @@ const RequestInputSchemas: Record<string, RequestInputSchema> = {
   'POST /api/webhooks/outlook/lifecycle/:applicationId': { query: OutlookWebhookQuerySchema, body: OutlookWebhookBodySchema },
 };
 
-export { ApplicationRulesQuerySchema, RequestInputSchemas, UpdateApplicationRulesBodySchema };
+export { ApplicationRulesQuerySchema, RequestInputSchemas, SuggestApplicationRuleBodySchema, UpdateApplicationRulesBodySchema };
 export type { RequestInputSchema };

--- a/test/utils/EmailRuleSuggestionUtil.test.ts
+++ b/test/utils/EmailRuleSuggestionUtil.test.ts
@@ -1,0 +1,110 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { EmailRuleSuggestionUtil } from '@mail-otter/backend-services/email';
+import { BadRequestError } from '@mail-otter/backend-errors';
+
+const MODEL = '@cf/meta/llama-3.1-8b-instruct-fast';
+
+function makeAi(response: unknown): Ai {
+  return { run: vi.fn().mockResolvedValue({ response: JSON.stringify(response) }) } as unknown as Ai;
+}
+
+function validRule() {
+  return {
+    name: 'Skip Newsletters',
+    enabled: true,
+    conditions: { operator: 'any', matchers: [{ field: 'from', op: 'matches_sender', value: '@newsletter.com' }] },
+    action: { type: 'skip' },
+  };
+}
+
+describe('EmailRuleSuggestionUtil.suggest', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('returns a valid rule from a well-formed AI response', async () => {
+    const ai = makeAi(validRule());
+    const result = await EmailRuleSuggestionUtil.suggest(ai, MODEL, 'skip newsletters from newsletter.com');
+    expect(result.name).toBe('Skip Newsletters');
+    expect(result.action.type).toBe('skip');
+    expect(result.conditions.matchers[0]?.field).toBe('from');
+    expect(result.conditions.matchers[0]?.op).toBe('matches_sender');
+  });
+
+  it('passes the description to the AI as user message', async () => {
+    const runFn = vi.fn().mockResolvedValue({ response: JSON.stringify(validRule()) });
+    const ai = { run: runFn } as unknown as Ai;
+    await EmailRuleSuggestionUtil.suggest(ai, MODEL, 'my custom description');
+    const call = runFn.mock.calls[0];
+    const messages = (call![1] as { messages: Array<{ role: string; content: string }> }).messages;
+    const userMessage = messages.find((m) => m.role === 'user');
+    expect(userMessage?.content).toBe('my custom description');
+  });
+
+  it('coerces matches_sender on a non-from field to contains', async () => {
+    const rule = {
+      ...validRule(),
+      conditions: { operator: 'any', matchers: [{ field: 'subject', op: 'matches_sender', value: '@example.com' }] },
+    };
+    const ai = makeAi(rule);
+    const result = await EmailRuleSuggestionUtil.suggest(ai, MODEL, 'test');
+    expect(result.conditions.matchers[0]?.op).toBe('contains');
+    expect(result.conditions.matchers[0]?.field).toBe('subject');
+  });
+
+  it('throws BadRequestError when AI returns unparseable text', async () => {
+    const ai = { run: vi.fn().mockResolvedValue({ response: 'this is not json at all' }) } as unknown as Ai;
+    await expect(EmailRuleSuggestionUtil.suggest(ai, MODEL, 'test')).rejects.toThrow(BadRequestError);
+  });
+
+  it('throws BadRequestError when AI returns an empty response', async () => {
+    const ai = { run: vi.fn().mockResolvedValue({ response: '' }) } as unknown as Ai;
+    await expect(EmailRuleSuggestionUtil.suggest(ai, MODEL, 'test')).rejects.toThrow(BadRequestError);
+  });
+
+  it('throws BadRequestError when AI returns JSON failing schema validation', async () => {
+    const invalid = { name: 'Bad Rule', enabled: true };
+    const ai = makeAi(invalid);
+    await expect(EmailRuleSuggestionUtil.suggest(ai, MODEL, 'test')).rejects.toThrow(BadRequestError);
+  });
+
+  it('throws BadRequestError when prepend_instruction action has no instruction', async () => {
+    const rule = { ...validRule(), action: { type: 'prepend_instruction' } };
+    const ai = makeAi(rule);
+    await expect(EmailRuleSuggestionUtil.suggest(ai, MODEL, 'test')).rejects.toThrow(BadRequestError);
+  });
+
+  it('accepts prepend_instruction action with a valid instruction', async () => {
+    const rule = { ...validRule(), action: { type: 'prepend_instruction', instruction: 'Extract invoice number.' } };
+    const ai = makeAi(rule);
+    const result = await EmailRuleSuggestionUtil.suggest(ai, MODEL, 'extract invoice details');
+    expect(result.action.type).toBe('prepend_instruction');
+    expect(result.action.instruction).toBe('Extract invoice number.');
+  });
+
+  it('extracts JSON object embedded in prose', async () => {
+    const json = JSON.stringify(validRule());
+    const ai = { run: vi.fn().mockResolvedValue({ response: `Here is your rule: ${json} Enjoy!` }) } as unknown as Ai;
+    const result = await EmailRuleSuggestionUtil.suggest(ai, MODEL, 'test');
+    expect(result.name).toBe('Skip Newsletters');
+  });
+
+  it('uses json_schema response_format for models that support JSON mode', async () => {
+    const runFn = vi.fn().mockResolvedValue({ response: JSON.stringify(validRule()) });
+    const ai = { run: runFn } as unknown as Ai;
+    await EmailRuleSuggestionUtil.suggest(ai, '@cf/meta/llama-3.1-8b-instruct-fast', 'test');
+    const call = runFn.mock.calls[0];
+    const req = call![1] as Record<string, unknown>;
+    expect(req['response_format']).toBeDefined();
+    expect((req['response_format'] as Record<string, unknown>)['type']).toBe('json_schema');
+  });
+
+  it('does not use response_format for unsupported models', async () => {
+    const runFn = vi.fn().mockResolvedValue({ response: JSON.stringify(validRule()) });
+    const ai = { run: runFn } as unknown as Ai;
+    await EmailRuleSuggestionUtil.suggest(ai, '@cf/some/unknown-model', 'test');
+    const call = runFn.mock.calls[0];
+    const req = call![1] as Record<string, unknown>;
+    expect(req['response_format']).toBeUndefined();
+  });
+});


### PR DESCRIPTION
Users can now describe an email processing rule in plain English (e.g. "skip newsletters from Substack") and have Workers AI generate the corresponding rule configuration automatically.

- `EmailRuleSuggestionUtil` calls Workers AI with a system prompt describing the rule schema, parses and validates the output, and coerces any `matches_sender` hallucinations on non-from fields to `contains` before validation.
- New `POST /user/application/rules/suggest` endpoint (authenticated) accepts `{ applicationId, description }` and returns a suggested rule without a `ruleId` (the frontend mints the UUID on accept).
- `ApplicationService.suggestRule()` wires the ownership check and model config lookup before delegating to the util.
- Input schema added to `packages/shared/src/schema/input.ts` for the new route.
- `RulesSection` gains a "Generate With AI" mode alongside "Add Rule": a description input, loading state, preview card with action badge + condition summary, and Accept / Regenerate / Cancel controls.
- 11 unit tests cover happy path, schema validation, coercion, JSON-embedded-in-prose extraction, and JSON mode flag.