### PR TITLE
Hide Webhook Endpoint For Outlook Mailboxes

### DIFF
--- a/apps/web/src/components/mailboxes/MailboxDetail.tsx
+++ b/apps/web/src/components/mailboxes/MailboxDetail.tsx
@@ -52,7 +52,9 @@ export function MailboxDetail({
           {application.providerId === 'google-gmail' && (
             <ReadOnlyField label="Gmail Pub/Sub Topic" value={application.gmailPubsubTopicName || ''} />
           )}
-          <ReadOnlyField label="Webhook Endpoint" value={watchWebhookUrl || application.webhookUrl || ''} showCopy />
+          {application.providerId !== 'microsoft-outlook' && (
+            <ReadOnlyField label="Webhook Endpoint" value={watchWebhookUrl || application.webhookUrl || ''} showCopy />
+          )}
         </div>
 
         <div className="mt-5 flex flex-wrap gap-2">


### PR DESCRIPTION
The webhook endpoint URL is not useful for Outlook mailboxes because push notifications are registered automatically via Microsoft Graph API, unlike Gmail where the user must manually configure a Pub/Sub push subscription using the URL.

Hiding it reduces UI noise for Outlook users.