### PR TITLE
Use ACTION_ENCRYPTION_KEY_SECRET For EmailActionDAO

### DIFF
--- a/apps/api/src/endpoints/user/application/digest/send/POST.ts
+++ b/apps/api/src/endpoints/user/application/digest/send/POST.ts
@@ -23,13 +23,14 @@ class SendDigestNowRoute extends IUserRoute<SendDigestNowRequest, SendDigestNowR
   ): Promise<SendDigestNowResponse> {
     const userEmail = this.getAuthenticatedUserEmailAddress(cxt);
     const masterKey: string = await env.AES_ENCRYPTION_KEY_SECRET.get();
+    const actionKey: string = await env.ACTION_ENCRYPTION_KEY_SECRET.get();
     const applicationDAO = new ConnectedApplicationDAO(env.DB, masterKey);
 
     const application = await applicationDAO.getByIdForUser(request.applicationId, userEmail);
     if (!application) throw new BadRequestError('Connected application not found.');
 
     const accessToken = await new OAuth2AccessTokenService(env).getAccessToken(request.applicationId);
-    const digestSvc = new DigestService(env, masterKey);
+    const digestSvc = new DigestService(env, masterKey, actionKey);
 
     await digestSvc.sendDigestForced(application, accessToken);
     return { sent: true };
@@ -48,6 +49,7 @@ interface SendDigestNowEnv extends IUserEnv {
   OAUTH2_TOKEN_CACHE: KVNamespace;
   OAUTH2_TOKEN_REFRESHERS: DurableObjectNamespace;
   OAUTH2_ACCESS_TOKEN_MIN_VALID_SECONDS?: string | undefined;
+  ACTION_ENCRYPTION_KEY_SECRET: SecretsStoreSecret;
 }
 
 export { SendDigestNowRoute };

--- a/apps/background/src/scheduled/ActionStatusSyncTask.ts
+++ b/apps/background/src/scheduled/ActionStatusSyncTask.ts
@@ -18,12 +18,13 @@ class ActionStatusSyncTask extends IScheduledTask<ActionStatusSyncTaskEnv> {
 
     const sessionEnv = createD1SessionEnv(env);
     const masterKey: string = await env.AES_ENCRYPTION_KEY_SECRET.get();
+    const actionKey: string = await env.ACTION_ENCRYPTION_KEY_SECRET.get();
     const applicationDAO = new ConnectedApplicationDAO(sessionEnv.DB, masterKey);
 
     const applicationIds = await applicationDAO.listApplicationIdsWithProviderConfig(DIGEST_CONFIG_KEY_ENABLED, 'true');
     if (applicationIds.length === 0) return;
 
-    const syncUtil = new ActionStatusSyncUtil(sessionEnv.DB, masterKey);
+    const syncUtil = new ActionStatusSyncUtil(sessionEnv.DB, actionKey);
     for (const applicationId of applicationIds) {
       try {
         if (packageApiKey) await syncUtil.syncPackageActions(applicationId, packageApiKey);
@@ -39,6 +40,7 @@ class ActionStatusSyncTask extends IScheduledTask<ActionStatusSyncTaskEnv> {
 interface ActionStatusSyncTaskEnv extends IEnv {
   DB: D1Database;
   AES_ENCRYPTION_KEY_SECRET: SecretsStoreSecret;
+  ACTION_ENCRYPTION_KEY_SECRET: SecretsStoreSecret;
   PACKAGE_TRACKING_API_KEY?: string | undefined;
   FLIGHT_TRACKING_API_KEY?: string | undefined;
 }

--- a/apps/background/src/scheduled/ScheduledDigestTask.ts
+++ b/apps/background/src/scheduled/ScheduledDigestTask.ts
@@ -19,6 +19,7 @@ class ScheduledDigestTask extends IScheduledTask<ScheduledDigestTaskEnv> {
   ): Promise<void> {
     const sessionEnv = createD1SessionEnv(env);
     const masterKey: string = await env.AES_ENCRYPTION_KEY_SECRET.get();
+    const actionKey: string = await env.ACTION_ENCRYPTION_KEY_SECRET.get();
     const applicationDAO = new ConnectedApplicationDAO(sessionEnv.DB, masterKey);
 
     const applicationIds = await applicationDAO.listApplicationIdsWithProviderConfig(DIGEST_CONFIG_KEY_ENABLED, 'true');
@@ -37,7 +38,7 @@ class ScheduledDigestTask extends IScheduledTask<ScheduledDigestTaskEnv> {
         if (!isDue) continue;
 
         const accessToken = await new OAuth2AccessTokenService(env).getAccessToken(applicationId);
-        const digestSvc = new DigestService(sessionEnv, masterKey);
+        const digestSvc = new DigestService(sessionEnv, masterKey, actionKey);
         await digestSvc.sendDigest(application, accessToken);
         sent++;
       } catch (error: unknown) {
@@ -51,6 +52,7 @@ class ScheduledDigestTask extends IScheduledTask<ScheduledDigestTaskEnv> {
 interface ScheduledDigestTaskEnv extends IEnv {
   DB: D1Database;
   AES_ENCRYPTION_KEY_SECRET: SecretsStoreSecret;
+  ACTION_ENCRYPTION_KEY_SECRET: SecretsStoreSecret;
   OAUTH2_TOKEN_CACHE: KVNamespace;
   OAUTH2_TOKEN_REFRESHERS: DurableObjectNamespace;
   OAUTH2_ACCESS_TOKEN_MIN_VALID_SECONDS?: string | undefined;

--- a/packages/backend-services/src/digest/ActionStatusSyncUtil.ts
+++ b/packages/backend-services/src/digest/ActionStatusSyncUtil.ts
@@ -24,8 +24,8 @@ interface FlightSyncStatus {
 class ActionStatusSyncUtil {
   private readonly actionDAO: EmailActionDAO;
 
-  constructor(db: D1Queryable, masterKey: string) {
-    this.actionDAO = new EmailActionDAO(db, masterKey);
+  constructor(db: D1Queryable, actionKey: string) {
+    this.actionDAO = new EmailActionDAO(db, actionKey);
   }
 
   public async syncPackageActions(applicationId: string, packageTrackingApiKey: string): Promise<void> {

--- a/packages/backend-services/src/digest/DigestService.ts
+++ b/packages/backend-services/src/digest/DigestService.ts
@@ -33,6 +33,7 @@ import type { DigestSections } from './DigestEmailUtil';
 interface DigestServiceEnv {
   DB: D1Queryable;
   AES_ENCRYPTION_KEY_SECRET: SecretsStoreSecret;
+  ACTION_ENCRYPTION_KEY_SECRET: SecretsStoreSecret;
   OAUTH2_TOKEN_CACHE: KVNamespace;
   OAUTH2_TOKEN_REFRESHERS: DurableObjectNamespace;
   OAUTH2_ACCESS_TOKEN_MIN_VALID_SECONDS?: string | undefined;
@@ -41,10 +42,12 @@ interface DigestServiceEnv {
 class DigestService {
   private readonly db: D1Queryable;
   private readonly masterKey: string;
+  private readonly actionKey: string;
 
-  constructor(private readonly env: DigestServiceEnv, masterKey: string) {
+  constructor(private readonly env: DigestServiceEnv, masterKey: string, actionKey: string) {
     this.db = env.DB;
     this.masterKey = masterKey;
+    this.actionKey = actionKey;
   }
 
   public async sendDigest(application: ConnectedApplicationMetadata, accessToken: string): Promise<void> {
@@ -95,7 +98,7 @@ class DigestService {
     now: Date,
     nowUnix: number,
   ): Promise<DigestSections> {
-    const actionDAO = new EmailActionDAO(this.db, this.masterKey);
+    const actionDAO = new EmailActionDAO(this.db, this.actionKey);
     const calendarDAO = new SyncedCalendarEventDAO(this.db);
 
     const dayStartUnix = DigestService.getDayStartUnix(now, timeZone);


### PR DESCRIPTION
DigestService and ActionStatusSyncUtil were creating EmailActionDAO with AES_ENCRYPTION_KEY_SECRET, but email action payloads are encrypted using ACTION_ENCRYPTION_KEY_SECRET (via ActionServiceUtils.createActionDAO).

This caused decryption failures when reading existing email actions because the HKDF-derived AES-GCM key from AES_ENCRYPTION_KEY_SECRET differs from the one derived from ACTION_ENCRYPTION_KEY_SECRET.

Affected paths:
- DigestService.buildSections() now uses actionKey instead of masterKey for EmailActionDAO
- ActionStatusSyncUtil now accepts actionKey instead of masterKey
- All callers (POST /user/application/digest/send, ScheduledDigestTask, ActionStatusSyncTask) now fetch ACTION_ENCRYPTION_KEY_SECRET and pass it as the action key