### PR TITLE
Display Gist In Email Subject With Body Overflow

### DIFF
--- a/packages/backend-services/src/email/EmailProcessingUtil.ts
+++ b/packages/backend-services/src/email/EmailProcessingUtil.ts
@@ -143,7 +143,7 @@ class EmailProcessingUtil {
       return;
     }
     try {
-      await GmailProviderUtil.sendSummaryReply(data.accessToken, data.application.providerEmail!, data.message, data.summaryHtml);
+      await GmailProviderUtil.sendSummaryReply(data.accessToken, data.application.providerEmail!, data.message, data.summaryHtml, EmailSummaryUtil.truncateGistForSubject(data.rawSummary.gist));
       await EmailProcessingUtil.logSummarySent(contextDAO, data.application, data.messageId, data.options.retryAttempt);
       await processedDAO.markSummarized(data.application.applicationId, data.messageId);
     } catch (error: unknown) {
@@ -224,7 +224,7 @@ class EmailProcessingUtil {
       return;
     }
     try {
-      await OutlookProviderUtil.sendSelfSummaryReply(data.accessToken, data.message, data.application.providerEmail!, data.summaryHtml);
+      await OutlookProviderUtil.sendSelfSummaryReply(data.accessToken, data.message, data.application.providerEmail!, data.summaryHtml, EmailSummaryUtil.truncateGistForSubject(data.rawSummary.gist));
       await EmailProcessingUtil.logSummarySent(contextDAO, data.application, data.messageId, data.options.retryAttempt);
       await processedDAO.markSummarized(data.application.applicationId, data.messageId);
     } catch (error: unknown) {
@@ -283,7 +283,7 @@ class EmailProcessingUtil {
     const existing = await processedDAO.getByMessageId(data.application.applicationId, data.emailId);
     if (existing?.status === PROCESSED_MESSAGE_STATUS_SUMMARIZED) return;
     try {
-      await FastmailProviderUtil.createDraftReply(data.accessToken, data.emailId, data.summaryHtml);
+      await FastmailProviderUtil.createDraftReply(data.accessToken, data.emailId, data.summaryHtml, EmailSummaryUtil.truncateGistForSubject(data.rawSummary.gist));
       await EmailProcessingUtil.logSummarySent(contextDAO, data.application, data.emailId, data.options.retryAttempt);
       await processedDAO.markSummarized(data.application.applicationId, data.emailId);
     } catch (error: unknown) {
@@ -342,7 +342,7 @@ class EmailProcessingUtil {
       const summaryRfc2822 = [
         `From: ${data.application.providerEmail ?? data.application.userEmail}`,
         `To: ${data.application.providerEmail ?? data.application.userEmail}`,
-        `Subject: [Mail Otter Summary] ${data.emailSubject}`,
+        `Subject: [Mail Otter Summary] ${EmailSummaryUtil.truncateGistForSubject(data.rawSummary.gist)}`,
         `X-Mail-Otter-Summary: true`,
         `Content-Type: text/html; charset=utf-8`,
         '',

--- a/packages/backend-services/src/email/EmailSummaryUtil.ts
+++ b/packages/backend-services/src/email/EmailSummaryUtil.ts
@@ -43,6 +43,8 @@ const SUMMARY_JSON_SCHEMA = {
 
 const GPT_OSS_MODELS: ReadonlySet<string> = new Set<string>(['@cf/openai/gpt-oss-120b', '@cf/openai/gpt-oss-20b']);
 
+const GIST_SUBJECT_MAX_LENGTH = 100;
+
 class EmailSummaryUtil {
   public static async summarizeEmail(
     ai: Ai,
@@ -171,13 +173,17 @@ class EmailSummaryUtil {
     };
   }
 
+  static truncateGistForSubject(gist: string): string {
+    return gist.length > GIST_SUBJECT_MAX_LENGTH ? `${gist.slice(0, GIST_SUBJECT_MAX_LENGTH - 3)}...` : gist;
+  }
+
   static renderHtmlSummary(summary: EmailSummary): string {
     const gist: string = EmailSummaryUtil.normalizeSentence(summary.gist) || 'No clear gist available.';
     const keyDetails: string[] = EmailSummaryUtil.normalizeItems(summary.keyDetails);
+    const gistOverflows: boolean = gist.length > GIST_SUBJECT_MAX_LENGTH;
 
     return [
-      `<p><strong>Gist:</strong> ${EmailContentUtil.sanitizeHtml(gist)}</p>`,
-      '',
+      ...(gistOverflows ? [`<p><strong>Gist:</strong> ${EmailContentUtil.sanitizeHtml(gist)}</p>`, ''] : []),
       '<p><strong>Details:</strong></p>',
       '<ul>',
       ...EmailSummaryUtil.renderHtmlList(keyDetails, '<li>No key details noted.</li>'),

--- a/packages/provider-clients/src/GmailProviderUtil.ts
+++ b/packages/provider-clients/src/GmailProviderUtil.ts
@@ -159,12 +159,11 @@ class GmailProviderUtil {
     });
   }
 
-  public static async sendSummaryReply(accessToken: string, from: string, originalMessage: GmailMessage, summary: string): Promise<void> {
+  public static async sendSummaryReply(accessToken: string, from: string, originalMessage: GmailMessage, summary: string, gist: string): Promise<void> {
     const headers: MailHeader[] | undefined = originalMessage.payload?.headers;
-    const originalSubject: string = EmailContentUtil.getHeader(headers, 'Subject') || '(no subject)';
     const originalMessageId: string | undefined = EmailContentUtil.getHeader(headers, 'Message-ID');
     const originalReferences: string | undefined = EmailContentUtil.getHeader(headers, 'References');
-    const replySubject: string = /^re:/i.test(originalSubject) ? originalSubject : `Re: ${originalSubject}`;
+    const replySubject: string = gist;
     const references: string = [originalReferences, originalMessageId].filter(Boolean).join(' ');
     const boundary: string = GmailProviderUtil.createSummaryMimeBoundary(originalMessage.id);
     const textSummary: string = EmailContentUtil.stripHtml(summary);

--- a/packages/provider-clients/src/OutlookProviderUtil.ts
+++ b/packages/provider-clients/src/OutlookProviderUtil.ts
@@ -206,6 +206,7 @@ class OutlookProviderUtil {
     originalMessage: OutlookMessage,
     mailboxAddress: string,
     summary: string,
+    gist: string,
   ): Promise<void> {
     const marker: string = await OutlookProviderUtil.deriveMessageMarker(originalMessage.id);
 
@@ -233,7 +234,6 @@ class OutlookProviderUtil {
     const sinkAddress: string = atIndex !== -1
       ? `${mailboxAddress.slice(0, atIndex)}+sink${mailboxAddress.slice(atIndex)}`
       : mailboxAddress;
-    const originalSubject: string = originalMessage.subject || '';
     const response: Response = await fetch(
       `https://graph.microsoft.com/v1.0/me/messages/${encodeURIComponent(originalMessage.id)}/reply`,
       {
@@ -244,7 +244,7 @@ class OutlookProviderUtil {
         },
         body: JSON.stringify({
           message: {
-            subject: `[${marker}] Re: ${originalSubject}`,
+            subject: `[${marker}] ${gist}`,
             body: {
               contentType: 'html',
               content: summary,

--- a/packages/provider-clients/src/fastmail/FastmailProviderUtil.ts
+++ b/packages/provider-clients/src/fastmail/FastmailProviderUtil.ts
@@ -89,7 +89,7 @@ class FastmailProviderUtil {
     return email;
   }
 
-  public static async createDraftReply(accessToken: string, originalEmailId: string, draftBody: string): Promise<{ id: string }> {
+  public static async createDraftReply(accessToken: string, originalEmailId: string, draftBody: string, gist?: string): Promise<{ id: string }> {
     const session = await FastmailProviderUtil.getSession(accessToken);
     const accountId = session.primaryAccounts['urn:ietf:params:jmap:mail'];
     const original = await FastmailProviderUtil.getEmail(accessToken, originalEmailId);
@@ -104,7 +104,7 @@ class FastmailProviderUtil {
           create: {
             draft: {
               mailboxIds: { [draftMailboxId]: true },
-              subject: `Re: ${original.subject ?? ''}`,
+              subject: gist ?? `Re: ${original.subject ?? ''}`,
               keywords: { $draft: true },
               replyTo: original.from ?? [],
               textBody: [{ partId: 'body', type: 'text/plain' }],

--- a/test/utils/EmailProcessingUtil.test.ts
+++ b/test/utils/EmailProcessingUtil.test.ts
@@ -125,7 +125,7 @@ describe('EmailProcessingUtil', () => {
       });
       expect(summarizeEmail).toHaveBeenCalledOnce();
       expect(sendSelfSummaryReply).toHaveBeenCalledOnce();
-      expect(sendSelfSummaryReply).toHaveBeenCalledWith('access-token', expect.anything(), 'owner@example.com', 'Summary text\n\n<p><em>Powered by Mail-Otter</em></p>');
+      expect(sendSelfSummaryReply).toHaveBeenCalledWith('access-token', expect.anything(), 'owner@example.com', 'Summary text\n\n<p><em>Powered by Mail-Otter</em></p>', '');
       expect(markSummarized).toHaveBeenCalledWith('app-1', 'reply-message-2');
     });
 

--- a/test/utils/EmailSummaryUtil.test.ts
+++ b/test/utils/EmailSummaryUtil.test.ts
@@ -13,9 +13,7 @@ describe('EmailSummaryUtil', () => {
     } as unknown as Ai;
 
     await expect(EmailSummaryUtil.summarizeEmail(ai, '@cf/meta/llama-3.1-8b-instruct', 'Campaign budget', 'sam@example.com', 'body'))
-      .resolves.toBe(`<p><strong>Gist:</strong> The sender wants approval for the May campaign budget.</p>
-
-<p><strong>Details:</strong></p>
+      .resolves.toBe(`<p><strong>Details:</strong></p>
 <ul>
 <li>Budget requested is $12,000.</li>
 <li>Launch is planned for May 20.</li>
@@ -41,9 +39,7 @@ describe('EmailSummaryUtil', () => {
     } as unknown as Ai;
 
     await expect(EmailSummaryUtil.summarizeEmail(ai, 'model', 'Status', 'sam@example.com', 'body')).resolves
-      .toBe(`<p><strong>Gist:</strong> The email shares a status update with no requests.</p>
-
-<p><strong>Details:</strong></p>
+      .toBe(`<p><strong>Details:</strong></p>
 <ul>
 <li>No key details noted.</li>
 </ul>`);
@@ -87,9 +83,7 @@ describe('EmailSummaryUtil', () => {
     } as unknown as Ai;
 
     await expect(EmailSummaryUtil.summarizeEmail(ai, '@cf/openai/gpt-oss-120b', 'Campaign budget', 'sam@example.com', 'body')).resolves
-      .toBe(`<p><strong>Gist:</strong> The sender needs approval for the budget.</p>
-
-<p><strong>Details:</strong></p>
+      .toBe(`<p><strong>Details:</strong></p>
 <ul>
 <li>Budget is $12,000.</li>
 </ul>`);
@@ -129,9 +123,7 @@ describe('EmailSummaryUtil', () => {
     } as unknown as Ai;
 
     await expect(EmailSummaryUtil.summarizeEmail(ai, '@cf/openai/gpt-oss-120b', 'Launch', 'sam@example.com', 'body')).resolves
-      .toBe(`<p><strong>Gist:</strong> The email shares a launch update.</p>
-
-<p><strong>Details:</strong></p>
+      .toBe(`<p><strong>Details:</strong></p>
 <ul>
 <li>Launch starts Monday.</li>
 </ul>`);
@@ -154,7 +146,7 @@ describe('EmailSummaryUtil', () => {
 
     await expect(EmailSummaryUtil.summarizeEmailWithUsage(ai, '@cf/openai/gpt-oss-120b', 'Review', 'sam@example.com', 'body')).resolves
       .toMatchObject({
-        summary: expect.stringContaining('<strong>Gist:</strong> The email asks for feedback.'),
+        summary: expect.stringContaining('<strong>Details:</strong>'),
         usage: {
           promptTokens: 1000,
           completionTokens: 100,
@@ -183,7 +175,7 @@ describe('EmailSummaryUtil', () => {
 
     await expect(EmailSummaryUtil.summarizeEmailWithUsage(ai, '@cf/openai/gpt-oss-120b', 'Review', 'sam@example.com', 'body')).resolves
       .toMatchObject({
-        summary: expect.stringContaining('<strong>Gist:</strong> The email asks for feedback.'),
+        summary: expect.stringContaining('<strong>Details:</strong>'),
         usage: {
           promptTokens: 1000,
           completionTokens: 800,
@@ -239,7 +231,7 @@ describe('EmailSummaryUtil', () => {
 
     await expect(EmailSummaryUtil.summarizeEmailWithUsage(ai, '@cf/openai/gpt-oss-120b', 'Review', 'sam@example.com', 'body')).resolves
       .toMatchObject({
-        summary: expect.stringContaining('<strong>Gist:</strong> The email asks for feedback.'),
+        summary: expect.stringContaining('<strong>Details:</strong>'),
         usage: {
           promptTokens: 1000,
           completionTokens: 800,

--- a/test/utils/OutlookProviderUtil.test.ts
+++ b/test/utils/OutlookProviderUtil.test.ts
@@ -40,6 +40,7 @@ describe('OutlookProviderUtil', () => {
         originalMessage,
         'sender@example.com',
         htmlSummary,
+        'Test gist.',
       );
 
       expect(fetchMock).toHaveBeenCalledTimes(6);
@@ -69,7 +70,7 @@ describe('OutlookProviderUtil', () => {
 
       expect(replyHeaders['Content-Type']).toBe('application/json');
       expect(replyHeaders['Authorization']).toBe('Bearer test-access-token');
-      expect(parsedBody.message.subject).toBe(`[${EXPECTED_MARKER}] Re: `);
+      expect(parsedBody.message.subject).toBe(`[${EXPECTED_MARKER}] Test gist.`);
       expect(parsedBody.message.body).toEqual({
         contentType: 'html',
         content: htmlSummary,


### PR DESCRIPTION
Moves the AI-generated gist (one-sentence summary) into the reply email subject line so users see the key takeaway at a glance in their inbox, without opening the message.

- Gists ≤ 100 chars become the subject verbatim; the Gist paragraph is dropped from the email body since it is already visible in the subject.
- Gists > 100 chars are truncated to 97 chars + "..." in the subject; the full gist is retained at the top of the body as an overflow.
- Gmail: gist replaces the old "Re: {original subject}" subject (threading is maintained via In-Reply-To / References headers, not subject).
- Outlook: gist follows the idempotency marker — "[{marker}] {gist}" — preserving the startswith filter used by findSummaryMessageInFolder.
- Fastmail JMAP: gist used as subject when provided; falls back to "Re: {original subject}" for action-originated draft replies.
- IMAP (Yahoo, Custom, Apple iCloud): "[Mail Otter Summary] {gist}".