### PR TITLE
Disable Thinking For Reasoning Models In JSON Mode

### DIFF
--- a/packages/backend-services/src/email/EmailSummaryUtil.ts
+++ b/packages/backend-services/src/email/EmailSummaryUtil.ts
@@ -50,6 +50,11 @@ const SUMMARY_JSON_SCHEMA = {
   },
 } as const;
 
+const REASONING_MODELS_REQUIRING_THINKING_DISABLED: ReadonlySet<string> = new Set<string>([
+  '@cf/moonshotai/kimi-k2.6',
+  '@cf/deepseek-ai/deepseek-r1-distill-qwen-32b',
+]);
+
 class EmailSummaryUtil {
   public static async summarizeEmail(
     ai: Ai,
@@ -96,6 +101,9 @@ class EmailSummaryUtil {
           strict: true,
         },
       };
+      if (REASONING_MODELS_REQUIRING_THINKING_DISABLED.has(model)) {
+        request.chat_template_kwargs = { thinking: false };
+      }
     }
 
     request.reasoning_effort = 'low';
@@ -307,6 +315,7 @@ interface AiTextGenerationRequest {
       }
     | undefined;
   reasoning_effort?: 'low' | 'medium' | 'high' | undefined;
+  chat_template_kwargs?: { thinking: boolean } | undefined;
 }
 
 export { EmailSummaryUtil };

--- a/test/utils/EmailSummaryUtil.test.ts
+++ b/test/utils/EmailSummaryUtil.test.ts
@@ -72,7 +72,7 @@ describe('EmailSummaryUtil', () => {
     } satisfies Partial<AiSummaryRetryableError>);
   });
 
-  it('requests JSON mode and low reasoning from kimi-k2.6', async () => {
+  it('requests JSON mode and low reasoning from kimi-k2.6 with thinking disabled', async () => {
     const ai = {
       run: vi.fn().mockResolvedValue({
         response: `Here is the summary:
@@ -104,9 +104,69 @@ describe('EmailSummaryUtil', () => {
           }),
         },
         reasoning_effort: 'low',
+        chat_template_kwargs: { thinking: false },
       }),
     );
-    expect((ai.run as ReturnType<typeof vi.fn>).mock.calls[0][1]).not.toHaveProperty('chat_template_kwargs');
+  });
+
+  it('requests JSON mode and low reasoning from deepseek-r1 with thinking disabled', async () => {
+    const ai = {
+      run: vi.fn().mockResolvedValue({
+        response: `Here is the summary:
+
+\`\`\`json
+{
+  "gist": "The sender needs approval for the budget.",
+  "keyDetails": ["Budget is $12,000."]
+}
+\`\`\``,
+      }),
+    } as unknown as Ai;
+
+    await expect(EmailSummaryUtil.summarizeEmail(ai, '@cf/deepseek-ai/deepseek-r1-distill-qwen-32b', 'Campaign budget', 'sam@example.com', 'body')).resolves
+      .toBe(`<p>The sender needs approval for the budget.</p>
+
+<p><strong>Details:</strong></p>
+<ul>
+<li>Budget is $12,000.</li>
+</ul>`);
+    expect(ai.run).toHaveBeenCalledWith(
+      '@cf/deepseek-ai/deepseek-r1-distill-qwen-32b',
+      expect.objectContaining({
+        response_format: {
+          type: 'json_schema',
+          json_schema: expect.objectContaining({
+            name: 'email_summary',
+            strict: true,
+          }),
+        },
+        reasoning_effort: 'low',
+        chat_template_kwargs: { thinking: false },
+      }),
+    );
+  });
+
+  it('does not add chat_template_kwargs for non-reasoning models with JSON mode', async () => {
+    const ai = {
+      run: vi.fn().mockResolvedValue({
+        response: JSON.stringify({
+          gist: 'The sender needs approval for the budget.',
+          keyDetails: ['Budget is $12,000.'],
+        }),
+      }),
+    } as unknown as Ai;
+
+    await expect(EmailSummaryUtil.summarizeEmail(ai, '@cf/openai/gpt-oss-20b', 'Campaign budget', 'sam@example.com', 'body')).resolves
+      .toBe(`<p>The sender needs approval for the budget.</p>
+
+<p><strong>Details:</strong></p>
+<ul>
+<li>Budget is $12,000.</li>
+</ul>`);
+    const requestArg = (ai.run as ReturnType<typeof vi.fn>).mock.calls[0][1];
+    expect(requestArg).toHaveProperty('response_format');
+    expect(requestArg).toHaveProperty('reasoning_effort', 'low');
+    expect(requestArg).not.toHaveProperty('chat_template_kwargs');
   });
 
   it('extracts summary text from Responses API output', async () => {


### PR DESCRIPTION
The Kimi K2.6 and DeepSeek R1 distilled models are reasoning models that return content: null in chat completions when reasoning is enabled (the default). When using JSON schema output format, this causes extractResponseText to return undefined, triggering 'Workers AI did not return a summary' error.

Added REASONING_MODELS_REQUIRING_THINKING_DISABLED set and conditionally set chat_template_kwargs: { thinking: false } for these models when using JSON schema mode, ensuring they output JSON directly in the content field.

Updated tests to verify thinking is disabled for reasoning models and not added for non-reasoning models.