### PR TITLE
Fix 0017 Foreign Key Constraint Failure

### DIFF
--- a/migrations/0017_new_providers.sql
+++ b/migrations/0017_new_providers.sql
@@ -3,6 +3,9 @@
 -- and adds imap_cursor column to provider_subscriptions for polling-based providers.
 
 -- SQLite does not support ALTER COLUMN or DROP CONSTRAINT. We rebuild each affected table.
+-- PRAGMA foreign_keys = OFF is required because DROP TABLE connected_applications would otherwise
+-- fail: D1 enforces foreign keys by default and multiple tables reference connected_applications.
+PRAGMA foreign_keys = OFF;
 
 -- 1. connected_applications: add new provider IDs and imap-password connection method
 -- Current column set (after migrations 0001–0015): application_id, user_email, provider_email,
@@ -118,3 +121,54 @@ CREATE UNIQUE INDEX idx_processed_messages_stable_fingerprint
 -- Recreate composite index from 0011 (used by getLatestForApplication/getLatestErrorForApplication)
 CREATE INDEX IF NOT EXISTS idx_processed_messages_app_status_updated
   ON processed_messages(application_id, status, updated_at);
+
+-- 4. email_summary_actions: add new provider IDs
+-- The CHECK constraint previously only allowed 'google-gmail' and 'microsoft-outlook'.
+CREATE TABLE email_summary_actions_new (
+    action_id TEXT PRIMARY KEY,
+    processed_message_id TEXT NOT NULL,
+    application_id TEXT NOT NULL,
+    user_email TEXT NOT NULL,
+    provider_id TEXT NOT NULL,
+    provider_message_id TEXT NOT NULL,
+    provider_thread_id TEXT,
+    action_type TEXT NOT NULL,
+    status TEXT NOT NULL,
+    risk_level TEXT NOT NULL,
+    token_hash TEXT NOT NULL UNIQUE,
+    encrypted_payload TEXT NOT NULL,
+    payload_iv TEXT NOT NULL,
+    payload_salt TEXT NOT NULL,
+    encrypted_result TEXT,
+    result_iv TEXT,
+    result_salt TEXT,
+    error_message TEXT,
+    expires_at INTEGER NOT NULL,
+    executed_at INTEGER,
+    created_at INTEGER NOT NULL,
+    updated_at INTEGER NOT NULL,
+    FOREIGN KEY (processed_message_id) REFERENCES processed_messages(processed_message_id) ON DELETE CASCADE,
+    FOREIGN KEY (application_id) REFERENCES connected_applications(application_id) ON DELETE CASCADE,
+    CHECK (provider_id IN ('google-gmail', 'microsoft-outlook', 'fastmail-jmap', 'yahoo-mail', 'custom-imap', 'apple-icloud')),
+    CHECK (action_type IN ('calendar.add_event', 'email.draft_reply', 'external.open_link', 'manual.todo')),
+    CHECK (status IN ('pending', 'executing', 'succeeded', 'failed', 'expired', 'cancelled')),
+    CHECK (risk_level IN ('low', 'medium', 'high'))
+);
+INSERT INTO email_summary_actions_new
+    SELECT action_id, processed_message_id, application_id, user_email, provider_id,
+           provider_message_id, provider_thread_id, action_type, status, risk_level,
+           token_hash, encrypted_payload, payload_iv, payload_salt, encrypted_result,
+           result_iv, result_salt, error_message, expires_at, executed_at, created_at, updated_at
+    FROM email_summary_actions;
+DROP TABLE email_summary_actions;
+ALTER TABLE email_summary_actions_new RENAME TO email_summary_actions;
+CREATE INDEX idx_email_summary_actions_user_sort
+  ON email_summary_actions(user_email, updated_at, created_at);
+CREATE INDEX idx_email_summary_actions_application_status
+  ON email_summary_actions(application_id, status, updated_at);
+CREATE INDEX idx_email_summary_actions_status_expires
+  ON email_summary_actions(status, expires_at);
+CREATE INDEX idx_email_summary_actions_processed_message
+  ON email_summary_actions(processed_message_id);
+
+PRAGMA foreign_keys = ON;


### PR DESCRIPTION
D1 enforces foreign keys by default. The migration's `DROP TABLE connected_applications` failed because ten tables hold FK references to it (`provider_subscriptions`, `processed_messages`, `oauth2_authorization_sessions`, `email_summary_actions`, `application_integrations`, and others).

Wrap the entire migration with `PRAGMA foreign_keys = OFF/ON` — the canonical SQLite approach for table rebuilds — so the DROP succeeds.

Also extends the migration to rebuild `email_summary_actions`, which had an overlooked `CHECK (provider_id IN ('google-gmail', 'microsoft-outlook'))` constraint that would have rejected action records for the four new providers at runtime.