### PR TITLE
Rename Clear Button To Cancel In Mailbox Form

### DIFF
--- a/apps/web/src/components/mailboxes/MailboxForm.tsx
+++ b/apps/web/src/components/mailboxes/MailboxForm.tsx
@@ -171,7 +171,7 @@ export function MailboxForm({
               {form.applicationId ? 'Save Changes' : 'Create Mailbox'}
             </Button>
             <Button variant="ghost" onClick={onCancel} disabled={busy}>
-              Clear
+              Cancel
             </Button>
           </div>
         </div>


### PR DESCRIPTION
The Clear button in the New Mailbox dropdown has been renamed to Cancel for better clarity on its purpose (closing the form without saving).