### PR TITLE
Add WRANGLER_PATCH_JSON Top-Level Config Override

### DIFF
--- a/.github/workflows/continuous-deployment.yml
+++ b/.github/workflows/continuous-deployment.yml
@@ -54,6 +54,7 @@ jobs:
           max_attempts: '3'
         env:
           WRANGLER_JSONC: ${{ vars.WRANGLER_JSONC }}
+          WRANGLER_PATCH_JSON: ${{ vars.WRANGLER_PATCH_JSON }}
           WRANGLER_VARS_PATCH_JSON: ${{ vars.WRANGLER_VARS_PATCH_JSON }}
           CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
           CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}

--- a/scripts/prepare-wrangler-config.ts
+++ b/scripts/prepare-wrangler-config.ts
@@ -81,6 +81,43 @@ function writeConfigValue(content: string, path: Array<string | number>, value: 
   return applyEdits(content, edits);
 }
 
+function parseTopLevelPatch(): Record<string, unknown> | undefined {
+  const rawPatch = process.env.WRANGLER_PATCH_JSON;
+  if (!rawPatch?.trim()) {
+    return undefined;
+  }
+
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(rawPatch) as unknown;
+  } catch {
+    throw new Error('WRANGLER_PATCH_JSON must be a valid JSON object.');
+  }
+
+  if (!parsed || typeof parsed !== 'object' || Array.isArray(parsed)) {
+    throw new Error('WRANGLER_PATCH_JSON must be a JSON object.');
+  }
+
+  return parsed as Record<string, unknown>;
+}
+
+function applyTopLevelPatch(): void {
+  const patch = parseTopLevelPatch();
+  const patchEntries = Object.entries(patch ?? {});
+  if (patchEntries.length === 0) {
+    return;
+  }
+
+  let { content } = readConfig();
+
+  for (const [key, value] of patchEntries) {
+    content = writeConfigValue(content, [key], value);
+  }
+
+  writeFileSync(CONFIG_PATH, content.endsWith('\n') ? content : `${content}\n`);
+  console.log(`Applied ${patchEntries.length} Wrangler top-level patch entr${patchEntries.length === 1 ? 'y' : 'ies'}.`);
+}
+
 function parseVarsPatch(): Record<string, string> | undefined {
   const rawPatch = process.env.WRANGLER_VARS_PATCH_JSON;
   if (!rawPatch?.trim()) {
@@ -353,6 +390,7 @@ function provisionWranglerResources(): void {
 }
 
 prepareConfigFile();
+applyTopLevelPatch();
 applyVarsPatch();
 provisionWranglerResources();
 console.log('Wrangler configuration is ready.');


### PR DESCRIPTION
Introduce a `WRANGLER_PATCH_JSON` GitHub repository variable that lets deployers override arbitrary top-level wrangler config fields (e.g. `name`, `routes`, `placement`, `triggers`) without supplying an entire `WRANGLER_JSONC` dump. The patch is applied after the config file is written from `WRANGLER_JSONC` or the template, and before `WRANGLER_VARS_PATCH_JSON`, so the existing vars mechanism still wins for individual `vars` keys. Each entry in the JSON object replaces the corresponding top-level field in the config.