### PR TITLE
Collapse Mailbox Settings Into Expandable Sections

### DIFF
--- a/apps/web/src/components/mailboxes/AutoExecuteSection.tsx
+++ b/apps/web/src/components/mailboxes/AutoExecuteSection.tsx
@@ -1,5 +1,5 @@
 import type { ConnectedApplication, EmailActionType } from '../../../components/types';
-import { Card, CardHeader, CardTitle } from '../ui/Card';
+import { CollapsibleSection } from '../shared/CollapsibleSection';
 import { useMailboxCallbacks } from '../../contexts/MailboxCallbacksContext';
 
 interface ActionTypeConfig {
@@ -42,10 +42,7 @@ export function AutoExecuteSection({ application }: { application: ConnectedAppl
   };
 
   return (
-    <Card>
-      <CardHeader>
-        <CardTitle>Action Auto-Execution</CardTitle>
-      </CardHeader>
+    <CollapsibleSection title="Action Auto-Execution">
       <p className="text-xs text-[var(--color-text-muted)] mb-4">
         Automatically execute these action types when a matching email is processed. Results appear in the Actions view without requiring a manual click.
       </p>
@@ -82,6 +79,6 @@ export function AutoExecuteSection({ application }: { application: ConnectedAppl
           );
         })}
       </div>
-    </Card>
+    </CollapsibleSection>
   );
 }

--- a/apps/web/src/components/mailboxes/ContextSection.tsx
+++ b/apps/web/src/components/mailboxes/ContextSection.tsx
@@ -1,8 +1,8 @@
 import type { ConnectedApplication } from '../../../components/types';
 import { formatTimestamp } from '../../../components/utils';
 import { Button } from '../ui/Button';
-import { Card, CardHeader, CardTitle } from '../ui/Card';
 import { Metric } from '../shared/Metric';
+import { CollapsibleSection } from '../shared/CollapsibleSection';
 import { useMailboxCallbacks } from '../../contexts/MailboxCallbacksContext';
 import { useCurrentUserData } from '../../contexts/UserContext';
 
