### PR TITLE
Redirect To UI On Callback Error Instead Of 500

### DIFF
--- a/apps/api/src/endpoints/api/oauth2/callback/GET.ts
+++ b/apps/api/src/endpoints/api/oauth2/callback/GET.ts
@@ -33,14 +33,19 @@ class OAuth2CallbackRoute extends IBaseRoute<OAuth2CallbackRequest, OAuth2Callba
       throw new BadRequestError('OAuth2 callback is missing code or state.');
     }
 
-    await OAuth2AuthorizationService.completeCallback(
-      {
-        applicationId,
-        code,
-        state,
-      },
-      env,
-    );
+    try {
+      await OAuth2AuthorizationService.completeCallback(
+        {
+          applicationId,
+          code,
+          state,
+        },
+        env,
+      );
+    } catch (error: unknown) {
+      const message = error instanceof Error ? error.message : 'OAuth2 authorization failed.';
+      return this.redirect(`/user/?oauth2=error&message=${encodeURIComponent(message)}`);
+    }
     return this.redirect(`/user/?oauth2=connected&applicationId=${encodeURIComponent(applicationId)}`);
   }
 

--- a/apps/background/src/OAuth2TokenRefreshWorker.ts
+++ b/apps/background/src/OAuth2TokenRefreshWorker.ts
@@ -9,7 +9,7 @@ import { ConnectedApplicationDAO, OAuth2AccessTokenCacheDAO, OAuth2AccessTokenRe
 import { createD1SessionEnv } from '@mail-otter/backend-data/utils';
 import type { ConnectedApplication, OAuth2Credentials } from '@mail-otter/shared/model';
 import { TimestampUtil } from '@mail-otter/shared/utils';
-import { BadRequestError } from '@mail-otter/backend-errors';
+import { BadRequestError, ProviderApiNonRetryableError } from '@mail-otter/backend-errors';
 import { ConfigurationManager } from '@mail-otter/backend-runtime/config';
 import { GmailProviderUtil } from '@mail-otter/provider-clients/gmail';
 import { OAuth2ProviderUtil } from '@mail-otter/provider-clients/oauth2';
@@ -58,7 +58,7 @@ class OAuth2TokenRefreshWorker extends AbstractDurableObjectWorker {
           : await this.runExclusive((): Promise<OAuth2TokenWorkerResponse> => this.exchangeCode(payload as OAuth2TokenExchangeRequest));
       return Response.json(result);
     } catch (error: unknown) {
-      const status: number = error instanceof BadRequestError ? 400 : 500;
+      const status: number = error instanceof BadRequestError || error instanceof ProviderApiNonRetryableError ? 400 : 500;
       const message: string = error instanceof Error ? error.message : String(error);
       if (status >= 500) console.error('OAuth2 token operation failed:', error);
       return Response.json({ error: message }, { status });


### PR DESCRIPTION
When the OAuth2 callback fails (e.g. Gmail API not enabled in GCP), the callback endpoint now catches the error and redirects to /user/?oauth2=error&message=... rather than letting it fall through to IBaseRoute.toErrorResponse(), which returned a raw JSON 500 page to the browser.

Also classifies ProviderApiNonRetryableError as a 4xx response in the OAuth2TokenRefreshWorker so provider-side config errors (403, 404, etc.) propagate as OAuth2TokenNonRetryableError (non-retryable) instead of the retryable variant, and are no longer logged at error level in the DO worker.