### PR TITLE
Add Missing Fields To UpdateApplicationBodySchema

### DIFF
--- a/packages/shared/src/schema/input.ts
+++ b/packages/shared/src/schema/input.ts
@@ -41,6 +41,14 @@ const UpdateApplicationBodySchema = z
       })
       .optional()
       .nullable(),
+    timeZone: z.string().max(64).optional().nullable(),
+    autoExecuteActionTypes: z.array(z.string()).optional().nullable(),
+    imapHost: z.string().max(253).optional(),
+    imapPort: z.number().int().min(1).max(65535).optional(),
+    imapUsername: z.string().max(512).optional(),
+    imapPassword: z.string().max(2048).optional(),
+    smtpHost: z.string().max(253).optional(),
+    smtpPort: z.number().int().min(1).max(65535).optional(),
   })
   .refine(
     (input): boolean =>

--- a/test/schema/RequestValidation.test.ts
+++ b/test/schema/RequestValidation.test.ts
@@ -64,6 +64,35 @@ describe('Request input schemas', () => {
     ).resolves.toMatchObject({ success: false, scope: 'body' });
   });
 
+  it('passes autoExecuteActionTypes through PUT /user/application schema', async () => {
+    const request = new Request('https://mail.example.com/user/application', { method: 'PUT' });
+    const result = await validateRequestInput(request, {
+      applicationId: '11111111-1111-4111-8111-111111111111',
+      displayName: 'Outlook inbox',
+      providerId: 'microsoft-outlook',
+      connectionMethod: 'oauth2',
+      autoExecuteActionTypes: ['delivery.track_package', 'manual.todo'],
+    });
+    expect(result).toMatchObject({ success: true });
+    expect((result as { success: true; data: Record<string, unknown> }).data.autoExecuteActionTypes).toEqual([
+      'delivery.track_package',
+      'manual.todo',
+    ]);
+  });
+
+  it('passes timeZone through PUT /user/application schema', async () => {
+    const request = new Request('https://mail.example.com/user/application', { method: 'PUT' });
+    const result = await validateRequestInput(request, {
+      applicationId: '11111111-1111-4111-8111-111111111111',
+      displayName: 'Outlook inbox',
+      providerId: 'microsoft-outlook',
+      connectionMethod: 'oauth2',
+      timeZone: 'America/New_York',
+    });
+    expect(result).toMatchObject({ success: true });
+    expect((result as { success: true; data: Record<string, unknown> }).data.timeZone).toBe('America/New_York');
+  });
+
   it('rejects unsupported providers', async () => {
     const request = new Request('https://mail.example.com/user/application', { method: 'POST' });
 


### PR DESCRIPTION
`UpdateApplicationBodySchema` was missing several fields that the handler accepts and the frontend sends: `timeZone`, `autoExecuteActionTypes`, and the IMAP/SMTP config fields (`imapHost`, `imapPort`, `imapUsername`, `imapPassword`, `smtpHost`, `smtpPort`).

Zod strips unknown keys by default, so these values were silently dropped during `validateRequestInput` before reaching the handler. The DAO received `undefined` for each and treated it as "don't modify," meaning saves were no-ops and the response always returned stale/null values.

Adds regression tests confirming `autoExecuteActionTypes` and `timeZone` pass through the schema rather than being stripped.