### PR TITLE
Remove Double D1 Session Wrap In Digest Endpoints

### DIFF
--- a/apps/api/src/endpoints/user/application/digest/GET.ts
+++ b/apps/api/src/endpoints/user/application/digest/GET.ts
@@ -1,7 +1,6 @@
 import { IUserRoute } from '@/endpoints/IUserRoute';
 import type { IUserEnv, IRequest, IResponse, RouteContext } from '@/endpoints/IUserRoute';
 import { ConnectedApplicationDAO } from '@mail-otter/backend-data/dao';
-import { createD1SessionEnv } from '@mail-otter/backend-data/utils';
 import { DigestConfigService } from '@mail-otter/backend-services/digest';
 import type { DigestConfig } from '@mail-otter/shared/model';
 
@@ -22,9 +21,8 @@ class GetDigestConfigRoute extends IUserRoute<GetDigestConfigRequest, GetDigestC
     cxt: RouteContext<GetDigestConfigEnv>,
   ): Promise<GetDigestConfigResponse> {
     const userEmail = this.getAuthenticatedUserEmailAddress(cxt);
-    const sessionEnv = createD1SessionEnv(env);
     const masterKey: string = await env.AES_ENCRYPTION_KEY_SECRET.get();
-    const applicationDAO = new ConnectedApplicationDAO(sessionEnv.DB, masterKey);
+    const applicationDAO = new ConnectedApplicationDAO(env.DB, masterKey);
 
     await applicationDAO.getByIdForUser(request.applicationId, userEmail);
 

--- a/apps/api/src/endpoints/user/application/digest/PUT.ts
+++ b/apps/api/src/endpoints/user/application/digest/PUT.ts
@@ -1,7 +1,6 @@
 import { IUserRoute } from '@/endpoints/IUserRoute';
 import type { IUserEnv, IRequest, IResponse, RouteContext } from '@/endpoints/IUserRoute';
 import { ConnectedApplicationDAO } from '@mail-otter/backend-data/dao';
-import { createD1SessionEnv } from '@mail-otter/backend-data/utils';
 import { BadRequestError } from '@mail-otter/backend-errors';
 import { DigestConfigService } from '@mail-otter/backend-services/digest';
 import type { DigestConfig } from '@mail-otter/shared/model';
@@ -23,9 +22,8 @@ class UpdateDigestConfigRoute extends IUserRoute<UpdateDigestConfigRequest, Upda
     cxt: RouteContext<UpdateDigestConfigEnv>,
   ): Promise<UpdateDigestConfigResponse> {
     const userEmail = this.getAuthenticatedUserEmailAddress(cxt);
-    const sessionEnv = createD1SessionEnv(env);
     const masterKey: string = await env.AES_ENCRYPTION_KEY_SECRET.get();
-    const applicationDAO = new ConnectedApplicationDAO(sessionEnv.DB, masterKey);
+    const applicationDAO = new ConnectedApplicationDAO(env.DB, masterKey);
 
     const application = await applicationDAO.getByIdForUser(request.applicationId, userEmail);
     if (!application) throw new BadRequestError('Connected application not found.');

--- a/apps/api/src/endpoints/user/application/digest/send/POST.ts
+++ b/apps/api/src/endpoints/user/application/digest/send/POST.ts
@@ -1,7 +1,6 @@
 import { IUserRoute } from '@/endpoints/IUserRoute';
 import type { IUserEnv, IRequest, IResponse, RouteContext } from '@/endpoints/IUserRoute';
 import { ConnectedApplicationDAO } from '@mail-otter/backend-data/dao';
-import { createD1SessionEnv } from '@mail-otter/backend-data/utils';
 import { BadRequestError } from '@mail-otter/backend-errors';
 import { DigestService } from '@mail-otter/backend-services/digest';
 import { OAuth2AccessTokenService } from '@mail-otter/backend-services/oauth2';
@@ -23,9 +22,8 @@ class SendDigestNowRoute extends IUserRoute<SendDigestNowRequest, SendDigestNowR
     cxt: RouteContext<SendDigestNowEnv>,
   ): Promise<SendDigestNowResponse> {
     const userEmail = this.getAuthenticatedUserEmailAddress(cxt);
-    const sessionEnv = createD1SessionEnv(env);
     const masterKey: string = await env.AES_ENCRYPTION_KEY_SECRET.get();
-    const applicationDAO = new ConnectedApplicationDAO(sessionEnv.DB, masterKey);
+    const applicationDAO = new ConnectedApplicationDAO(env.DB, masterKey);
 
     const application = await applicationDAO.getByIdForUser(request.applicationId, userEmail);
     if (!application) throw new BadRequestError('Connected application not found.');


### PR DESCRIPTION
The three digest endpoint handlers (GET, PUT, send/POST) each called `createD1SessionEnv(env)` inside `handleRequest`, which invokes `env.DB.withSession(...)`. However, `MailOtterWorker.onRequest` already wraps `env` with a D1 session before routing — so the endpoint receives either a `D1DatabaseSession` (which has no `withSession` method) or an unwrapped DB when sessions are unsupported (where the call also fails).

This caused a 500 `TypeError: t.DB.withSession is not a function` on every request to the three digest routes in production.

All other API endpoints use `env.DB` directly because the middleware already handles session setup. The digest endpoints now follow the same pattern.