### PR TITLE
Include Digest Config In Application List Response

### DIFF
--- a/packages/backend-services/src/application/ApplicationResponseUtil.ts
+++ b/packages/backend-services/src/application/ApplicationResponseUtil.ts
@@ -1,12 +1,14 @@
-import { ApplicationContextDAO, ProcessedMessageDAO, ProviderSubscriptionDAO } from '@mail-otter/backend-data/dao';
+import { ApplicationContextDAO, ConnectedApplicationDAO, ProcessedMessageDAO, ProviderSubscriptionDAO } from '@mail-otter/backend-data/dao';
 import type { D1Queryable } from '@mail-otter/backend-data/utils';
 import type {
   ApplicationContextSummary,
   ConnectedApplicationMetadata,
+  DigestConfig,
   ProcessedMessage,
   ProviderSubscription,
 } from '@mail-otter/shared/model';
 import { BaseUrlUtil } from '@mail-otter/shared/utils';
+import { DigestConfigService } from '../digest/DigestConfigService';
 
 class ApplicationResponseUtil {
   public static async decorateApplication(
@@ -34,8 +36,20 @@ class ApplicationResponseUtil {
       contextSummary.lastErrorAt != null &&
       contextSummary.lastErrorAt <= application.contextLastErrorAcknowledgedAt;
 
+    let digestConfig: DigestConfig | null = null;
+    if (env.AES_ENCRYPTION_KEY_SECRET) {
+      try {
+        const masterKey: string = await env.AES_ENCRYPTION_KEY_SECRET.get();
+        const digestService = new DigestConfigService(new ConnectedApplicationDAO(env.DB, masterKey));
+        digestConfig = await digestService.getConfig(application.applicationId);
+      } catch {
+        console.warn(`[ApplicationResponseUtil] Failed to fetch digest config for ${application.applicationId}`);
+      }
+    }
+
     return {
       ...application,
+      digestConfig,
       oauth2RedirectUri: `${baseUrl}/api/oauth2/callback/${application.applicationId}`,
       webhookUrl: `${baseUrl}/api/webhooks/${application.providerId === 'google-gmail' ? 'gmail' : 'outlook'}/${application.applicationId}${
         subscription?.webhookSecretHash ? '?token=shown-on-watch-start' : ''
@@ -56,9 +70,11 @@ class ApplicationResponseUtil {
 
 interface ApplicationDecorationEnv {
   DB: D1Queryable;
+  AES_ENCRYPTION_KEY_SECRET?: SecretsStoreSecret | undefined;
 }
 
 interface ApplicationResponse extends ConnectedApplicationMetadata {
+  digestConfig?: DigestConfig | null;
   oauth2RedirectUri: string;
   webhookUrl: string;
   watchStatus?: string | undefined;

--- a/packages/shared/src/model/ConnectedApplication.ts
+++ b/packages/shared/src/model/ConnectedApplication.ts
@@ -1,4 +1,5 @@
 import type { ConnectedApplicationStatus, ConnectionMethod, ProviderId } from '../constants';
+import type { DigestConfig } from './DigestConfig';
 import type { EmailProcessingRule } from './EmailRule';
 
 interface SenderDomainFilters {
@@ -32,6 +33,7 @@ interface ConnectedApplicationMetadata {
   senderDomainFilters?: SenderDomainFilters | null | undefined;
   emailProcessingRules?: EmailProcessingRule[] | null | undefined;
   autoExecuteActionTypes?: string[] | null | undefined;
+  digestConfig?: DigestConfig | null | undefined;
   gmailPubsubTopicName?: string | null | undefined;
   imapHost?: string | null | undefined;
   imapPort?: number | null | undefined;


### PR DESCRIPTION
The GET /user/applications endpoint did not include digestConfig in its response. After a page refresh, the DigestSection component fell back to defaults (enabled: false) because application.digestConfig was undefined.

Now ApplicationResponseUtil.decorateApplication fetches the digest config via DigestConfigService and includes it in the response, so the UI reflects the actual saved state after page load.