### PR TITLE
Gracefully skip deleted Gmail messages instead of retrying

### DIFF
--- a/packages/backend-services/src/email/EmailProcessingUtil.ts
+++ b/packages/backend-services/src/email/EmailProcessingUtil.ts
@@ -102,7 +102,22 @@ class EmailProcessingUtil {
     enabledApplicationIds: string[],
     options: EmailProcessingOptions = {},
   ): Promise<GmailSummaryData | null> {
-    const message: GmailMessage = await GmailProviderUtil.getMessage(accessToken, messageId);
+    const contextDAO = new ApplicationContextDAO(env.DB);
+    const processedDAO = new ProcessedMessageDAO(env.DB);
+    let message: GmailMessage;
+    try {
+      message = await GmailProviderUtil.getMessage(accessToken, messageId);
+    } catch (error: unknown) {
+      if (GmailProviderUtil.isMessageNotFoundError(error)) {
+        const started = await processedDAO.tryStart(application.applicationId, application.providerId, messageId, null, {
+          allowExistingForRetry: EmailProcessingUtil.isRetryAttempt(options),
+        });
+        if (!started) return null;
+        await processedDAO.markSkipped(application.applicationId, messageId, 'Gmail message was deleted before Mail-Otter could process it.');
+        return null;
+      }
+      throw error;
+    }
     const headers = message.payload?.headers;
     const subject: string = EmailContentUtil.getHeader(headers, 'Subject') || '(no subject)';
     const from: string = EmailContentUtil.getHeader(headers, 'From') || '';
@@ -110,8 +125,6 @@ class EmailProcessingUtil {
     const stableMessageFingerprint: string | null = await EmailProcessingUtil.getStableMessageFingerprint(
       env, application.providerId, EmailContentUtil.getHeader(headers, 'Message-ID'),
     );
-    const contextDAO = new ApplicationContextDAO(env.DB);
-    const processedDAO = new ProcessedMessageDAO(env.DB);
     if (isSummary || EmailContentUtil.isFromMailbox(from, application.providerEmail)) return null;
     const started: boolean = await processedDAO.tryStart(application.applicationId, application.providerId, message.id, message.threadId, {
       allowExistingForRetry: EmailProcessingUtil.isRetryAttempt(options),

--- a/packages/provider-clients/src/GmailProviderUtil.ts
+++ b/packages/provider-clients/src/GmailProviderUtil.ts
@@ -50,6 +50,8 @@ interface GmailDraftReplyResult {
 }
 
 class GmailProviderUtil {
+  private static readonly MESSAGE_NOT_FOUND_PATTERN: RegExp = /Gmail request failed \(404\)/;
+
   public static async getProfile(accessToken: string): Promise<GmailProfile> {
     return GmailProviderUtil.fetchJson<GmailProfile>('https://gmail.googleapis.com/gmail/v1/users/me/profile', accessToken);
   }
@@ -123,6 +125,11 @@ class GmailProviderUtil {
     const url: URL = new URL(`https://gmail.googleapis.com/gmail/v1/users/me/messages/${encodeURIComponent(messageId)}`);
     url.searchParams.set('format', 'FULL');
     return GmailProviderUtil.fetchJson<GmailMessage>(url.toString(), accessToken);
+  }
+
+  public static isMessageNotFoundError(error: unknown): boolean {
+    const message: string = error instanceof Error ? error.message : String(error);
+    return GmailProviderUtil.MESSAGE_NOT_FOUND_PATTERN.test(message);
   }
 
   public static async createCalendarEvent(accessToken: string, input: GmailCalendarEventInput): Promise<GmailCalendarEventResult> {


### PR DESCRIPTION
When a Gmail message is deleted before processing, the workflow step was retrying 5 times (30s exponential backoff) on 404 errors before failing. Mirror the existing Outlook pattern: detect 404 via isMessageNotFoundError(), mark the message as skipped, and return null so the workflow continues cleanly.