### PR TITLE
Whitelist Webhook Endpoint To Gmail Only

### DIFF
--- a/apps/web/src/components/mailboxes/MailboxDetail.tsx
+++ b/apps/web/src/components/mailboxes/MailboxDetail.tsx
@@ -52,7 +52,7 @@ export function MailboxDetail({
           {application.providerId === 'google-gmail' && (
             <ReadOnlyField label="Gmail Pub/Sub Topic" value={application.gmailPubsubTopicName || ''} />
           )}
-          {application.providerId !== 'microsoft-outlook' && (
+          {application.providerId === 'google-gmail' && (
             <ReadOnlyField label="Webhook Endpoint" value={watchWebhookUrl || application.webhookUrl || ''} showCopy />
           )}
         </div>


### PR DESCRIPTION
Only Gmail requires the webhook URL to be shown in the UI because users must manually configure a Pub/Sub push subscription in Google Cloud Console. All other providers (Outlook OAuth2, Fastmail JMAP, and all IMAP-based providers) handle webhook registration automatically or don't use webhooks at all.

Inverting the condition from a blacklist (hide for Outlook) to a whitelist (show only for Gmail) is cleaner and avoids needing to maintain an exclusion list as new providers are added.