### PR TITLE
Rename Auto-Renews Automatically To Renews Automatically

### DIFF
--- a/apps/web/src/components/mailboxes/MailboxDetail.tsx
+++ b/apps/web/src/components/mailboxes/MailboxDetail.tsx
@@ -90,7 +90,7 @@ export function MailboxDetail({
           <Metric
             label="Watch Expires"
             value={formatExpiryTimestamp(application.watchExpiresAt)}
-            subtitle={application.watchExpiresAt ? 'Auto-Renews Automatically' : undefined}
+            subtitle={application.watchExpiresAt ? 'Renews Automatically' : undefined}
           />
           <Metric label="Last Summary" value={formatTimestamp(application.lastSummaryAt)} />
           <Metric


### PR DESCRIPTION
Update the watch expiry subtitle text from 'Auto-Renews Automatically' to 'Renews Automatically'.