@@ -11,38 +11,35 @@ export function ContextSection({ application }: { application: ConnectedApplicat
   const { busy, onUpdateContextIndexing, onUpdateMaxContextDocuments, onOpenContextAudit, onDeleteContextDocuments, onDismissContextError } = useMailboxCallbacks();
 
   return (
-    <Card>
-      <CardHeader>
-        <CardTitle>RAG Context</CardTitle>
-        <div className="flex flex-wrap items-center gap-4">
-          <label className="inline-flex items-center gap-2.5 text-sm text-[var(--color-text-secondary)] cursor-pointer">
-            <input
-              type="checkbox"
-              checked={application.contextIndexingEnabled}
-              onChange={(e) => onUpdateContextIndexing(application.applicationId, e.target.checked)}
-              disabled={busy}
-              className="h-4 w-4 accent-[var(--color-accent)] rounded"
-            />
-            Index New Emails
-          </label>
-          <label className="inline-flex items-center gap-2 text-sm text-[var(--color-text-secondary)]">
-            Max Docs
-            <input
-              type="number"
-              min={1}
-              max={user.limits.maxContextDocumentsPerApplication}
-              placeholder={`Default (${user.limits.maxContextDocumentsPerApplication})`}
-              value={application.maxContextDocuments ?? ''}
-              onChange={(e) => {
-                const val = e.target.value === '' ? null : Number(e.target.value);
-                onUpdateMaxContextDocuments(application.applicationId, val);
-              }}
-              disabled={busy}
-              className="w-28 px-2 py-1 rounded-lg bg-[var(--color-surface-base)] border border-[var(--color-border)] text-[var(--color-text-primary)] text-sm focus:outline-none focus:border-[var(--color-accent)]"
-            />
-          </label>
-        </div>
-      </CardHeader>
+    <CollapsibleSection title="RAG Context">
+      <div className="flex flex-wrap items-center gap-4 mb-4">
+        <label className="inline-flex items-center gap-2.5 text-sm text-[var(--color-text-secondary)] cursor-pointer">
+          <input
+            type="checkbox"
+            checked={application.contextIndexingEnabled}
+            onChange={(e) => onUpdateContextIndexing(application.applicationId, e.target.checked)}
+            disabled={busy}
+            className="h-4 w-4 accent-[var(--color-accent)] rounded"
+          />
+          Index New Emails
+        </label>
+        <label className="inline-flex items-center gap-2 text-sm text-[var(--color-text-secondary)]">
+          Max Docs
+          <input
+            type="number"
+            min={1}
+            max={user.limits.maxContextDocumentsPerApplication}
+            placeholder={`Default (${user.limits.maxContextDocumentsPerApplication})`}
+            value={application.maxContextDocuments ?? ''}
+            onChange={(e) => {
+              const val = e.target.value === '' ? null : Number(e.target.value);
+              onUpdateMaxContextDocuments(application.applicationId, val);
+            }}
+            disabled={busy}
+            className="w-28 px-2 py-1 rounded-lg bg-[var(--color-surface-base)] border border-[var(--color-border)] text-[var(--color-text-primary)] text-sm focus:outline-none focus:border-[var(--color-accent)]"
+          />
+        </label>
+      </div>
 
       <div className="grid grid-cols-1 md:grid-cols-4 gap-3">
         <Metric label="Indexed Docs" value={String(application.contextDocumentCount || 0)} />
@@ -70,6 +67,6 @@ export function ContextSection({ application }: { application: ConnectedApplicat
           Delete Indexed Documents
         </Button>
       </div>
-    </Card>
+    </CollapsibleSection>
   );
 }

--- a/apps/web/src/components/mailboxes/DigestSection.tsx
+++ b/apps/web/src/components/mailboxes/DigestSection.tsx
@@ -1,6 +1,6 @@
 import { useState } from 'react';
 import type { ConnectedApplication } from '../../../components/types';
-import { Card, CardHeader, CardTitle } from '../ui/Card';
+import { CollapsibleSection } from '../shared/CollapsibleSection';
 import { Button } from '../ui/Button';
 import { useMailboxCallbacks } from '../../contexts/MailboxCallbacksContext';
 
@@ -47,10 +47,7 @@ export function DigestSection({ application }: { application: ConnectedApplicati
     : 'Never';
 
   return (
-    <Card>
-      <CardHeader>
-        <CardTitle>Daily Digest</CardTitle>
-      </CardHeader>
+    <CollapsibleSection title="Daily Digest">
 
       <p className="text-xs text-[var(--color-text-muted)] mb-4">
         Receive a daily digest email summarizing your pending tasks, calendar events, package deliveries, and more.
@@ -133,6 +130,6 @@ export function DigestSection({ application }: { application: ConnectedApplicati
           </div>
         </div>
       </div>
-    </Card>
+    </CollapsibleSection>
   );
 }

--- a/apps/web/src/components/mailboxes/IntegrationsSection.tsx
+++ b/apps/web/src/components/mailboxes/IntegrationsSection.tsx
@@ -1,7 +1,7 @@
 import { useEffect, useState } from 'react';
 import type { OutboundIntegration, OutboundIntegrationType } from '../../../components/types';
 import { Button } from '../ui/Button';
-import { Card, CardHeader, CardTitle } from '../ui/Card';
+import { CollapsibleSection } from '../shared/CollapsibleSection';
 import { Input } from '../ui/Input';
 import { useMailboxCallbacks } from '../../contexts/MailboxCallbacksContext';
 
@@ -160,13 +160,10 @@ export function IntegrationsSection({ applicationId }: { applicationId: string }
   const atLimit = integrations.length >= 5;
 
   return (
-    <Card>
-      <CardHeader>
-        <CardTitle>Outbound Integrations</CardTitle>
-        <p className="text-xs text-[var(--color-text-muted)] mt-0.5">
-          Forward email summaries to Slack, Discord, or a custom webhook.
-        </p>
-      </CardHeader>
+    <CollapsibleSection title="Outbound Integrations">
+      <p className="text-xs text-[var(--color-text-muted)] mb-3">
+        Forward email summaries to Slack, Discord, or a custom webhook.
+      </p>
       <div className="px-4 pb-4">
         {loadingIntegrations && integrations.length === 0 ? (
           <p className="text-sm text-[var(--color-text-muted)]">Loading...</p>
@@ -191,6 +188,6 @@ export function IntegrationsSection({ applicationId }: { applicationId: string }
           <AddIntegrationForm applicationId={applicationId} onCancel={() => setShowAddForm(false)} />
         )}
       </div>
-    </Card>
+    </CollapsibleSection>
   );
 }

--- a/apps/web/src/components/mailboxes/MailboxDetail.tsx
+++ b/apps/web/src/components/mailboxes/MailboxDetail.tsx
@@ -2,7 +2,7 @@ import type { ConnectedApplication } from '../../../components/types';
 import { formatTimestamp, formatExpiryTimestamp, providerLabels } from '../../../components/utils';
 import { ConnectionBadge, WatchBadge } from '../ui/Badge';
 import { Button } from '../ui/Button';
-import { Card, CardHeader, CardTitle } from '../ui/Card';
+import { Card } from '../ui/Card';
 import { Metric } from '../shared/Metric';
 import { ReadOnlyField } from '../shared/ReadOnlyField';
 import { WatchSection } from './WatchSection';
@@ -12,6 +12,7 @@ import { RulesSection } from './RulesSection';
 import { SenderFilterSection } from './SenderFilterSection';
 import { AutoExecuteSection } from './AutoExecuteSection';
 import { DigestSection } from './DigestSection';
+import { CollapsibleSection } from '../shared/CollapsibleSection';
 import { useMailboxCallbacks } from '../../contexts/MailboxCallbacksContext';
 
 export function MailboxDetail({
@@ -86,10 +87,7 @@ export function MailboxDetail({
         </div>
       </Card>
 
-      <Card>
-        <CardHeader>
-          <CardTitle>Processing</CardTitle>
-        </CardHeader>
+      <CollapsibleSection title="Processing">
         <div className="grid grid-cols-1 md:grid-cols-3 gap-3">
           <Metric
             label="Watch Expires"
@@ -105,7 +103,7 @@ export function MailboxDetail({
             onDismiss={application.lastError ? () => onDismissProcessingError(application.applicationId) : undefined}
           />
         </div>
-      </Card>
+      </CollapsibleSection>
 
       <ContextSection application={application} />
       <IntegrationsSection applicationId={application.applicationId} />

--- a/apps/web/src/components/mailboxes/RulesSection.tsx
+++ b/apps/web/src/components/mailboxes/RulesSection.tsx
@@ -1,7 +1,7 @@
 import { useState } from 'react';
 import type { ConnectedApplication, EmailProcessingRule, EmailRuleConditionMatcher, EmailRuleConditionMatcherField, EmailRuleConditionMatcherOp } from '../../../components/types';
 import { Button } from '../ui/Button';
-import { Card, CardHeader, CardTitle } from '../ui/Card';
+import { CollapsibleSection } from '../shared/CollapsibleSection';
 import { Input } from '../ui/Input';
 import { useMailboxCallbacks } from '../../contexts/MailboxCallbacksContext';
 import { suggestRule as apiSuggestRule } from '../../services/applicationService';
@@ -475,10 +475,7 @@ export function RulesSection({ application }: { application: ConnectedApplicatio
   const canAddMore = rules.length < MAX_RULES;
 
   return (
-    <Card>
-      <CardHeader>
-        <CardTitle>Email Processing Rules</CardTitle>
-      </CardHeader>
+    <CollapsibleSection title="Email Processing Rules">
       <p className="text-xs text-[var(--color-text-muted)] mb-4">
         Rules Are Evaluated In Order. The First Matching Rule Wins.
         Skip Rules Prevent Summarization. Skip Actions Rules Summarize Without Creating Action Proposals.
@@ -538,6 +535,6 @@ export function RulesSection({ application }: { application: ConnectedApplicatio
           <p className="text-xs text-[var(--color-text-muted)]">Maximum {MAX_RULES} Rules Reached.</p>
         )
       )}
-    </Card>
+    </CollapsibleSection>
   );
 }

--- a/apps/web/src/components/mailboxes/SenderFilterSection.tsx
+++ b/apps/web/src/components/mailboxes/SenderFilterSection.tsx
@@ -1,7 +1,7 @@
 import { useState } from 'react';
 import type { ConnectedApplication, SenderDomainFilters } from '../../../components/types';
 import { Button } from '../ui/Button';
-import { Card, CardHeader, CardTitle } from '../ui/Card';
+import { CollapsibleSection } from '../shared/CollapsibleSection';
 import { Input } from '../ui/Input';
 import { useMailboxCallbacks } from '../../contexts/MailboxCallbacksContext';
 
@@ -22,10 +22,7 @@ export function SenderFilterSection({ application }: { application: ConnectedApp
   };
 
   return (
-    <Card>
-      <CardHeader>
-        <CardTitle>Sender Allowlist</CardTitle>
-      </CardHeader>
+    <CollapsibleSection title="Sender Allowlist">
       <p className="text-xs text-[var(--color-text-muted)] mb-4">
         When set, only emails from matching senders are processed. Leave empty to process all senders.
         Use <code className="font-mono">@domain.com</code> to match a domain or <code className="font-mono">user@domain.com</code> for an exact address.
@@ -66,6 +63,6 @@ export function SenderFilterSection({ application }: { application: ConnectedApp
           Add
         </Button>
       </div>
-    </Card>
+    </CollapsibleSection>
   );
 }

--- a/apps/web/src/components/mailboxes/WatchSection.tsx
+++ b/apps/web/src/components/mailboxes/WatchSection.tsx
@@ -1,7 +1,7 @@
 import { useState, useEffect } from 'react';
 import type { ConnectedApplication } from '../../../components/types';
 import { Button } from '../ui/Button';
-import { Card, CardHeader, CardTitle } from '../ui/Card';
+import { CollapsibleSection } from '../shared/CollapsibleSection';
 import { useMailboxCallbacks } from '../../contexts/MailboxCallbacksContext';
 
 const setsEqual = (a: string[] | null, b: string[] | null) => {
@@ -35,9 +35,8 @@ export function WatchSection({
   const isUnchanged = setsEqual(pendingIds, originalIds);
 
   return (
-    <Card>
-      <CardHeader>
-        <CardTitle>Watch Folders</CardTitle>
+    <CollapsibleSection title="Watch Folders">
+      <div className="mb-4">
         <Button
           variant="secondary"
           size="sm"
@@ -47,7 +46,7 @@ export function WatchSection({
         >
           Load Folders
         </Button>
-      </CardHeader>
+      </div>
 
       {availableFolders ? (
         availableFolders.length === 0 ? (
@@ -105,6 +104,6 @@ export function WatchSection({
           Watching Default Folder (Inbox). Click &quot;Load Folders&quot; To Customize.
         </p>
       )}
-    </Card>
+    </CollapsibleSection>
   );
 }

--- a/apps/web/src/components/shared/CollapsibleSection.tsx
+++ b/apps/web/src/components/shared/CollapsibleSection.tsx
@@ -1,0 +1,38 @@
+import { useState } from 'react';
+import { ChevronDown } from 'lucide-react';
+import { cn } from '../../lib/utils';
+
+export function CollapsibleSection({
+  title,
+  children,
+  defaultExpanded = false,
+}: {
+  title: string;
+  children: React.ReactNode;
+  defaultExpanded?: boolean;
+}) {
+  const [isExpanded, setIsExpanded] = useState(defaultExpanded);
+
+  return (
+    <div className="rounded-xl border border-[var(--color-border)] bg-[var(--color-surface-1)] overflow-hidden">
+      <button
+        type="button"
+        onClick={() => setIsExpanded((v) => !v)}
+        className="w-full flex items-center justify-between px-5 py-4 text-left hover:bg-[var(--color-surface-2)] transition-colors duration-150"
+      >
+        <h2 className="text-base font-semibold text-[var(--color-text-primary)]">{title}</h2>
+        <ChevronDown
+          className={cn(
+            'h-4 w-4 text-[var(--color-text-muted)] transition-transform duration-200',
+            isExpanded && 'rotate-180',
+          )}
+        />
+      </button>
+      {isExpanded && (
+        <div className="px-5 pb-5 pt-4 border-t border-[var(--color-border)] animate-fade-in">
+          {children}
+        </div>
+      )}
+    </div>
+  );
+}


### PR DESCRIPTION
The mailbox detail view had too many settings stacked vertically. This introduces a shared `CollapsibleSection` component — a card with a clickable title row and rotating chevron — mirroring the existing New Mailbox form pattern. All eight settings sections (Processing, RAG Context, Outbound Integrations, Sender Allowlist, Action Auto-Execution, Daily Digest, Email Processing Rules, Watch Folders) now default to collapsed and expand individually. The top identity card remains always visible.