### PR TITLE
Track Neuron Usage For AI Rule Suggestions

### DIFF
--- a/packages/backend-services/src/application/ApplicationService.ts
+++ b/packages/backend-services/src/application/ApplicationService.ts
@@ -1,5 +1,5 @@
 import { CONNECTED_APPLICATION_STATUS_DRAFT, CONNECTION_METHOD_OAUTH2 } from '@mail-otter/shared/constants';
-import { ApplicationContextDAO, ApplicationIntegrationDAO, ConnectedApplicationDAO, OAuth2AccessTokenCacheDAO } from '@mail-otter/backend-data/dao';
+import { AiDailyUsageDAO, ApplicationContextDAO, ApplicationIntegrationDAO, ConnectedApplicationDAO, OAuth2AccessTokenCacheDAO } from '@mail-otter/backend-data/dao';
 import type { D1Queryable } from '@mail-otter/backend-data/utils';
 import { BadRequestError } from '@mail-otter/backend-errors';
 import type {
@@ -15,6 +15,8 @@ import type {
 import { ConfigurationManager } from '@mail-otter/backend-runtime/config';
 import { EmailContextUtil } from '../email/EmailContextUtil';
 import { EmailRuleSuggestionUtil } from '../email/EmailRuleSuggestionUtil';
+import { AiUsageUtil } from '../email/AiUsageUtil';
+import type { AiTextGenerationUsage } from '../email/WorkersAiResponseUtil';
 import { IntegrationService } from '../integration/IntegrationService';
 import type { IntegrationServiceEnv } from '../integration/IntegrationService';
 import { WatchService } from '../subscription/WatchService';
@@ -256,7 +258,29 @@ class ApplicationService {
   ): Promise<Omit<EmailProcessingRule, 'ruleId'>> {
     await ApplicationService.assertApplicationOwnership(userEmail, applicationId, env);
     const model = ConfigurationManager.getEmailSummaryModel(env);
-    return EmailRuleSuggestionUtil.suggest(env.AI, model, description);
+    const { rule, usage } = await EmailRuleSuggestionUtil.suggestWithUsage(env.AI, model, description);
+    await ApplicationService.recordRuleSuggestionUsage(env, model, usage, description, rule);
+    return rule;
+  }
+
+  private static async recordRuleSuggestionUsage(
+    env: SuggestRuleEnv,
+    model: string,
+    usage: AiTextGenerationUsage | undefined,
+    description: string,
+    rule: Omit<EmailProcessingRule, 'ruleId'>,
+  ): Promise<void> {
+    try {
+      const estimate = AiUsageUtil.estimateTextGenerationUsage(model, usage, description, JSON.stringify(rule));
+      await new AiDailyUsageDAO(env.DB).incrementUsage({
+        usageDate: AiUsageUtil.getCurrentUtcUsageDate(),
+        estimatedNeurons: estimate.estimatedNeurons,
+        promptTokens: estimate.promptTokens,
+        completionTokens: estimate.completionTokens,
+      });
+    } catch (error: unknown) {
+      console.warn('Failed to record rule suggestion usage estimate:', error);
+    }
   }
 
   private static async assertApplicationOwnership(

--- a/packages/backend-services/src/email/EmailRuleSuggestionUtil.ts
+++ b/packages/backend-services/src/email/EmailRuleSuggestionUtil.ts
@@ -1,6 +1,8 @@
 import { BadRequestError } from '@mail-otter/backend-errors';
 import type { EmailProcessingRule, EmailRuleAction, EmailRuleCondition } from '@mail-otter/shared/model';
 import { EmailRuleActionSchema, EmailRuleConditionSchema } from '@mail-otter/shared/schema';
+import { WorkersAiResponseUtil } from './WorkersAiResponseUtil';
+import type { AiTextGenerationUsage } from './WorkersAiResponseUtil';
 
 const SUGGESTION_JSON_SCHEMA = {
   type: 'object',
@@ -39,20 +41,6 @@ const SUGGESTION_JSON_SCHEMA = {
   },
 } as const;
 
-const JSON_MODE_SUPPORTED_MODELS: ReadonlySet<string> = new Set<string>([
-  '@cf/openai/gpt-oss-120b',
-  '@cf/openai/gpt-oss-20b',
-  '@cf/meta/llama-3.1-8b-instruct-fast',
-  '@cf/meta/llama-3.1-70b-instruct',
-  '@cf/meta/llama-3.3-70b-instruct-fp8-fast',
-  '@cf/meta/llama-3-8b-instruct',
-  '@cf/meta/llama-3.1-8b-instruct',
-  '@cf/meta/llama-3.2-11b-vision-instruct',
-  '@hf/nousresearch/hermes-2-pro-mistral-7b',
-  '@hf/thebloke/deepseek-coder-6.7b-instruct-awq',
-  '@cf/deepseek-ai/deepseek-r1-distill-qwen-32b',
-]);
-
 const SYSTEM_PROMPT = `You are a rule configuration assistant for an email processing system.
 Generate a single email processing rule as JSON based on the user's description.
 
@@ -89,12 +77,26 @@ interface ValidatedSuggestedRule {
   action: EmailRuleAction;
 }
 
+interface EmailRuleSuggestionResult {
+  rule: Omit<EmailProcessingRule, 'ruleId'>;
+  usage: AiTextGenerationUsage | undefined;
+}
+
 class EmailRuleSuggestionUtil {
   public static async suggest(
     ai: Ai,
     model: string,
     description: string,
   ): Promise<Omit<EmailProcessingRule, 'ruleId'>> {
+    const { rule } = await EmailRuleSuggestionUtil.suggestWithUsage(ai, model, description);
+    return rule;
+  }
+
+  public static async suggestWithUsage(
+    ai: Ai,
+    model: string,
+    description: string,
+  ): Promise<EmailRuleSuggestionResult> {
     const request: Record<string, unknown> = {
       messages: [
         { role: 'system', content: SYSTEM_PROMPT },
@@ -104,7 +106,7 @@ class EmailRuleSuggestionUtil {
       temperature: 0.2,
     };
 
-    if (JSON_MODE_SUPPORTED_MODELS.has(model)) {
+    if (WorkersAiResponseUtil.supportsJsonMode(model)) {
       request['response_format'] = {
         type: 'json_schema',
         json_schema: {
@@ -116,13 +118,22 @@ class EmailRuleSuggestionUtil {
     }
 
     const result = await (ai as unknown as { run: (...args: unknown[]) => Promise<unknown> }).run(model, request);
-    const text = EmailRuleSuggestionUtil.extractText(result);
+    const usage: AiTextGenerationUsage | undefined = WorkersAiResponseUtil.extractUsage(result);
+
+    const text = WorkersAiResponseUtil.extractResponseText(result);
     if (!text) {
       throw new BadRequestError('Could not generate a rule from that description. Try rephrasing.');
     }
 
-    const parsed = EmailRuleSuggestionUtil.parseJson(text);
-    if (!parsed) {
+    const jsonText = WorkersAiResponseUtil.extractJsonObjectText(text);
+    if (!jsonText) {
+      throw new BadRequestError('Could not generate a rule from that description. Try rephrasing.');
+    }
+
+    let parsed: unknown;
+    try {
+      parsed = JSON.parse(jsonText);
+    } catch {
       throw new BadRequestError('Could not generate a rule from that description. Try rephrasing.');
     }
 
@@ -131,7 +142,7 @@ class EmailRuleSuggestionUtil {
       throw new BadRequestError('Could not generate a valid rule from that description. Try rephrasing.');
     }
 
-    return validated;
+    return { rule: validated, usage };
   }
 
   private static validateRule(parsed: unknown): ValidatedSuggestedRule | undefined {
@@ -171,52 +182,7 @@ class EmailRuleSuggestionUtil {
       }),
     };
   }
-
-  private static extractText(result: unknown): string | undefined {
-    if (typeof result === 'string') return result;
-    if (!result || typeof result !== 'object') return undefined;
-    const r = result as Record<string, unknown>;
-    if (typeof r['response'] === 'string') return r['response'];
-    if (typeof r['output_text'] === 'string') return r['output_text'];
-    if (Array.isArray(r['choices'])) {
-      const first = r['choices'][0];
-      if (first && typeof first === 'object') {
-        const msg = (first as Record<string, unknown>)['message'];
-        if (msg && typeof msg === 'object' && typeof (msg as Record<string, unknown>)['content'] === 'string') {
-          return (msg as Record<string, unknown>)['content'] as string;
-        }
-      }
-    }
-    return undefined;
-  }
-
-  private static parseJson(text: string): unknown {
-    try {
-      return JSON.parse(text);
-    } catch {
-      // try to extract a JSON object embedded in prose
-    }
-    const start = text.indexOf('{');
-    if (start === -1) return undefined;
-    let depth = 0;
-    let inString = false;
-    let escaped = false;
-    for (let i = start; i < text.length; i++) {
-      const ch = text[i]!;
-      if (escaped) { escaped = false; continue; }
-      if (ch === '\\') { escaped = true; continue; }
-      if (ch === '"') { inString = !inString; continue; }
-      if (inString) continue;
-      if (ch === '{') depth++;
-      if (ch === '}') {
-        depth--;
-        if (depth === 0) {
-          try { return JSON.parse(text.slice(start, i + 1)); } catch { return undefined; }
-        }
-      }
-    }
-    return undefined;
-  }
 }
 
 export { EmailRuleSuggestionUtil };
+export type { EmailRuleSuggestionResult };

--- a/packages/backend-services/src/email/EmailSummaryUtil.ts
+++ b/packages/backend-services/src/email/EmailSummaryUtil.ts
@@ -2,6 +2,8 @@ import { AiSummaryRetryableError } from '@mail-otter/backend-errors';
 import { EmailContentUtil } from '@mail-otter/provider-clients/email-content';
 import { TimeZoneUtil } from '@mail-otter/shared/utils';
 import type { EmailActionProposal } from '@mail-otter/shared/model';
+import { WorkersAiResponseUtil } from './WorkersAiResponseUtil';
+import type { AiTextGenerationUsage } from './WorkersAiResponseUtil';
 
 const SUMMARY_JSON_SCHEMA = {
   type: 'object',
@@ -38,20 +40,6 @@ const SUMMARY_JSON_SCHEMA = {
     },
   },
 } as const;
-
-const JSON_MODE_SUPPORTED_MODELS: ReadonlySet<string> = new Set<string>([
-  '@cf/openai/gpt-oss-120b',
-  '@cf/openai/gpt-oss-20b',
-  '@cf/meta/llama-3.1-8b-instruct-fast',
-  '@cf/meta/llama-3.1-70b-instruct',
-  '@cf/meta/llama-3.3-70b-instruct-fp8-fast',
-  '@cf/meta/llama-3-8b-instruct',
-  '@cf/meta/llama-3.1-8b-instruct',
-  '@cf/meta/llama-3.2-11b-vision-instruct',
-  '@hf/nousresearch/hermes-2-pro-mistral-7b',
-  '@hf/thebloke/deepseek-coder-6.7b-instruct-awq',
-  '@cf/deepseek-ai/deepseek-r1-distill-qwen-32b',
-]);
 
 const GPT_OSS_MODELS: ReadonlySet<string> = new Set<string>(['@cf/openai/gpt-oss-120b', '@cf/openai/gpt-oss-20b']);
 
@@ -92,7 +80,7 @@ class EmailSummaryUtil {
       temperature: 0.2,
     };
 
-    if (EmailSummaryUtil.supportsJsonMode(model)) {
+    if (WorkersAiResponseUtil.supportsJsonMode(model)) {
       request.response_format = {
         type: 'json_schema',
         json_schema: {
@@ -109,9 +97,9 @@ class EmailSummaryUtil {
     }
 
     const result = await (ai as unknown as { run: (...args: unknown[]) => Promise<unknown> }).run(model, request);
-    const usage: AiTextGenerationUsage | undefined = EmailSummaryUtil.extractUsage(result);
+    const usage: AiTextGenerationUsage | undefined = WorkersAiResponseUtil.extractUsage(result);
 
-    const summaryText = EmailSummaryUtil.extractResponseText(result);
+    const summaryText = WorkersAiResponseUtil.extractResponseText(result);
     if (!summaryText) {
       throw new AiSummaryRetryableError('Workers AI did not return a summary.', { aiUsage: usage });
     }
@@ -163,83 +151,8 @@ class EmailSummaryUtil {
     ].join('\n');
   }
 
-  private static supportsJsonMode(model: string): boolean {
-    return JSON_MODE_SUPPORTED_MODELS.has(model);
-  }
-
   private static isGptOssModel(model: string): boolean {
     return GPT_OSS_MODELS.has(model);
-  }
-
-  private static extractResponseText(result: unknown): string | undefined {
-    if (typeof result === 'string') {
-      return result;
-    }
-    if (!EmailSummaryUtil.isRecord(result)) {
-      return undefined;
-    }
-
-    const response: unknown = result.response;
-    if (response) {
-      return EmailSummaryUtil.stringifyTextResponse(response);
-    }
-
-    const outputText: unknown = result.output_text;
-    if (typeof outputText === 'string') {
-      return outputText;
-    }
-
-    const output: unknown = result.output;
-    const outputFromResponsesApi: string | undefined = EmailSummaryUtil.extractResponsesApiOutputText(output);
-    if (outputFromResponsesApi) {
-      return outputFromResponsesApi;
-    }
-
-    const choices: unknown = result.choices;
-    const chatCompletionText: string | undefined = EmailSummaryUtil.extractChatCompletionText(choices);
-    if (chatCompletionText) {
-      return chatCompletionText;
-    }
-
-    const toolCalls: unknown = result.tool_calls;
-    if (Array.isArray(toolCalls) && EmailSummaryUtil.isRecord(toolCalls[0]) && toolCalls[0].arguments) {
-      return EmailSummaryUtil.stringifyTextResponse(toolCalls[0].arguments);
-    }
-
-    return undefined;
-  }
-
-  private static extractUsage(result: unknown): AiTextGenerationUsage | undefined {
-    if (!EmailSummaryUtil.isRecord(result) || !EmailSummaryUtil.isRecord(result.usage)) return undefined;
-
-    const promptTokens: number | undefined = EmailSummaryUtil.getOptionalNumber(result.usage.prompt_tokens ?? result.usage.input_tokens);
-    const outputTokens: number | undefined = EmailSummaryUtil.getOptionalNumber(result.usage.completion_tokens ?? result.usage.output_tokens);
-    const totalTokens: number | undefined = EmailSummaryUtil.getOptionalNumber(result.usage.total_tokens);
-    const completionTokens: number | undefined = EmailSummaryUtil.resolveBilledOutputTokens(promptTokens, outputTokens, totalTokens);
-    const reasoningTokens: number | undefined = EmailSummaryUtil.extractReasoningTokens(result.usage);
-    if (promptTokens === undefined && completionTokens === undefined && totalTokens === undefined) return undefined;
-    return { promptTokens, completionTokens, totalTokens, reasoningTokens };
-  }
-
-  private static resolveBilledOutputTokens(
-    promptTokens: number | undefined,
-    outputTokens: number | undefined,
-    totalTokens: number | undefined,
-  ): number | undefined {
-    const outputTokensFromTotal: number | undefined =
-      promptTokens !== undefined && totalTokens !== undefined ? Math.max(0, totalTokens - promptTokens) : undefined;
-    if (outputTokens === undefined) return outputTokensFromTotal;
-    if (outputTokensFromTotal === undefined) return outputTokens;
-    return Math.max(outputTokens, outputTokensFromTotal);
-  }
-
-  private static extractReasoningTokens(usage: Record<string, unknown>): number | undefined {
-    const directReasoningTokens: number | undefined = EmailSummaryUtil.getOptionalNumber(usage.reasoning_tokens);
-    if (directReasoningTokens !== undefined) return directReasoningTokens;
-
-    const completionTokenDetails: unknown = usage.completion_tokens_details ?? usage.output_tokens_details;
-    if (!EmailSummaryUtil.isRecord(completionTokenDetails)) return undefined;
-    return EmailSummaryUtil.getOptionalNumber(completionTokenDetails.reasoning_tokens);
   }
 
   static parseAiSummaryResult(result: string): EmailSummary | undefined {
@@ -315,108 +228,8 @@ class EmailSummaryUtil {
   }
 
   private static tryParseExtractedJsonObject(value: string): unknown {
-    const jsonObjectText: string | undefined = EmailSummaryUtil.extractJsonObjectText(value);
+    const jsonObjectText: string | undefined = WorkersAiResponseUtil.extractJsonObjectText(value);
     return jsonObjectText ? EmailSummaryUtil.tryParseJson(jsonObjectText) : undefined;
-  }
-
-  private static extractJsonObjectText(value: string): string | undefined {
-    const fencedJson: string | undefined = EmailSummaryUtil.extractFencedJsonText(value);
-    if (fencedJson) {
-      return fencedJson.trim();
-    }
-
-    const start: number = value.indexOf('{');
-    if (start === -1) return undefined;
-
-    let depth = 0;
-    let inString = false;
-    let escaped = false;
-    for (let index = start; index < value.length; index += 1) {
-      const char: string = value[index]!;
-      if (escaped) {
-        escaped = false;
-        continue;
-      }
-      if (char === '\\') {
-        escaped = true;
-        continue;
-      }
-      if (char === '"') {
-        inString = !inString;
-        continue;
-      }
-      if (inString) continue;
-      if (char === '{') depth += 1;
-      if (char === '}') {
-        depth -= 1;
-        if (depth === 0) return value.slice(start, index + 1);
-      }
-    }
-    return undefined;
-  }
-
-  private static extractFencedJsonText(value: string): string | undefined {
-    const openingFence: number = value.indexOf('```');
-    if (openingFence === -1) return undefined;
-
-    let contentStart: number = openingFence + 3;
-    if (value.slice(contentStart, contentStart + 4).toLowerCase() === 'json') {
-      contentStart += 4;
-    }
-
-    while (contentStart < value.length) {
-      const char: string = value[contentStart]!;
-      if (char !== ' ' && char !== '\t' && char !== '\n' && char !== '\r') break;
-      contentStart += 1;
-    }
-
-    const closingFence: number = value.indexOf('```', contentStart);
-    return closingFence === -1 ? undefined : value.slice(contentStart, closingFence);
-  }
-
-  private static extractResponsesApiOutputText(output: unknown): string | undefined {
-    if (!Array.isArray(output)) return undefined;
-    const textParts: string[] = [];
-    for (const item of output) {
-      if (!EmailSummaryUtil.isRecord(item)) continue;
-      const content: unknown = item.content;
-      if (!Array.isArray(content)) continue;
-      for (const contentPart of content) {
-        if (!EmailSummaryUtil.isRecord(contentPart)) continue;
-        if (typeof contentPart.text === 'string') {
-          textParts.push(contentPart.text);
-        }
-      }
-    }
-    return textParts.length > 0 ? textParts.join('\n') : undefined;
-  }
-
-  private static extractChatCompletionText(choices: unknown): string | undefined {
-    if (!Array.isArray(choices)) return undefined;
-    const firstChoice: unknown = choices[0];
-    if (!EmailSummaryUtil.isRecord(firstChoice)) return undefined;
-    const message: unknown = firstChoice.message;
-    if (!EmailSummaryUtil.isRecord(message)) return undefined;
-    const content: unknown = message.content;
-    return typeof content === 'string' ? content : undefined;
-  }
-
-  private static stringifyTextResponse(value: unknown): string | undefined {
-    if (typeof value === 'string') {
-      return value;
-    }
-    if (value && typeof value === 'object') {
-      return JSON.stringify(value);
-    }
-    return undefined;
-  }
-
-  private static isRecord(value: unknown): value is Record<string, unknown> {
-    return Boolean(value && typeof value === 'object' && !Array.isArray(value));
-  }
-
-  private static getOptionalNumber(value: unknown): number | undefined {
-    return typeof value === 'number' && Number.isFinite(value) ? value : undefined;
   }
 
   private static isEmailSummary(value: unknown): value is EmailSummary {
@@ -434,7 +247,7 @@ class EmailSummaryUtil {
     if (!Array.isArray(value)) return [];
     const actions: EmailActionProposal[] = [];
     for (const item of value) {
-      if (!EmailSummaryUtil.isRecord(item)) continue;
+      if (!WorkersAiResponseUtil.isRecord(item)) continue;
       const type = typeof item.type === 'string' ? item.type : '';
       if (!['calendar.add_event', 'email.draft_reply', 'external.open_link', 'manual.todo'].includes(type)) continue;
       if (typeof item.title !== 'string' || typeof item.description !== 'string') continue;
@@ -443,7 +256,7 @@ class EmailSummaryUtil {
         title: EmailSummaryUtil.normalizeSentence(item.title),
         description: EmailSummaryUtil.normalizeSentence(item.description),
         confidence: typeof item.confidence === 'number' && Number.isFinite(item.confidence) ? item.confidence : undefined,
-        parameters: EmailSummaryUtil.isRecord(item.parameters) ? item.parameters : {},
+        parameters: WorkersAiResponseUtil.isRecord(item.parameters) ? item.parameters : {},
       });
     }
     return actions;
@@ -461,13 +274,6 @@ interface EmailSummaryResult {
   emailSummary?: EmailSummary | undefined;
   actionProposals?: EmailActionProposal[] | undefined;
   usage?: AiTextGenerationUsage | undefined;
-}
-
-interface AiTextGenerationUsage {
-  promptTokens?: number | undefined;
-  completionTokens?: number | undefined;
-  totalTokens?: number | undefined;
-  reasoningTokens?: number | undefined;
 }
 
 interface AiTextGenerationRequest {

--- a/packages/backend-services/src/email/WorkersAiResponseUtil.ts
+++ b/packages/backend-services/src/email/WorkersAiResponseUtil.ts
@@ -1,0 +1,179 @@
+const JSON_MODE_SUPPORTED_MODELS: ReadonlySet<string> = new Set<string>([
+  '@cf/openai/gpt-oss-120b',
+  '@cf/openai/gpt-oss-20b',
+  '@cf/meta/llama-3.1-8b-instruct-fast',
+  '@cf/meta/llama-3.1-70b-instruct',
+  '@cf/meta/llama-3.3-70b-instruct-fp8-fast',
+  '@cf/meta/llama-3-8b-instruct',
+  '@cf/meta/llama-3.1-8b-instruct',
+  '@cf/meta/llama-3.2-11b-vision-instruct',
+  '@hf/nousresearch/hermes-2-pro-mistral-7b',
+  '@hf/thebloke/deepseek-coder-6.7b-instruct-awq',
+  '@cf/deepseek-ai/deepseek-r1-distill-qwen-32b',
+]);
+
+class WorkersAiResponseUtil {
+  public static supportsJsonMode(model: string): boolean {
+    return JSON_MODE_SUPPORTED_MODELS.has(model);
+  }
+
+  public static extractResponseText(result: unknown): string | undefined {
+    if (typeof result === 'string') return result;
+    if (!WorkersAiResponseUtil.isRecord(result)) return undefined;
+
+    const response: unknown = result.response;
+    if (response) return WorkersAiResponseUtil.stringifyTextResponse(response);
+
+    const outputText: unknown = result.output_text;
+    if (typeof outputText === 'string') return outputText;
+
+    const outputFromResponsesApi: string | undefined = WorkersAiResponseUtil.extractResponsesApiOutputText(result.output);
+    if (outputFromResponsesApi) return outputFromResponsesApi;
+
+    const chatCompletionText: string | undefined = WorkersAiResponseUtil.extractChatCompletionText(result.choices);
+    if (chatCompletionText) return chatCompletionText;
+
+    const toolCalls: unknown = result.tool_calls;
+    if (Array.isArray(toolCalls) && WorkersAiResponseUtil.isRecord(toolCalls[0]) && toolCalls[0].arguments) {
+      return WorkersAiResponseUtil.stringifyTextResponse(toolCalls[0].arguments);
+    }
+
+    return undefined;
+  }
+
+  public static extractUsage(result: unknown): AiTextGenerationUsage | undefined {
+    if (!WorkersAiResponseUtil.isRecord(result) || !WorkersAiResponseUtil.isRecord(result.usage)) return undefined;
+
+    const promptTokens: number | undefined = WorkersAiResponseUtil.getOptionalNumber(
+      result.usage.prompt_tokens ?? result.usage.input_tokens,
+    );
+    const outputTokens: number | undefined = WorkersAiResponseUtil.getOptionalNumber(
+      result.usage.completion_tokens ?? result.usage.output_tokens,
+    );
+    const totalTokens: number | undefined = WorkersAiResponseUtil.getOptionalNumber(result.usage.total_tokens);
+    const completionTokens: number | undefined = WorkersAiResponseUtil.resolveBilledOutputTokens(promptTokens, outputTokens, totalTokens);
+    const reasoningTokens: number | undefined = WorkersAiResponseUtil.extractReasoningTokens(result.usage);
+    if (promptTokens === undefined && completionTokens === undefined && totalTokens === undefined) return undefined;
+    return { promptTokens, completionTokens, totalTokens, reasoningTokens };
+  }
+
+  public static extractJsonObjectText(value: string): string | undefined {
+    const fencedJson: string | undefined = WorkersAiResponseUtil.extractFencedJsonText(value);
+    if (fencedJson) return fencedJson.trim();
+
+    const start: number = value.indexOf('{');
+    if (start === -1) return undefined;
+
+    let depth = 0;
+    let inString = false;
+    let escaped = false;
+    for (let index = start; index < value.length; index += 1) {
+      const char: string = value[index]!;
+      if (escaped) {
+        escaped = false;
+        continue;
+      }
+      if (char === '\\') {
+        escaped = true;
+        continue;
+      }
+      if (char === '"') {
+        inString = !inString;
+        continue;
+      }
+      if (inString) continue;
+      if (char === '{') depth += 1;
+      if (char === '}') {
+        depth -= 1;
+        if (depth === 0) return value.slice(start, index + 1);
+      }
+    }
+    return undefined;
+  }
+
+  public static isRecord(value: unknown): value is Record<string, unknown> {
+    return Boolean(value && typeof value === 'object' && !Array.isArray(value));
+  }
+
+  public static getOptionalNumber(value: unknown): number | undefined {
+    return typeof value === 'number' && Number.isFinite(value) ? value : undefined;
+  }
+
+  private static resolveBilledOutputTokens(
+    promptTokens: number | undefined,
+    outputTokens: number | undefined,
+    totalTokens: number | undefined,
+  ): number | undefined {
+    const outputTokensFromTotal: number | undefined =
+      promptTokens !== undefined && totalTokens !== undefined ? Math.max(0, totalTokens - promptTokens) : undefined;
+    if (outputTokens === undefined) return outputTokensFromTotal;
+    if (outputTokensFromTotal === undefined) return outputTokens;
+    return Math.max(outputTokens, outputTokensFromTotal);
+  }
+
+  private static extractReasoningTokens(usage: Record<string, unknown>): number | undefined {
+    const directReasoningTokens: number | undefined = WorkersAiResponseUtil.getOptionalNumber(usage.reasoning_tokens);
+    if (directReasoningTokens !== undefined) return directReasoningTokens;
+    const completionTokenDetails: unknown = usage.completion_tokens_details ?? usage.output_tokens_details;
+    if (!WorkersAiResponseUtil.isRecord(completionTokenDetails)) return undefined;
+    return WorkersAiResponseUtil.getOptionalNumber(completionTokenDetails.reasoning_tokens);
+  }
+
+  private static extractResponsesApiOutputText(output: unknown): string | undefined {
+    if (!Array.isArray(output)) return undefined;
+    const textParts: string[] = [];
+    for (const item of output) {
+      if (!WorkersAiResponseUtil.isRecord(item)) continue;
+      const content: unknown = item.content;
+      if (!Array.isArray(content)) continue;
+      for (const contentPart of content) {
+        if (!WorkersAiResponseUtil.isRecord(contentPart)) continue;
+        if (typeof contentPart.text === 'string') textParts.push(contentPart.text);
+      }
+    }
+    return textParts.length > 0 ? textParts.join('\n') : undefined;
+  }
+
+  private static extractChatCompletionText(choices: unknown): string | undefined {
+    if (!Array.isArray(choices)) return undefined;
+    const firstChoice: unknown = choices[0];
+    if (!WorkersAiResponseUtil.isRecord(firstChoice)) return undefined;
+    const message: unknown = firstChoice.message;
+    if (!WorkersAiResponseUtil.isRecord(message)) return undefined;
+    const content: unknown = message.content;
+    return typeof content === 'string' ? content : undefined;
+  }
+
+  private static stringifyTextResponse(value: unknown): string | undefined {
+    if (typeof value === 'string') return value;
+    if (value && typeof value === 'object') return JSON.stringify(value);
+    return undefined;
+  }
+
+  private static extractFencedJsonText(value: string): string | undefined {
+    const openingFence: number = value.indexOf('```');
+    if (openingFence === -1) return undefined;
+
+    let contentStart: number = openingFence + 3;
+    if (value.slice(contentStart, contentStart + 4).toLowerCase() === 'json') contentStart += 4;
+
+    while (contentStart < value.length) {
+      const char: string = value[contentStart]!;
+      if (char !== ' ' && char !== '\t' && char !== '\n' && char !== '\r') break;
+      contentStart += 1;
+    }
+
+    const closingFence: number = value.indexOf('```', contentStart);
+    return closingFence === -1 ? undefined : value.slice(contentStart, closingFence);
+  }
+}
+
+interface AiTextGenerationUsage {
+  promptTokens?: number | undefined;
+  completionTokens?: number | undefined;
+  totalTokens?: number | undefined;
+  reasoningTokens?: number | undefined;
+}
+
+export { WorkersAiResponseUtil };
+export type { AiTextGenerationUsage };

--- a/packages/backend-services/src/email/index.ts
+++ b/packages/backend-services/src/email/index.ts
@@ -7,3 +7,4 @@ export * from './EmailRuleSuggestionUtil';
 export * from './EmailSummaryUtil';
 export * from './SenderFilterUtil';
 export * from './WorkersAiErrorUtil';
+export * from './WorkersAiResponseUtil';

--- a/test/utils/EmailRuleSuggestionUtil.test.ts
+++ b/test/utils/EmailRuleSuggestionUtil.test.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { EmailRuleSuggestionUtil } from '@mail-otter/backend-services/email';
+import type { EmailRuleSuggestionResult } from '@mail-otter/backend-services/email';
 import { BadRequestError } from '@mail-otter/backend-errors';
 
 const MODEL = '@cf/meta/llama-3.1-8b-instruct-fast';
@@ -106,5 +107,46 @@ describe('EmailRuleSuggestionUtil.suggest', () => {
     const call = runFn.mock.calls[0];
     const req = call![1] as Record<string, unknown>;
     expect(req['response_format']).toBeUndefined();
+  });
+});
+
+describe('EmailRuleSuggestionUtil.suggestWithUsage', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('returns the rule and usage when the AI response includes token counts', async () => {
+    const runFn = vi.fn().mockResolvedValue({
+      response: JSON.stringify(validRule()),
+      usage: { prompt_tokens: 200, completion_tokens: 50, total_tokens: 250 },
+    });
+    const ai = { run: runFn } as unknown as Ai;
+    const result: EmailRuleSuggestionResult = await EmailRuleSuggestionUtil.suggestWithUsage(ai, MODEL, 'skip newsletters');
+    expect(result.rule.name).toBe('Skip Newsletters');
+    expect(result.usage).toEqual({ promptTokens: 200, completionTokens: 50, totalTokens: 250, reasoningTokens: undefined });
+  });
+
+  it('returns usage: undefined when the AI response has no usage metadata', async () => {
+    const ai = makeAi(validRule());
+    const result: EmailRuleSuggestionResult = await EmailRuleSuggestionUtil.suggestWithUsage(ai, MODEL, 'skip newsletters');
+    expect(result.usage).toBeUndefined();
+  });
+
+  it('suggest() delegates to suggestWithUsage() and returns only the rule', async () => {
+    const runFn = vi.fn().mockResolvedValue({
+      response: JSON.stringify(validRule()),
+      usage: { prompt_tokens: 100, completion_tokens: 30 },
+    });
+    const ai = { run: runFn } as unknown as Ai;
+    const rule = await EmailRuleSuggestionUtil.suggest(ai, MODEL, 'test');
+    expect(rule.name).toBe('Skip Newsletters');
+    expect((rule as unknown as Record<string, unknown>)['usage']).toBeUndefined();
+  });
+
+  it('extracts JSON object embedded in fenced code block', async () => {
+    const json = JSON.stringify(validRule());
+    const ai = { run: vi.fn().mockResolvedValue({ response: `\`\`\`json\n${json}\n\`\`\`` }) } as unknown as Ai;
+    const result = await EmailRuleSuggestionUtil.suggestWithUsage(ai, MODEL, 'test');
+    expect(result.rule.name).toBe('Skip Newsletters');
   });
 });


### PR DESCRIPTION
Extract shared Workers AI response parsing into WorkersAiResponseUtil, eliminating duplication between EmailSummaryUtil and EmailRuleSuggestionUtil (JSON_MODE_SUPPORTED_MODELS, extractText/extractResponseText, JSON extraction, extractUsage, and private helpers).

Add EmailRuleSuggestionUtil.suggestWithUsage() that returns both the generated rule and AiTextGenerationUsage metadata. ApplicationService.suggestRule() now calls suggestWithUsage(), estimates neuron cost via AiUsageUtil, and persists it to AiDailyUsageDAO — matching the same pattern used for email summarization. Rule suggestion calls are no longer silently excluded from the usage dashboard.