### PR TITLE
Remove Redundant Type Check Step From CD Pipeline

### DIFF
--- a/.github/workflows/continuous-deployment.yml
+++ b/.github/workflows/continuous-deployment.yml
@@ -90,9 +90,6 @@ jobs:
       - name: Build Web App
         run: pnpm --filter @mail-otter/web build
 
-      - name: Type Check API Worker
-        run: pnpm --filter @mail-otter/api typecheck
-
       - name: Prepare for Deploy
         run: |
           # Hide OpenNext config so wrangler doesn't delegate to opennextjs-cloudflare.


### PR DESCRIPTION
The Type Check API Worker step in continuous-deployment.yml is redundant because:
- CI already type-checks all workspace packages (including @mail-otter/api) via pnpm -r typecheck in the checks job, plus an explicit filter check in the build job
- CD is gated on CI success, so the code has already passed type-checking
- Both run on the same commit SHA, so no new type errors can surface