### PR TITLE
Skip Unconfigured Destinations

### DIFF
--- a/.github/workflows/backup-main.yml
+++ b/.github/workflows/backup-main.yml
@@ -25,17 +25,40 @@ jobs:
             name: GitLab
 
     steps:
+      - name: Check Destination Configuration
+        id: check-config
+        run: |
+          case "${{ matrix.destination.id }}" in
+            azure-devops)
+              if [ -n "${{ secrets.BACKUP_REPO_AZURE_DEVOPS_SSH_KEY }}" ] && [ -n "${{ secrets.BACKUP_REPO_AZURE_DEVOPS_REPO_URL }}" ]; then
+                echo "configured=true" >> $GITHUB_OUTPUT
+              else
+                echo "configured=false" >> $GITHUB_OUTPUT
+              fi
+              ;;
+            gitlab)
+              if [ -n "${{ secrets.BACKUP_REPO_GITLAB_SSH_KEY }}" ] && [ -n "${{ secrets.BACKUP_REPO_GITLAB_REPO_URL }}" ]; then
+                echo "configured=true" >> $GITHUB_OUTPUT
+              else
+                echo "configured=false" >> $GITHUB_OUTPUT
+              fi
+              ;;
+          esac
+
       - name: Checkout Source Repository
+        if: steps.check-config.outputs.configured == 'true'
         uses: actions/checkout@v6
         with:
           fetch-depth: 0
 
       - name: Configure Git
+        if: steps.check-config.outputs.configured == 'true'
         run: |
           git config user.name "Actions"
           git config user.email "actions@github.com"
 
       - name: Set Up SSH for ${{ matrix.destination.name }}
+        if: steps.check-config.outputs.configured == 'true'
         run: |
           mkdir -p ~/.ssh
           case "${{ matrix.destination.id }}" in
@@ -54,9 +77,11 @@ jobs:
           ssh-add ~/.ssh/id_rsa
 
       - name: Add SSH Remote
+        if: steps.check-config.outputs.configured == 'true'
         run: git remote add backup "${REMOTE_URL}"
 
       - name: Push main Branch to ${{ matrix.destination.name }}
+        if: steps.check-config.outputs.configured == 'true'
         uses: ./.github/actions/retry-step
         with:
           command: git push --force backup main:main


### PR DESCRIPTION
Add a Check Destination Configuration step as the first step in the matrix job. It inspects the secrets for the current destination and writes a `configured` step output. All subsequent steps are gated on `steps.check-config.outputs.configured == 'true'`, so a destination whose SSH key or repo URL is absent is silently skipped rather than causing the job to fail.