### PR TITLE
Merge Sender Exclude Rules Into Email Processing Rules Engine

### DIFF
--- a/apps/web/components/types.ts
+++ b/apps/web/components/types.ts
@@ -42,7 +42,6 @@ export interface OutboundIntegration {
 
 export interface SenderDomainFilters {
   includeRules: string[];
-  excludeRules: string[];
 }
 
 export interface CurrentUser {

--- a/apps/web/src/components/mailboxes/SenderFilterSection.tsx
+++ b/apps/web/src/components/mailboxes/SenderFilterSection.tsx
@@ -5,34 +5,35 @@ import { Card, CardHeader, CardTitle } from '../ui/Card';
 import { Input } from '../ui/Input';
 import { useMailboxCallbacks } from '../../contexts/MailboxCallbacksContext';
 
-function RuleList({
-  label,
-  rules,
-  busy,
-  onAdd,
-  onRemove,
-}: {
-  label: string;
-  rules: string[];
-  busy: boolean;
-  onAdd: (rule: string) => void;
-  onRemove: (rule: string) => void;
-}) {
+export function SenderFilterSection({ application }: { application: ConnectedApplication }) {
+  const { busy, onUpdateSenderFilters } = useMailboxCallbacks();
   const [draft, setDraft] = useState('');
+  const current: SenderDomainFilters = application.senderDomainFilters ?? { includeRules: [] };
 
   const handleAdd = () => {
     const trimmed = draft.trim().toLowerCase();
-    if (!trimmed || rules.includes(trimmed)) return;
-    onAdd(trimmed);
+    if (!trimmed || current.includeRules.includes(trimmed)) return;
+    onUpdateSenderFilters(application.applicationId, { includeRules: [...current.includeRules, trimmed] });
     setDraft('');
   };
 
+  const handleRemove = (rule: string) => {
+    onUpdateSenderFilters(application.applicationId, { includeRules: current.includeRules.filter((r) => r !== rule) });
+  };
+
   return (
-    <div className="flex flex-col gap-2">
-      <p className="text-xs font-medium text-[var(--color-text-secondary)] uppercase tracking-wide">{label}</p>
-      {rules.length > 0 && (
-        <div className="flex flex-wrap gap-1.5">
-          {rules.map((rule) => (
+    <Card>
+      <CardHeader>
+        <CardTitle>Sender Allowlist</CardTitle>
+      </CardHeader>
+      <p className="text-xs text-[var(--color-text-muted)] mb-4">
+        When set, only emails from matching senders are processed. Leave empty to process all senders.
+        Use <code className="font-mono">@domain.com</code> to match a domain or <code className="font-mono">user@domain.com</code> for an exact address.
+        To block specific senders, create a rule with Field: From, Operator: Matches Sender, Action: Skip.
+      </p>
+      {current.includeRules.length > 0 && (
+        <div className="flex flex-wrap gap-1.5 mb-3">
+          {current.includeRules.map((rule) => (
             <span
               key={rule}
               className="inline-flex items-center gap-1 px-2 py-0.5 rounded-md text-xs bg-[var(--color-surface-raised)] border border-[var(--color-border)] text-[var(--color-text-primary)]"
@@ -40,7 +41,7 @@ function RuleList({
               {rule}
               <button
                 type="button"
-                onClick={() => onRemove(rule)}
+                onClick={() => handleRemove(rule)}
                 disabled={busy}
                 className="ml-0.5 text-[var(--color-text-muted)] hover:text-[var(--color-text-primary)] disabled:opacity-40"
                 aria-label={`Remove ${rule}`}
@@ -64,33 +65,6 @@ function RuleList({
         <Button variant="secondary" size="sm" onClick={handleAdd} disabled={busy || !draft.trim()}>
           Add
         </Button>
-      </div>
-    </div>
-  );
-}
-
-export function SenderFilterSection({ application }: { application: ConnectedApplication }) {
-  const { busy, onUpdateSenderFilters } = useMailboxCallbacks();
-  const current: SenderDomainFilters = application.senderDomainFilters ?? { includeRules: [], excludeRules: [] };
-
-  const addInclude = (rule: string) => onUpdateSenderFilters(application.applicationId, { ...current, includeRules: [...current.includeRules, rule] });
-  const removeInclude = (rule: string) => onUpdateSenderFilters(application.applicationId, { ...current, includeRules: current.includeRules.filter((r) => r !== rule) });
-  const addExclude = (rule: string) => onUpdateSenderFilters(application.applicationId, { ...current, excludeRules: [...current.excludeRules, rule] });
-  const removeExclude = (rule: string) => onUpdateSenderFilters(application.applicationId, { ...current, excludeRules: current.excludeRules.filter((r) => r !== rule) });
-
-  return (
-    <Card>
-      <CardHeader>
-        <CardTitle>Sender Filters</CardTitle>
-      </CardHeader>
-      <p className="text-xs text-[var(--color-text-muted)] mb-4">
-        Include Rules: Only Process Emails From Matching Senders. Exclude Rules: Skip Emails From Matching Senders.
-        Use <code className="font-mono">@domain.com</code> To Match A Domain Or <code className="font-mono">user@domain.com</code> For An Exact Address.
-        Exclude Rules Are Checked First.
-      </p>
-      <div className="flex flex-col gap-4">
-        <RuleList label="Include Rules" rules={current.includeRules} busy={busy} onAdd={addInclude} onRemove={removeInclude} />
-        <RuleList label="Exclude Rules" rules={current.excludeRules} busy={busy} onAdd={addExclude} onRemove={removeExclude} />
       </div>
     </Card>
   );

--- a/packages/backend-data/src/dao/ConnectedApplicationDAO.ts
+++ b/packages/backend-data/src/dao/ConnectedApplicationDAO.ts
@@ -176,7 +176,7 @@ class ConnectedApplicationDAO {
     } else if (enabledFeatures !== undefined) {
       await this.deleteProviderConfig(applicationId, 'oauth2_enabled_features');
     }
-    if (senderDomainFilters != null && (senderDomainFilters.includeRules.length > 0 || senderDomainFilters.excludeRules.length > 0)) {
+    if (senderDomainFilters != null && senderDomainFilters.includeRules.length > 0) {
       await this.setProviderConfig(applicationId, 'sender_domain_filters', JSON.stringify(senderDomainFilters), now);
     } else if (senderDomainFilters !== undefined) {
       await this.deleteProviderConfig(applicationId, 'sender_domain_filters');
@@ -439,6 +439,36 @@ class ConnectedApplicationDAO {
       this.getProviderConfig(row.application_id, 'calendar_time_zone'),
       this.getProviderConfig(row.application_id, 'email_processing_rules'),
     ]);
+    // Lazily migrate legacy excludeRules (stored in sender_domain_filters) into email processing rules
+    let senderDomainFilters: SenderDomainFilters | null = null;
+    let resolvedRulesJson: string | null = emailProcessingRulesJson;
+    if (senderDomainFiltersJson) {
+      const parsed = JSON.parse(senderDomainFiltersJson) as { includeRules?: string[]; excludeRules?: string[] };
+      const legacyExcludes = parsed.excludeRules ?? [];
+      const includeRules = parsed.includeRules ?? [];
+      if (legacyExcludes.length > 0) {
+        const migratedRules: EmailProcessingRule[] = legacyExcludes.map((pattern) => ({
+          ruleId: UUIDUtil.getRandomUUID(),
+          name: `Block ${pattern}`,
+          enabled: true,
+          conditions: { operator: 'any' as const, matchers: [{ field: 'from' as const, op: 'matches_sender' as const, value: pattern }] },
+          action: { type: 'skip' as const },
+        }));
+        const existingRules: EmailProcessingRule[] = emailProcessingRulesJson ? (JSON.parse(emailProcessingRulesJson) as EmailProcessingRule[]) : [];
+        const merged = [...existingRules, ...migratedRules];
+        resolvedRulesJson = JSON.stringify(merged);
+        await this.setProviderConfig(row.application_id, 'email_processing_rules', resolvedRulesJson);
+        if (includeRules.length > 0) {
+          await this.setProviderConfig(row.application_id, 'sender_domain_filters', JSON.stringify({ includeRules }));
+          senderDomainFilters = { includeRules };
+        } else {
+          await this.deleteProviderConfig(row.application_id, 'sender_domain_filters');
+        }
+      } else {
+        senderDomainFilters = includeRules.length > 0 ? { includeRules } : null;
+      }
+    }
+
     return {
       applicationId: row.application_id,
       userEmail: row.user_email,
@@ -451,8 +481,8 @@ class ConnectedApplicationDAO {
       maxContextDocuments: row.max_context_documents ?? null,
       enabledFeatures: enabledFeaturesJson ? (JSON.parse(enabledFeaturesJson) as string[]) : null,
       timeZone: timeZone ?? null,
-      senderDomainFilters: senderDomainFiltersJson ? (JSON.parse(senderDomainFiltersJson) as SenderDomainFilters) : null,
-      emailProcessingRules: emailProcessingRulesJson ? (JSON.parse(emailProcessingRulesJson) as EmailProcessingRule[]) : null,
+      senderDomainFilters,
+      emailProcessingRules: resolvedRulesJson ? (JSON.parse(resolvedRulesJson) as EmailProcessingRule[]) : null,
       watchedFolders: watchedFolders.length > 0 ? watchedFolders.map((f) => ({ id: f.folderPath, name: f.folderName })) : null,
       lastErrorAcknowledgedAt: row.last_error_acknowledged_at ?? null,
       contextLastErrorAcknowledgedAt: row.context_last_error_acknowledged_at ?? null,

--- a/packages/backend-services/src/email/SenderFilterUtil.ts
+++ b/packages/backend-services/src/email/SenderFilterUtil.ts
@@ -24,13 +24,6 @@ class SenderFilterUtil {
   ): { skip: false } | { skip: true; reason: string } {
     const address = SenderFilterUtil.extractEmailAddress(from);
 
-    if (filters.excludeRules.length > 0) {
-      const excluded = filters.excludeRules.some((r) => SenderFilterUtil.matchesPattern(address, r));
-      if (excluded) {
-        return { skip: true, reason: 'Sender matches application exclude filter rules.' };
-      }
-    }
-
     if (filters.includeRules.length > 0) {
       const included = filters.includeRules.some((r) => SenderFilterUtil.matchesPattern(address, r));
       if (!included) {

--- a/packages/shared/src/model/ConnectedApplication.ts
+++ b/packages/shared/src/model/ConnectedApplication.ts
@@ -3,7 +3,6 @@ import type { EmailProcessingRule } from './EmailRule';
 
 interface SenderDomainFilters {
   includeRules: string[];
-  excludeRules: string[];
 }
 
 interface OAuth2Credentials {

--- a/packages/shared/src/schema/input.ts
+++ b/packages/shared/src/schema/input.ts
@@ -36,7 +36,6 @@ const UpdateApplicationBodySchema = z
     senderDomainFilters: z
       .object({
         includeRules: z.array(z.string().max(320)).max(100),
-        excludeRules: z.array(z.string().max(320)).max(100),
       })
       .optional()
       .nullable(),

--- a/test/services/ApplicationService.test.ts
+++ b/test/services/ApplicationService.test.ts
@@ -194,7 +194,7 @@ describe('ApplicationService', () => {
         credentials: { refreshToken: 'rt' },
       });
       mockUpdateForUser.mockResolvedValue({ applicationId: 'app-1' });
-      const filters = { includeRules: ['@company.com'], excludeRules: [] };
+      const filters = { includeRules: ['@company.com'] };
 
       await ApplicationService.updateUserApplication(
         'user@example.com',
@@ -265,7 +265,7 @@ describe('ApplicationService', () => {
           displayName: 'Updated',
           providerId: 'google-gmail',
           connectionMethod: 'oauth2',
-          senderDomainFilters: { includeRules: ['@company.com'], excludeRules: [] },
+          senderDomainFilters: { includeRules: ['@company.com'] },
         },
         makeEnv(),
         new Request('https://example.com'),

--- a/test/utils/EmailProcessingUtil.test.ts
+++ b/test/utils/EmailProcessingUtil.test.ts
@@ -339,26 +339,6 @@ describe('EmailProcessingUtil', () => {
 
   describe('sender filter rules', () => {
     describe('Outlook path', () => {
-      it('skips Outlook message when sender matches an exclude rule', async () => {
-        vi.spyOn(ProcessedMessageDAO.prototype, 'tryStart').mockResolvedValue(true);
-        const markSkipped = vi.spyOn(ProcessedMessageDAO.prototype, 'markSkipped').mockResolvedValue();
-        const summarizeEmail = vi.spyOn(EmailSummaryUtil, 'summarizeEmailWithUsage');
-        vi.spyOn(OutlookProviderUtil, 'getMessage').mockResolvedValue(
-          createOutlookMessage({ from: { emailAddress: { address: 'newsletter@promotions.com' } } }),
-        );
-
-        await EmailProcessingUtil.processOutlookMessage(
-          createApplication({ senderDomainFilters: { includeRules: [], excludeRules: ['@promotions.com'] } }),
-          'access-token',
-          'message-1',
-          createEnv(),
-          [],
-        );
-
-        expect(markSkipped).toHaveBeenCalledWith('app-1', 'message-1', 'Sender matches application exclude filter rules.');
-        expect(summarizeEmail).not.toHaveBeenCalled();
-      });
-
       it('skips Outlook message when sender does not match any include rule', async () => {
         vi.spyOn(ProcessedMessageDAO.prototype, 'tryStart').mockResolvedValue(true);
         const markSkipped = vi.spyOn(ProcessedMessageDAO.prototype, 'markSkipped').mockResolvedValue();
@@ -368,7 +348,7 @@ describe('EmailProcessingUtil', () => {
         );
 
         await EmailProcessingUtil.processOutlookMessage(
-          createApplication({ senderDomainFilters: { includeRules: ['@company.com'], excludeRules: [] } }),
+          createApplication({ senderDomainFilters: { includeRules: ['@company.com'] } }),
           'access-token',
           'message-1',
           createEnv(),
@@ -391,7 +371,7 @@ describe('EmailProcessingUtil', () => {
         vi.spyOn(EmailSummaryUtil, 'summarizeEmailWithUsage').mockResolvedValue({ summary: 'Summary text' });
 
         await EmailProcessingUtil.processOutlookMessage(
-          createApplication({ senderDomainFilters: { includeRules: ['@company.com'], excludeRules: [] } }),
+          createApplication({ senderDomainFilters: { includeRules: ['@company.com'] } }),
           'access-token',
           'message-1',
           createEnv(),
@@ -423,26 +403,6 @@ describe('EmailProcessingUtil', () => {
     });
 
     describe('Gmail path', () => {
-      it('skips Gmail message when sender matches an exclude rule', async () => {
-        vi.spyOn(ProcessedMessageDAO.prototype, 'tryStart').mockResolvedValue(true);
-        const markSkipped = vi.spyOn(ProcessedMessageDAO.prototype, 'markSkipped').mockResolvedValue();
-        const summarizeEmail = vi.spyOn(EmailSummaryUtil, 'summarizeEmailWithUsage');
-        vi.spyOn(GmailProviderUtil, 'getMessage').mockResolvedValue(
-          createGmailMessage({ fromHeader: 'Newsletter <newsletter@promotions.com>' }),
-        );
-
-        await EmailProcessingUtil.processGmailMessage(
-          createApplication({ senderDomainFilters: { includeRules: [], excludeRules: ['@promotions.com'] } }),
-          'access-token',
-          'message-1',
-          createEnv(),
-          [],
-        );
-
-        expect(markSkipped).toHaveBeenCalledWith('app-1', 'message-1', 'Sender matches application exclude filter rules.');
-        expect(summarizeEmail).not.toHaveBeenCalled();
-      });
-
       it('skips Gmail message when sender does not match any include rule', async () => {
         vi.spyOn(ProcessedMessageDAO.prototype, 'tryStart').mockResolvedValue(true);
         const markSkipped = vi.spyOn(ProcessedMessageDAO.prototype, 'markSkipped').mockResolvedValue();
@@ -452,7 +412,7 @@ describe('EmailProcessingUtil', () => {
         );
 
         await EmailProcessingUtil.processGmailMessage(
-          createApplication({ senderDomainFilters: { includeRules: ['@company.com'], excludeRules: [] } }),
+          createApplication({ senderDomainFilters: { includeRules: ['@company.com'] } }),
           'access-token',
           'message-1',
           createEnv(),

--- a/test/utils/SenderFilterUtil.test.ts
+++ b/test/utils/SenderFilterUtil.test.ts
@@ -51,44 +51,14 @@ describe('SenderFilterUtil', () => {
   });
 
   describe('shouldSkip', () => {
-    it('returns skip: false when no rules are set', () => {
-      const result = SenderFilterUtil.shouldSkip('user@example.com', { includeRules: [], excludeRules: [] });
+    it('returns skip: false when no include rules are set', () => {
+      const result = SenderFilterUtil.shouldSkip('user@example.com', { includeRules: [] });
       expect(result).toEqual({ skip: false });
     });
 
-    it('returns skip: false when empty arrays match nothing', () => {
-      const result = SenderFilterUtil.shouldSkip('user@example.com', { includeRules: [], excludeRules: [] });
-      expect(result.skip).toBe(false);
-    });
-
-    it('skips sender matching an exclude rule (domain)', () => {
-      const result = SenderFilterUtil.shouldSkip('newsletter@promotions.com', {
-        includeRules: [],
-        excludeRules: ['@promotions.com'],
-      });
-      expect(result).toEqual({ skip: true, reason: 'Sender matches application exclude filter rules.' });
-    });
-
-    it('skips sender matching an exclude rule (exact address)', () => {
-      const result = SenderFilterUtil.shouldSkip('noreply@foo.com', {
-        includeRules: [],
-        excludeRules: ['noreply@foo.com'],
-      });
-      expect(result).toEqual({ skip: true, reason: 'Sender matches application exclude filter rules.' });
-    });
-
-    it('does not skip sender that does not match any exclude rule', () => {
-      const result = SenderFilterUtil.shouldSkip('alice@company.com', {
-        includeRules: [],
-        excludeRules: ['@promotions.com'],
-      });
-      expect(result).toEqual({ skip: false });
-    });
-
-    it('does not skip sender matching an include rule', () => {
+    it('does not skip sender matching an include rule (domain)', () => {
       const result = SenderFilterUtil.shouldSkip('alice@company.com', {
         includeRules: ['@company.com'],
-        excludeRules: [],
       });
       expect(result).toEqual({ skip: false });
     });
@@ -96,39 +66,34 @@ describe('SenderFilterUtil', () => {
     it('skips sender not matching any include rule', () => {
       const result = SenderFilterUtil.shouldSkip('alice@other.com', {
         includeRules: ['@company.com'],
-        excludeRules: [],
       });
       expect(result).toEqual({ skip: true, reason: 'Sender does not match application include filter rules.' });
     });
 
-    it('exclude takes precedence over include when sender is in both', () => {
-      const result = SenderFilterUtil.shouldSkip('admin@company.com', {
-        includeRules: ['@company.com'],
-        excludeRules: ['admin@company.com'],
-      });
-      expect(result).toEqual({ skip: true, reason: 'Sender matches application exclude filter rules.' });
-    });
-
-    it('does not skip sender in include rules but not in exclude rules', () => {
+    it('does not skip sender matching an include rule (exact address)', () => {
       const result = SenderFilterUtil.shouldSkip('alice@company.com', {
-        includeRules: ['@company.com'],
-        excludeRules: ['@other.com'],
+        includeRules: ['alice@company.com'],
       });
       expect(result).toEqual({ skip: false });
+    });
+
+    it('skips sender not matching any include rule (exact address)', () => {
+      const result = SenderFilterUtil.shouldSkip('bob@company.com', {
+        includeRules: ['alice@company.com'],
+      });
+      expect(result).toEqual({ skip: true, reason: 'Sender does not match application include filter rules.' });
     });
 
     it('extracts email from angle-bracket From header when matching', () => {
       const result = SenderFilterUtil.shouldSkip('Alice Smith <alice@company.com>', {
         includeRules: ['@company.com'],
-        excludeRules: [],
       });
       expect(result).toEqual({ skip: false });
     });
 
-    it('skips bare address not matching include rule extracted from angle-bracket header', () => {
+    it('skips sender extracted from angle-bracket header not matching include rule', () => {
       const result = SenderFilterUtil.shouldSkip('Bob Jones <bob@other.com>', {
         includeRules: ['@company.com'],
-        excludeRules: [],
       });
       expect(result).toEqual({ skip: true, reason: 'Sender does not match application include filter rules.' });
     });


### PR DESCRIPTION
Sender Filters and Email Processing Rules overlapped: adding an exclude rule in Sender Filters was functionally identical to creating a Rule with field=from, op=matches_sender, action=skip. The matches_sender operator already delegated to SenderFilterUtil.matchesPattern(), confirming the intended shared logic.

This change absorbs excludeRules into the Rules engine:

- Remove excludeRules from SenderDomainFilters model, schema, and web types
- Update SenderFilterUtil.shouldSkip to only check includeRules (allowlist)
- Add a lazy one-time migration in ConnectedApplicationDAO.toMetadata: when a stored sender_domain_filters record still contains legacy excludeRules, each pattern is converted to an EmailProcessingRule (from + matches_sender + skip) and persisted to email_processing_rules; the excludeRules key is then cleared from the stored JSON
- Rename SenderFilterSection to "Sender Allowlist" with updated copy directing users to the Rules UI for sender blocking
- Remove the two "exclude rule" test cases from EmailProcessingUtil and SenderFilterUtil tests; update remaining filter fixtures to the new shape

Include rules (allowlist semantics) are preserved as a distinct first-class concept since they cannot be expressed as a single first-match rule.