### PR TITLE
Allow Editing AI-Suggested Rules Before Saving

### DIFF
--- a/apps/web/src/components/mailboxes/RulesSection.tsx
+++ b/apps/web/src/components/mailboxes/RulesSection.tsx
@@ -235,6 +235,7 @@ type SuggestState =
   | { phase: 'idle' }
   | { phase: 'loading' }
   | { phase: 'preview'; rule: Omit<EmailProcessingRule, 'ruleId'>; description: string }
+  | { phase: 'edit'; rule: EmailProcessingRule; description: string }
   | { phase: 'error'; message: string; description: string };
 
 function SuggestRuleForm({
@@ -275,6 +276,19 @@ function SuggestRuleForm({
     if (state.phase !== 'preview') return;
     onAdd({ ...state.rule, ruleId: crypto.randomUUID() });
   };
+
+  if (state.phase === 'edit') {
+    return (
+      <RuleForm
+        initialRule={state.rule}
+        onAdd={onAdd}
+        onCancel={() => {
+          const { ruleId: _, ...ruleWithoutId } = state.rule;
+          setState({ phase: 'preview', rule: ruleWithoutId, description: state.description });
+        }}
+      />
+    );
+  }
 
   return (
     <div className="border border-[var(--color-border)] rounded-lg p-4 flex flex-col gap-3 bg-[var(--color-surface-raised)]">
@@ -329,6 +343,7 @@ function SuggestRuleForm({
         {state.phase === 'preview' && (
           <>
             <Button variant="secondary" size="sm" onClick={handleRegenerate}>Regenerate</Button>
+            <Button variant="secondary" size="sm" onClick={() => setState({ phase: 'edit', rule: { ...state.rule, ruleId: crypto.randomUUID() }, description: state.description })}>Edit</Button>
             <Button variant="primary" size="sm" onClick={handleAccept}>Add Rule</Button>
           </>
         )}


### PR DESCRIPTION
Adds an edit phase to SuggestRuleForm so users can tweak the AI-generated rule before it is saved, rather than having to accept or reject it as-is.

- Extend SuggestState with an 'edit' phase that holds a full EmailProcessingRule (with a temporary ruleId assigned on entry)
- Add 'Edit' button in the preview footer between Regenerate and Add Rule; transitions to the new edit phase
- When phase === 'edit', render RuleForm pre-populated with the suggestion; cancel returns to the static preview so the user can still regenerate; save calls onAdd directly (same path as accepting without edits)