### PR TITLE
Remove Worker Trigger And Execution ID Logs

### DIFF
--- a/packages/backend-runtime/src/base/AbstractDurableObjectWorker.ts
+++ b/packages/backend-runtime/src/base/AbstractDurableObjectWorker.ts
@@ -5,15 +5,7 @@ type DurableObjectFetchResult = ReturnType<NonNullable<DurableObject<Env>['fetch
 type DurableObjectFetchResponse = Awaited<DurableObjectFetchResult>;
 
 abstract class AbstractDurableObjectWorker extends DurableObject<Env> {
-  protected printExecId(): string {
-    const execId: string = crypto.randomUUID();
-    console.log('Durable Object Execution ID:', execId);
-    return execId;
-  }
-
   public fetch(request: DurableObjectFetchRequest): DurableObjectFetchResult {
-    this.printExecId();
-    console.log('Durable Object triggered by HTTP request');
     return this.onRequest(request).catch((err: unknown): DurableObjectFetchResponse => {
       console.error('Unhandled error in durable object fetch():', err);
       return Response.json({ error: 'Internal Error' }, { status: 500 }) as DurableObjectFetchResponse;

--- a/packages/backend-runtime/src/base/AbstractEntrypointWorker.ts
+++ b/packages/backend-runtime/src/base/AbstractEntrypointWorker.ts
@@ -1,10 +1,4 @@
 abstract class AbstractEntrypointWorker {
-  protected printExecId(): string {
-    const execId: string = crypto.randomUUID();
-    console.log('Worker Execution ID:', execId);
-    return execId;
-  }
-
   public async fetch(request: Request, env: Env, ctx: ExecutionContext): Promise<Response> {
     const url: URL = new URL(request.url);
     if ('/__scheduled' === url.pathname) {
@@ -20,8 +14,6 @@ abstract class AbstractEntrypointWorker {
       return new Response(null, { status: 204 });
     }
 
-    this.printExecId();
-    console.log('Worker triggered by HTTP request');
     try {
       return await this.onRequest(request, env, ctx);
     } catch (err: unknown) {
@@ -31,8 +23,6 @@ abstract class AbstractEntrypointWorker {
   }
 
   public async scheduled(event: ScheduledController, env: Env, ctx: ExecutionContext): Promise<void> {
-    this.printExecId();
-    console.log('Worker triggered by Cron schedule');
     try {
       await this.onScheduled(event, env, ctx);
     } catch (err: unknown) {

--- a/packages/backend-runtime/src/base/AbstractQueueWorker.ts
+++ b/packages/backend-runtime/src/base/AbstractQueueWorker.ts
@@ -1,13 +1,5 @@
 abstract class AbstractQueueWorker {
-  protected printExecId(): string {
-    const execId: string = crypto.randomUUID();
-    console.log('Worker Execution ID:', execId);
-    return execId;
-  }
-
   public async queue(batch: MessageBatch<unknown>, env: Env, ctx: ExecutionContext): Promise<void> {
-    this.printExecId();
-    console.log('Worker triggered by Queue batch');
     try {
       await this.onQueue(batch, env, ctx);
     } catch (err: unknown) {

--- a/packages/backend-runtime/src/base/AbstractWorkflowWorker.ts
+++ b/packages/backend-runtime/src/base/AbstractWorkflowWorker.ts
@@ -5,15 +5,7 @@ abstract class AbstractWorkflowWorker<
   TPayload extends Rpc.Serializable<TPayload>,
   TResult extends Rpc.Serializable<TResult>,
 > extends WorkflowEntrypoint<Env, TPayload> {
-  protected printExecId(): string {
-    const execId: string = crypto.randomUUID();
-    console.log('Workflow Execution ID:', execId);
-    return execId;
-  }
-
   public async run(event: Readonly<WorkflowEvent<TPayload>>, step: WorkflowStep): Promise<TResult> {
-    this.printExecId();
-    console.log('Worker triggered by Workflow instance:', event.instanceId);
     try {
       return await this.onWorkflow(event, step);
     } catch (err: unknown) {


### PR DESCRIPTION
Drop the `printExecId()` helper and all companion "triggered by" console.log lines from the four abstract base workers (Entrypoint, DurableObject, Queue, Workflow). The logs added no diagnostic value — the random UUID was never correlated with anything, and the trigger-type string is already implicit from context. Removing them reduces noise in production log streams.