### PR TITLE
Include Estimated Neurons In Summary Generated Audit Event

### DIFF
--- a/packages/backend-services/src/email/EmailProcessingAuditLogger.ts
+++ b/packages/backend-services/src/email/EmailProcessingAuditLogger.ts
@@ -29,7 +29,7 @@ class EmailProcessingAuditLogger {
     );
   }
 
-  async logSummaryGenerated(application: ConnectedApplication, sourceDocumentId: string, model: string, retryAttempt?: number | undefined): Promise<void> {
+  async logSummaryGenerated(application: ConnectedApplication, sourceDocumentId: string, model: string, estimatedNeurons: number, retryAttempt?: number | undefined): Promise<void> {
     return this.logAuditEvent(
       application,
       sourceDocumentId,
@@ -38,6 +38,7 @@ class EmailProcessingAuditLogger {
       CONTEXT_AUDIT_LOG_SEVERITY_INFO,
       {
         summaryModel: model,
+        estimatedNeurons,
         ...(retryAttempt != null && retryAttempt > 1 ? { attempt: retryAttempt } : {}),
       },
     );

--- a/packages/backend-services/src/email/EmailSummaryOrchestrator.ts
+++ b/packages/backend-services/src/email/EmailSummaryOrchestrator.ts
@@ -20,6 +20,7 @@ interface EmailProcessingSummary {
   actionProposals: EmailActionProposal[];
   rawSummary: { gist: string; keyDetails: string[] };
   summaryModel: string;
+  estimatedNeurons: number;
 }
 
 interface OrchestrationResult {
@@ -93,7 +94,7 @@ class EmailSummaryOrchestrator {
       sourceDocumentId: resolvedMessageId, sourceThreadId: threadId,
     });
     const summary: EmailProcessingSummary = await this.summarize(application, resolvedMessageId, subject, from, body, ragContext, customInstruction);
-    await this.auditLogger.logSummaryGenerated(application, resolvedMessageId, summary.summaryModel, options.retryAttempt);
+    await this.auditLogger.logSummaryGenerated(application, resolvedMessageId, summary.summaryModel, summary.estimatedNeurons, options.retryAttempt);
     const processedMessage = await this.processedDAO.getByMessageId(application.applicationId, resolvedMessageId);
     const actions: CreatedEmailAction[] = !suppressActions && processedMessage
       ? await ActionService.createActionsForSummary(
@@ -147,7 +148,7 @@ class EmailSummaryOrchestrator {
     }
     const usageEstimate: AiTextGenerationUsageEstimate | undefined = await this.recordSummaryUsage(model, result.usage, promptText, result.summary);
     const rawSummary = { gist: result.emailSummary?.gist ?? '', keyDetails: result.emailSummary?.keyDetails ?? [] };
-    if (!ConfigurationManager.getDebugMode(this.env)) return { html: result.summary, actionProposals: result.actionProposals ?? [], rawSummary, summaryModel: model };
+    if (!ConfigurationManager.getDebugMode(this.env)) return { html: result.summary, actionProposals: result.actionProposals ?? [], rawSummary, summaryModel: model, estimatedNeurons: usageEstimate?.estimatedNeurons ?? 0 };
 
     const applicationName: string = application.displayName || application.applicationId;
     return {
@@ -173,6 +174,7 @@ class EmailSummaryOrchestrator {
       actionProposals: result.actionProposals ?? [],
       rawSummary,
       summaryModel: model,
+      estimatedNeurons: usageEstimate?.estimatedNeurons ?? 0,
     };
   }
 


### PR DESCRIPTION
Add estimatedNeurons to the summary_generated audit log event data so the dashboard can display neuron cost per summarization alongside the model name. The orchestrator already calculates the estimate via AiUsageUtil and records it in ai_daily_usage; this change surfaces it in the per-event audit trail as well.

- EmailProcessingAuditLogger.logSummaryGenerated now accepts estimatedNeurons param and includes it in event_data
- EmailProcessingSummary.estimatedNeurons propagated from recordSummaryUsage return value through summarize() into the audit logger call in orchestrate()