### PR TITLE
Pass real applicationId into notificationUrl registered with Microsoft Graph

### DIFF
--- a/packages/backend-services/src/provider/IEmailProvider.ts
+++ b/packages/backend-services/src/provider/IEmailProvider.ts
@@ -24,6 +24,7 @@ type AnyProviderCredentials = ProviderCredentials | ImapProviderCredentials;
 
 interface StartWatchInput {
   baseUrl: string;
+  applicationId?: string | undefined;
   watchedFolderIds?: string[] | undefined;
   gmailPubsubTopicName?: string | undefined;
   clientState?: string | undefined;

--- a/packages/backend-services/src/provider/OutlookEmailProvider.ts
+++ b/packages/backend-services/src/provider/OutlookEmailProvider.ts
@@ -32,8 +32,9 @@ class OutlookEmailProvider implements IEmailProvider {
     if (credentials.type !== 'oauth2') throw new BadRequestError('Outlook requires OAuth2 credentials.');
     if (!input.clientState) throw new BadRequestError('clientState is required to start an Outlook subscription.');
     if (!input.expiresAt) throw new BadRequestError('expiresAt is required to start an Outlook subscription.');
-    const notificationUrl = `${input.baseUrl}/api/webhooks/outlook/__APPLICATION_ID__`;
-    const lifecycleNotificationUrl = `${input.baseUrl}/api/webhooks/outlook/lifecycle/__APPLICATION_ID__`;
+    const appId = input.applicationId ?? '__APPLICATION_ID__';
+    const notificationUrl = `${input.baseUrl}/api/webhooks/outlook/${appId}`;
+    const lifecycleNotificationUrl = `${input.baseUrl}/api/webhooks/outlook/lifecycle/${appId}`;
     const graphSubscription = await OutlookProviderUtil.createInboxSubscription(
       credentials.accessToken,
       notificationUrl,

--- a/packages/backend-services/src/subscription/WatchService.ts
+++ b/packages/backend-services/src/subscription/WatchService.ts
@@ -37,6 +37,7 @@ class WatchService {
 
     const result = await provider.startWatch(credentials, {
       baseUrl,
+      applicationId,
       watchedFolderIds: application.watchedFolders?.map((f) => f.id),
       gmailPubsubTopicName: application.gmailPubsubTopicName ?? undefined,
       clientState,

--- a/test/services/WatchService.test.ts
+++ b/test/services/WatchService.test.ts
@@ -138,6 +138,14 @@ describe('WatchService', () => {
 
       expect(result.message).toContain('Outlook subscription started');
       expect(result.webhookUrl).toContain('/api/webhooks/outlook/app-1');
+      expect(OutlookProviderUtil.createInboxSubscription).toHaveBeenCalledWith(
+        expect.any(String),
+        expect.stringContaining('/api/webhooks/outlook/app-1'),
+        expect.stringContaining('/api/webhooks/outlook/lifecycle/app-1'),
+        expect.any(String),
+        expect.any(Number),
+        undefined,
+      );
     });
 
     it('throws when application not connected', async () => {


### PR DESCRIPTION
The placeholder __APPLICATION_ID__ was being sent verbatim to Microsoft Graph as the notificationUrl, so when Graph called the webhook the router extracted __APPLICATION_ID__ as the applicationId param. This caused getAuthorizedSubscription to reject every notification with "Unknown Outlook subscription" because the stored applicationId (a real UUID) never matched.

Fix: add applicationId to StartWatchInput, thread it through WatchService into OutlookEmailProvider.startWatch, and use it when building the URLs passed to createInboxSubscription.