### PR TITLE
Gate Upstream Sync Dispatch On Integration Tests

### DIFF
--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -149,6 +149,7 @@ jobs:
     name: Dispatch Upstream Sync Deployment
     needs:
       - checks
+      - integration-tests
       - build
     permissions:
       contents: write


### PR DESCRIPTION
Add `integration-tests` to the `needs` list of `dispatch-upstream-sync-deployment` so it is consistent with `dependabot-auto-merge` — both downstream action jobs now require all three gates (checks, integration-tests, build) before firing.