### PR TITLE
Gate Dependabot Auto-Merge On Integration Tests

### DIFF
--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -124,6 +124,7 @@ jobs:
     name: Auto-Merge Dependabot PR
     needs:
       - checks
+      - integration-tests
       - build
     permissions:
       contents: write


### PR DESCRIPTION
Add `integration-tests` to the `needs` list of the `dependabot-auto-merge` job so that Dependabot PRs are not auto-merged until integration tests pass, in addition to the existing `checks` and `build` gates.