### PR TITLE
OOP Maintainability Refactoring (Phases 4)

### DIFF
--- a/apps/web/src/SpaApp.tsx
+++ b/apps/web/src/SpaApp.tsx
@@ -21,6 +21,7 @@ import { useActions } from './hooks/useActions';
 import { useAuditLogs } from './hooks/useAuditLogs';
 import { useAnalytics } from './hooks/useAnalytics';
 import { getUrlParam, useSyncedUrl } from './hooks/useSyncedUrl';
+import { useMailboxCallbacksValue } from './hooks/useMailboxCallbacksValue';
 import type { ApplicationContextDocumentStatus, EmailActionStatus } from '../components/types';
 
 // Read URL params synchronously before first render so useState initializers can use them
@@ -113,43 +114,7 @@ export default function SpaApp() {
 
   if (!authorized || !user) return <Unauthorized />;
 
-  // Mailbox callbacks object — stable per interaction (recreated when isBusy or selectedApplication change)
-  const mailboxCallbacksValue = {
-    busy: isBusy,
-    onEdit: mailboxes.editApplication,
-    onDelete: () => {
-      if (mailboxes.selectedApplication) {
-        mailboxes.setConfirmDelete({
-          applicationId: mailboxes.selectedApplication.applicationId,
-          displayName: mailboxes.selectedApplication.displayName,
-        });
-      }
-    },
-    onStartOAuth2: mailboxes.startOAuth2,
-    onStartWatch: mailboxes.startWatch,
-    onStopWatch: mailboxes.stopWatch,
-    onLoadFolders: mailboxes.loadFolders,
-    onUpdateWatchedFolders: mailboxes.updateWatchedFolderIds,
-    onUpdateSenderFilters: mailboxes.updateSenderFilters,
-    onUpdateContextIndexing: mailboxes.updateContextIndexing,
-    onUpdateMaxContextDocuments: mailboxes.updateMaxContextDocuments,
-    onOpenContextAudit: (id: string) => { contextAudit.setAuditApplicationId(id); setActiveView('context'); },
-    onDeleteContextDocuments: mailboxes.deleteContextDocuments,
-    onDismissProcessingError: (id: string) => mailboxes.dismissError(id, 'processing'),
-    onDismissContextError: (id: string) => mailboxes.dismissError(id, 'context'),
-    integrationsByApplicationId: mailboxes.integrationsByApplicationId,
-    loadingIntegrations: mailboxes.loadingIntegrations,
-    onLoadIntegrations: mailboxes.loadIntegrations,
-    onCreateIntegration: mailboxes.createIntegration,
-    onUpdateIntegration: mailboxes.updateIntegration,
-    onDeleteIntegration: async (integrationId: string) => {
-      const allIntegrations = Object.values(mailboxes.integrationsByApplicationId).flat();
-      const found = allIntegrations.find((i) => i.integrationId === integrationId);
-      if (found) await mailboxes.deleteIntegration(integrationId, found.applicationId);
-    },
-    onTestIntegration: mailboxes.testIntegration,
-    onUpdateRules: mailboxes.updateRules,
-  };
+  const mailboxCallbacksValue = useMailboxCallbacksValue(mailboxes, contextAudit, isBusy, setActiveView);
 
   return (
     <NoticeContext.Provider value={{ showNotice }}>

--- a/apps/web/src/components/views/AnalyticsView.tsx
+++ b/apps/web/src/components/views/AnalyticsView.tsx
@@ -48,7 +48,7 @@ export function AnalyticsView({
       <div className="flex flex-col sm:flex-row sm:items-end justify-between gap-4">
         <div>
           <h1 className="text-xl font-semibold text-[var(--color-text-primary)]">Analytics</h1>
-          <p className="mt-1 text-sm text-[var(--color-text-muted)]">Usage trends and processing stats</p>
+          <p className="mt-1 text-sm text-[var(--color-text-muted)]">Usage Trends And Processing Stats</p>
         </div>
         <Button variant="secondary" size="sm" onClick={onRefresh} loading={loading}>
           <RefreshCw className="h-3.5 w-3.5" />

--- a/apps/web/src/components/views/MailboxesView.tsx
+++ b/apps/web/src/components/views/MailboxesView.tsx
@@ -1,3 +1,4 @@
+import { useMemo } from 'react';
 import type { ConnectedApplication } from '../../../components/types';
 import { MailboxCard } from '../mailboxes/MailboxCard';
 import { MailboxDetail } from '../mailboxes/MailboxDetail';
@@ -36,7 +37,10 @@ export function MailboxesView({
 }) {
   const user = useCurrentUserData();
   const { busy } = useMailboxCallbacks();
-  const selectedApplication = applications.find((a) => a.applicationId === selectedApplicationId);
+  const selectedApplication = useMemo(
+    () => applications.find((a) => a.applicationId === selectedApplicationId),
+    [applications, selectedApplicationId],
+  );
 
   return (
     <main className="max-w-7xl mx-auto px-6 py-8 grid grid-cols-1 lg:grid-cols-[340px_minmax(0,1fr)] gap-6 animate-fade-in-up">

--- a/apps/web/src/hooks/useMailboxCallbacksValue.ts
+++ b/apps/web/src/hooks/useMailboxCallbacksValue.ts
@@ -1,0 +1,54 @@
+import type { ActiveView } from '../types';
+import type { MailboxCallbacksContextValue } from '../contexts/MailboxCallbacksContext';
+import type { useMailboxes } from './useMailboxes';
+import type { useContextAudit } from './useContextAudit';
+
+type MailboxesHook = ReturnType<typeof useMailboxes>;
+type ContextAuditHook = ReturnType<typeof useContextAudit>;
+
+export function useMailboxCallbacksValue(
+  mailboxes: MailboxesHook,
+  contextAudit: ContextAuditHook,
+  isBusy: boolean,
+  setActiveView: (view: ActiveView) => void,
+): MailboxCallbacksContextValue {
+  return {
+    busy: isBusy,
+    onEdit: mailboxes.editApplication,
+    onDelete: () => {
+      if (mailboxes.selectedApplication) {
+        mailboxes.setConfirmDelete({
+          applicationId: mailboxes.selectedApplication.applicationId,
+          displayName: mailboxes.selectedApplication.displayName,
+        });
+      }
+    },
+    onStartOAuth2: mailboxes.startOAuth2,
+    onStartWatch: mailboxes.startWatch,
+    onStopWatch: mailboxes.stopWatch,
+    onLoadFolders: mailboxes.loadFolders,
+    onUpdateWatchedFolders: mailboxes.updateWatchedFolderIds,
+    onUpdateSenderFilters: mailboxes.updateSenderFilters,
+    onUpdateContextIndexing: mailboxes.updateContextIndexing,
+    onUpdateMaxContextDocuments: mailboxes.updateMaxContextDocuments,
+    onOpenContextAudit: (id: string) => {
+      contextAudit.setAuditApplicationId(id);
+      setActiveView('context');
+    },
+    onDeleteContextDocuments: mailboxes.deleteContextDocuments,
+    onDismissProcessingError: (id: string) => mailboxes.dismissError(id, 'processing'),
+    onDismissContextError: (id: string) => mailboxes.dismissError(id, 'context'),
+    integrationsByApplicationId: mailboxes.integrationsByApplicationId,
+    loadingIntegrations: mailboxes.loadingIntegrations,
+    onLoadIntegrations: mailboxes.loadIntegrations,
+    onCreateIntegration: mailboxes.createIntegration,
+    onUpdateIntegration: mailboxes.updateIntegration,
+    onDeleteIntegration: async (integrationId: string) => {
+      const allIntegrations = Object.values(mailboxes.integrationsByApplicationId).flat();
+      const found = allIntegrations.find((i) => i.integrationId === integrationId);
+      if (found) await mailboxes.deleteIntegration(integrationId, found.applicationId);
+    },
+    onTestIntegration: mailboxes.testIntegration,
+    onUpdateRules: mailboxes.updateRules,
+  };
+}


### PR DESCRIPTION
- Extract `useMailboxCallbacksValue` hook from `SpaApp.tsx`: the 35-line inline `mailboxCallbacksValue` construction is moved to `apps/web/src/hooks/useMailboxCallbacksValue.ts`, decoupling callback wiring from render logic and making `SpaApp` significantly shorter.
- Fix Title Case violation in `AnalyticsView`: subtitle was "Usage trends and processing stats"; corrected to "Usage Trends And Processing Stats" per CLAUDE.md convention.
- Memoize `selectedApplication` in `MailboxesView`: wrapped the `applications.find()` call in `useMemo` to avoid recomputing on every render.