### PR TITLE
Retry OAuth2 Token Errors And Log Non-Retryable Failures

### DIFF
--- a/apps/background/src/EmailProcessingWorkflow.ts
+++ b/apps/background/src/EmailProcessingWorkflow.ts
@@ -1,6 +1,6 @@
 import { AbstractWorkflowWorker } from '@mail-otter/backend-runtime/base';
 import { createD1SessionEnv } from '@mail-otter/backend-data/utils';
-import { DatabaseError, NonRetryableError, RetryableError } from '@mail-otter/backend-errors';
+import { DatabaseError, NonRetryableError, OAuth2TokenNonRetryableError, RetryableError } from '@mail-otter/backend-errors';
 import { EmailProcessingUtil } from '@mail-otter/backend-services/email';
 import type { GmailMessageList, GmailSummaryData, ImapSummaryData, JmapSummaryData, OutlookSummaryData, ResolvedApplication } from '@mail-otter/backend-services/email';
 import { IntegrationService } from '@mail-otter/backend-services/integration';
@@ -287,7 +287,14 @@ class EmailProcessingWorkflow extends AbstractWorkflowWorker<EmailQueueMessage, 
   }
 
   private static toWorkflowError(error: unknown): Error {
+    // OAuth2 4xx from the Durable Object can be transient (cold-start, network hiccup);
+    // let the step's configured retry policy handle it rather than killing the workflow immediately.
+    if (error instanceof OAuth2TokenNonRetryableError) {
+      console.error('[Workflow] OAuth2 token error (will retry via step policy):', error.message);
+      return new RetryableError(error.message);
+    }
     if (error instanceof NonRetryableError) {
+      console.error('[Workflow] Non-retryable error (permanent failure):', error.constructor.name, error.message);
       return new WorkflowNonRetryableError(error.message, error.name);
     }
     if (error instanceof RetryableError) {
@@ -295,6 +302,7 @@ class EmailProcessingWorkflow extends AbstractWorkflowWorker<EmailQueueMessage, 
     }
     if (error instanceof DatabaseError) {
       if (!error.retryable) {
+        console.error('[Workflow] Non-retryable database error (permanent failure):', error.message);
         return new WorkflowNonRetryableError(error.message, 'DatabaseError');
       }
       return new RetryableError(error.message);


### PR DESCRIPTION
Previously, `OAuth2TokenNonRetryableError` (a subclass of `NonRetryableError`) was immediately converted to `WorkflowNonRetryableError`, killing the workflow instance with no retries. A transient Durable Object failure — cold-start, network hiccup, or brief provider blip — could permanently stop email processing for all mailboxes.

This change intercepts `OAuth2TokenNonRetryableError` before the general `NonRetryableError` branch and converts it to `RetryableError` instead, so the step's configured retry policy (3 attempts, 30 s exponential backoff in `Resolve Application`) gets a chance to recover transient failures.

Genuine permanent failures (revoked refresh token, application not found) will still exhaust all retries and fail, but the tail logs now include structured `[Workflow]` messages for every non-retryable path, making the root cause visible without requiring a Workflows instance trace.