### PR TITLE
Remove Gist Label From User-Facing Summary

### DIFF
--- a/packages/backend-services/src/email/EmailSummaryUtil.ts
+++ b/packages/backend-services/src/email/EmailSummaryUtil.ts
@@ -189,7 +189,7 @@ class EmailSummaryUtil {
     const keyDetails: string[] = EmailSummaryUtil.normalizeItems(summary.keyDetails);
 
     return [
-      `<p><strong>Gist:</strong> ${EmailContentUtil.sanitizeHtml(gist)}</p>`,
+      `<p>${EmailContentUtil.sanitizeHtml(gist)}</p>`,
       '',
       '<p><strong>Details:</strong></p>',
       '<ul>',

--- a/test/utils/EmailSummaryUtil.test.ts
+++ b/test/utils/EmailSummaryUtil.test.ts
@@ -13,7 +13,7 @@ describe('EmailSummaryUtil', () => {
     } as unknown as Ai;
 
     await expect(EmailSummaryUtil.summarizeEmail(ai, '@cf/meta/llama-3.1-8b-instruct', 'Campaign budget', 'sam@example.com', 'body'))
-      .resolves.toBe(`<p><strong>Gist:</strong> The sender wants approval for the May campaign budget.</p>
+      .resolves.toBe(`<p>The sender wants approval for the May campaign budget.</p>
 
 <p><strong>Details:</strong></p>
 <ul>
@@ -41,7 +41,7 @@ describe('EmailSummaryUtil', () => {
     } as unknown as Ai;
 
     await expect(EmailSummaryUtil.summarizeEmail(ai, 'model', 'Status', 'sam@example.com', 'body')).resolves
-      .toBe(`<p><strong>Gist:</strong> The email shares a status update with no requests.</p>
+      .toBe(`<p>The email shares a status update with no requests.</p>
 
 <p><strong>Details:</strong></p>
 <ul>
@@ -87,7 +87,7 @@ describe('EmailSummaryUtil', () => {
     } as unknown as Ai;
 
     await expect(EmailSummaryUtil.summarizeEmail(ai, '@cf/openai/gpt-oss-120b', 'Campaign budget', 'sam@example.com', 'body')).resolves
-      .toBe(`<p><strong>Gist:</strong> The sender needs approval for the budget.</p>
+      .toBe(`<p>The sender needs approval for the budget.</p>
 
 <p><strong>Details:</strong></p>
 <ul>
@@ -129,7 +129,7 @@ describe('EmailSummaryUtil', () => {
     } as unknown as Ai;
 
     await expect(EmailSummaryUtil.summarizeEmail(ai, '@cf/openai/gpt-oss-120b', 'Launch', 'sam@example.com', 'body')).resolves
-      .toBe(`<p><strong>Gist:</strong> The email shares a launch update.</p>
+      .toBe(`<p>The email shares a launch update.</p>
 
 <p><strong>Details:</strong></p>
 <ul>
@@ -154,7 +154,7 @@ describe('EmailSummaryUtil', () => {
 
     await expect(EmailSummaryUtil.summarizeEmailWithUsage(ai, '@cf/openai/gpt-oss-120b', 'Review', 'sam@example.com', 'body')).resolves
       .toMatchObject({
-        summary: expect.stringContaining('<strong>Gist:</strong> The email asks for feedback.'),
+        summary: expect.stringContaining('The email asks for feedback.'),
         usage: {
           promptTokens: 1000,
           completionTokens: 100,
@@ -183,7 +183,7 @@ describe('EmailSummaryUtil', () => {
 
     await expect(EmailSummaryUtil.summarizeEmailWithUsage(ai, '@cf/openai/gpt-oss-120b', 'Review', 'sam@example.com', 'body')).resolves
       .toMatchObject({
-        summary: expect.stringContaining('<strong>Gist:</strong> The email asks for feedback.'),
+        summary: expect.stringContaining('The email asks for feedback.'),
         usage: {
           promptTokens: 1000,
           completionTokens: 800,
@@ -239,7 +239,7 @@ describe('EmailSummaryUtil', () => {
 
     await expect(EmailSummaryUtil.summarizeEmailWithUsage(ai, '@cf/openai/gpt-oss-120b', 'Review', 'sam@example.com', 'body')).resolves
       .toMatchObject({
-        summary: expect.stringContaining('<strong>Gist:</strong> The email asks for feedback.'),
+        summary: expect.stringContaining('The email asks for feedback.'),
         usage: {
           promptTokens: 1000,
           completionTokens: 800,

--- a/test/utils/GmailProviderUtil.test.ts
+++ b/test/utils/GmailProviderUtil.test.ts
@@ -27,7 +27,7 @@ describe('GmailProviderUtil', () => {
       };
 
       const htmlSummary =
-        '<p><strong>Gist:</strong> Summary &lt;tag&gt; &amp; text</p>\n<p><strong>Details:</strong></p>\n<ul>\n<li>Next line</li>\n</ul>';
+        '<p>Summary &lt;tag&gt; &amp; text</p>\n<p><strong>Details:</strong></p>\n<ul>\n<li>Next line</li>\n</ul>';
       await GmailProviderUtil.sendSummaryReply(
         'test-access-token',
         'sender@example.com',
@@ -48,9 +48,9 @@ describe('GmailProviderUtil', () => {
       expect(rawMessage).toContain('X-Mail-Otter-Summary: true');
       expect(rawMessage).toContain(`Content-Type: multipart/alternative; boundary="${boundary}"`);
       expect(rawMessage).toContain(`--${boundary}\r\nContent-Type: text/plain; charset=utf-8`);
-      expect(rawMessage).toContain('Gist: Summary <tag> & text');
+      expect(rawMessage).toContain('Summary <tag> & text');
       expect(rawMessage).toContain(`--${boundary}\r\nContent-Type: text/html; charset=utf-8`);
-      expect(rawMessage).toContain('<p><strong>Gist:</strong> Summary &lt;tag&gt; &amp; text</p>');
+      expect(rawMessage).toContain('<p>Summary &lt;tag&gt; &amp; text</p>');
       expect(rawMessage).toContain(`--${boundary}--`);
 
       const trashCall = fetchMock.mock.calls[1];

--- a/test/utils/OutlookProviderUtil.test.ts
+++ b/test/utils/OutlookProviderUtil.test.ts
@@ -34,7 +34,7 @@ describe('OutlookProviderUtil', () => {
       const originalMessage = { id: 'original-msg-id' };
 
       const htmlSummary =
-        '<p><strong>Gist:</strong> Summary &lt;tag&gt; &amp; text</p>\n<p><strong>Details:</strong></p>\n<ul>\n<li>Next line</li>\n</ul>';
+        '<p>Summary &lt;tag&gt; &amp; text</p>\n<p><strong>Details:</strong></p>\n<ul>\n<li>Next line</li>\n</ul>';
       await OutlookProviderUtil.sendSelfSummaryReply(
         'test-access-token',
         originalMessage,


### PR DESCRIPTION
Remove the 'Gist:' label prefix from the rendered summary HTML sent to users via email reply. The AI output (raw gist JSON field) is preserved unchanged.

Affected files:
- EmailSummaryUtil.ts: renderHtmlSummary no longer prepends 'Gist:'
- EmailSummaryUtil.test.ts: Update 7 test assertions
- GmailProviderUtil.test.ts: Update 3 test assertions
- OutlookProviderUtil.test.ts: Update 1 test assertion