### PR TITLE
Include AI Model In Summary Audit Logs

### DIFF
--- a/packages/backend-services/src/email/EmailProcessingAuditLogger.ts
+++ b/packages/backend-services/src/email/EmailProcessingAuditLogger.ts
@@ -28,14 +28,17 @@ class EmailProcessingAuditLogger {
     );
   }
 
-  async logSummaryGenerated(application: ConnectedApplication, sourceDocumentId: string, retryAttempt?: number | undefined): Promise<void> {
+  async logSummaryGenerated(application: ConnectedApplication, sourceDocumentId: string, model: string, retryAttempt?: number | undefined): Promise<void> {
     return this.logAuditEvent(
       application,
       sourceDocumentId,
       CONTEXT_AUDIT_EVENT_SUMMARY_GENERATED,
       'AI Summary Generated',
       CONTEXT_AUDIT_LOG_SEVERITY_INFO,
-      retryAttempt != null && retryAttempt > 1 ? { attempt: retryAttempt } : undefined,
+      {
+        summaryModel: model,
+        ...(retryAttempt != null && retryAttempt > 1 ? { attempt: retryAttempt } : {}),
+      },
     );
   }
 
@@ -59,14 +62,17 @@ class EmailProcessingAuditLogger {
     );
   }
 
-  async logSummarySent(application: ConnectedApplication, sourceDocumentId: string, retryAttempt?: number | undefined): Promise<void> {
+  async logSummarySent(application: ConnectedApplication, sourceDocumentId: string, model: string, retryAttempt?: number | undefined): Promise<void> {
     return this.logAuditEvent(
       application,
       sourceDocumentId,
       CONTEXT_AUDIT_EVENT_SUMMARY_SENT,
       'Summary Email Sent',
       CONTEXT_AUDIT_LOG_SEVERITY_INFO,
-      retryAttempt != null && retryAttempt > 1 ? { attempt: retryAttempt } : undefined,
+      {
+        summaryModel: model,
+        ...(retryAttempt != null && retryAttempt > 1 ? { attempt: retryAttempt } : {}),
+      },
     );
   }
 

--- a/packages/backend-services/src/email/EmailProcessingUtil.ts
+++ b/packages/backend-services/src/email/EmailProcessingUtil.ts
@@ -146,7 +146,7 @@ class EmailProcessingUtil {
     if (existing?.status === PROCESSED_MESSAGE_STATUS_SUMMARIZED) return;
     try {
       await GmailProviderUtil.sendSummaryReply(data.accessToken, data.application.providerEmail!, data.message, data.summaryHtml);
-      await auditLogger.logSummarySent(data.application, data.messageId, data.options.retryAttempt);
+      await auditLogger.logSummarySent(data.application, data.messageId, data.summaryModel, data.options.retryAttempt);
       await processedDAO.markSummarized(data.application.applicationId, data.messageId);
     } catch (error: unknown) {
       const processingError: Error = EmailProcessingUtil.classifyError(error);
@@ -223,7 +223,7 @@ class EmailProcessingUtil {
     if (existing?.status === PROCESSED_MESSAGE_STATUS_SUMMARIZED) return;
     try {
       await OutlookProviderUtil.sendSelfSummaryReply(data.accessToken, data.message, data.application.providerEmail!, data.summaryHtml);
-      await auditLogger.logSummarySent(data.application, data.messageId, data.options.retryAttempt);
+      await auditLogger.logSummarySent(data.application, data.messageId, data.summaryModel, data.options.retryAttempt);
       await processedDAO.markSummarized(data.application.applicationId, data.messageId);
     } catch (error: unknown) {
       const processingError: Error = EmailProcessingUtil.classifyError(error);
@@ -280,7 +280,7 @@ class EmailProcessingUtil {
     if (existing?.status === PROCESSED_MESSAGE_STATUS_SUMMARIZED) return;
     try {
       await FastmailProviderUtil.createDraftReply(data.accessToken, data.emailId, data.summaryHtml);
-      await auditLogger.logSummarySent(data.application, data.emailId, data.options.retryAttempt);
+      await auditLogger.logSummarySent(data.application, data.emailId, data.summaryModel, data.options.retryAttempt);
       await processedDAO.markSummarized(data.application.applicationId, data.emailId);
     } catch (error: unknown) {
       const processingError = EmailProcessingUtil.classifyError(error);
@@ -343,7 +343,7 @@ class EmailProcessingUtil {
         data.summaryHtml,
       ].join('\r\n');
       await imapClient.append('INBOX', summaryRfc2822);
-      await auditLogger.logSummarySent(data.application, data.messageId, data.options.retryAttempt);
+      await auditLogger.logSummarySent(data.application, data.messageId, data.summaryModel, data.options.retryAttempt);
       await processedDAO.markSummarized(data.application.applicationId, data.messageId);
     } catch (error: unknown) {
       const processingError = EmailProcessingUtil.classifyError(error);
@@ -429,6 +429,7 @@ interface EmailProcessingOptions {
 interface GmailSummaryData {
   message: GmailMessage;
   summaryHtml: string;
+  summaryModel: string;
   rawSummary: { gist: string; keyDetails: string[] };
   emailSubject: string;
   emailFrom: string;
@@ -442,6 +443,7 @@ interface GmailSummaryData {
 interface OutlookSummaryData {
   message: OutlookMessage;
   summaryHtml: string;
+  summaryModel: string;
   rawSummary: { gist: string; keyDetails: string[] };
   emailSubject: string;
   emailFrom: string;
@@ -455,6 +457,7 @@ interface OutlookSummaryData {
 interface JmapSummaryData {
   email: { id: string; subject?: string | null; from?: Array<{ email: string; name?: string }> | null; threadId?: string | null };
   summaryHtml: string;
+  summaryModel: string;
   rawSummary: { gist: string; keyDetails: string[] };
   emailSubject: string;
   emailFrom: string;
@@ -467,6 +470,7 @@ interface JmapSummaryData {
 
 interface ImapSummaryData {
   summaryHtml: string;
+  summaryModel: string;
   rawSummary: { gist: string; keyDetails: string[] };
   emailSubject: string;
   emailFrom: string;

--- a/packages/backend-services/src/email/EmailSummaryOrchestrator.ts
+++ b/packages/backend-services/src/email/EmailSummaryOrchestrator.ts
@@ -19,10 +19,12 @@ interface EmailProcessingSummary {
   html: string;
   actionProposals: EmailActionProposal[];
   rawSummary: { gist: string; keyDetails: string[] };
+  summaryModel: string;
 }
 
 interface OrchestrationResult {
   summaryHtml: string;
+  summaryModel: string;
   actions: CreatedEmailAction[];
   rawSummary: { gist: string; keyDetails: string[] };
 }
@@ -91,7 +93,7 @@ class EmailSummaryOrchestrator {
       sourceDocumentId: resolvedMessageId, sourceThreadId: threadId,
     });
     const summary: EmailProcessingSummary = await this.summarize(application, subject, from, body, ragContext, customInstruction);
-    await this.auditLogger.logSummaryGenerated(application, resolvedMessageId, options.retryAttempt);
+    await this.auditLogger.logSummaryGenerated(application, resolvedMessageId, summary.summaryModel, options.retryAttempt);
     const processedMessage = await this.processedDAO.getByMessageId(application.applicationId, resolvedMessageId);
     const actions: CreatedEmailAction[] = !suppressActions && processedMessage
       ? await ActionService.createActionsForSummary(
@@ -105,7 +107,7 @@ class EmailSummaryOrchestrator {
     if (application.autoExecuteActionTypes?.length && actions.length) {
       await ActionService.autoExecuteCreatedActions(application.autoExecuteActionTypes, actions, this.env as ActionExecutionEnv);
     }
-    return { summaryHtml: this.withActionSection(summary.html, actions), actions, rawSummary: summary.rawSummary };
+    return { summaryHtml: this.withActionSection(summary.html, actions), summaryModel: summary.summaryModel, actions, rawSummary: summary.rawSummary };
   }
 
   private async summarize(
@@ -143,7 +145,7 @@ class EmailSummaryOrchestrator {
     }
     const usageEstimate: AiTextGenerationUsageEstimate | undefined = await this.recordSummaryUsage(model, result.usage, promptText, result.summary);
     const rawSummary = { gist: result.emailSummary?.gist ?? '', keyDetails: result.emailSummary?.keyDetails ?? [] };
-    if (!ConfigurationManager.getDebugMode(this.env)) return { html: result.summary, actionProposals: result.actionProposals ?? [], rawSummary };
+    if (!ConfigurationManager.getDebugMode(this.env)) return { html: result.summary, actionProposals: result.actionProposals ?? [], rawSummary, summaryModel: model };
 
     const applicationName: string = application.displayName || application.applicationId;
     return {
@@ -168,6 +170,7 @@ class EmailSummaryOrchestrator {
       ].join('\n'),
       actionProposals: result.actionProposals ?? [],
       rawSummary,
+      summaryModel: model,
     };
   }
 


### PR DESCRIPTION
Both summary_generated and summary_sent audit log events now include the AI model used for the email summary via eventData.summaryModel, matching the pattern already used by embedding_generated (which logs embeddingModel).

- EmailProcessingAuditLogger.logSummaryGenerated() and logSummarySent() accept a model parameter and include { summaryModel } in the eventData payload.
- EmailSummaryOrchestrator.summarize() returns the resolved model (primary or fallback) via the new summaryModel field on EmailProcessingSummary/OrchestrationResult.
- EmailProcessingUtil *SummaryData interfaces carry summaryModel through the generate/send pipeline so send* methods can pass it to logSummarySent().