### PR TITLE
Real Package Tracking Via Aftership API

### DIFF
--- a/packages/backend-runtime/src/env.d.ts
+++ b/packages/backend-runtime/src/env.d.ts
@@ -38,6 +38,8 @@ declare global {
     ACTION_CALLBACK_BASE_URL?: string | undefined;
     ACTION_DEFAULT_EXPIRY_HOURS?: string | undefined;
     ACTION_RETENTION_DAYS?: string | undefined;
+    PACKAGE_TRACKING_API_KEY?: string | undefined;
+    FLIGHT_TRACKING_API_KEY?: string | undefined;
   }
 }
 

--- a/packages/backend-services/src/action/ActionExecutionService.ts
+++ b/packages/backend-services/src/action/ActionExecutionService.ts
@@ -35,6 +35,8 @@ import { OAuth2AccessTokenService } from '../oauth2/OAuth2AccessTokenService';
 import { createActionDAO, hashToken } from './ActionServiceUtils';
 import type { ActionCreationEnv } from './ActionCreationService';
 import { renderConfirmationPage, renderMessagePage, renderResultPage } from './ActionRenderService';
+import * as PackageTrackingService from './PackageTrackingService';
+import { ConfigurationManager } from '@mail-otter/backend-runtime/config';
 
 interface ActionHtmlResponse {
   statusCode: number;
@@ -88,6 +90,11 @@ async function executeProviderOperation(action: EmailAction, env: ActionExecutio
   }
   if (action.actionType === EMAIL_ACTION_TYPE_DELIVERY_TRACK_PACKAGE) {
     const payload = action.payload as DeliveryTrackPackageActionPayload;
+    const trackingApiKey = ConfigurationManager.digest.getPackageTrackingApiKey(env);
+    if (trackingApiKey) {
+      const status = await PackageTrackingService.fetchStatus(payload.trackingNumber, payload.carrier, trackingApiKey);
+      if (status) return { summary: status.summary, externalUrl: payload.trackingUrl ?? undefined };
+    }
     if (payload.trackingUrl) return { summary: 'Package tracking link opened.', externalUrl: payload.trackingUrl };
     const via = payload.carrier ? ` via ${payload.carrier}` : '';
     return { summary: `Package tracking noted: ${payload.trackingNumber}${via}.` };

--- a/packages/backend-services/src/action/PackageTrackingService.ts
+++ b/packages/backend-services/src/action/PackageTrackingService.ts
@@ -1,0 +1,119 @@
+const AFTERSHIP_API_BASE = 'https://api.aftership.com/tracking/2024-10';
+
+// Maps common carrier name substrings (lower-cased) to Aftership slugs.
+const CARRIER_SLUG_MAP: [string, string][] = [
+  ['ups', 'ups'],
+  ['fedex', 'fedex'],
+  ['usps', 'usps'],
+  ['dhl', 'dhl'],
+  ['amazon', 'amazon'],
+  ['ontrac', 'ontrac'],
+  ['lasership', 'lasership'],
+  ['lso', 'lasership'],
+  ['purolator', 'purolator'],
+  ['canada post', 'canada-post'],
+  ['royal mail', 'royal-mail'],
+  ['australia post', 'australia-post'],
+];
+
+const TAG_LABELS: Record<string, string> = {
+  Delivered: 'Delivered',
+  OutForDelivery: 'Out For Delivery',
+  InTransit: 'In Transit',
+  AttemptFail: 'Delivery Attempted',
+  Exception: 'Exception',
+  AvailableForPickup: 'Available For Pickup',
+  Pending: 'Label Created',
+  InfoReceived: 'Label Created',
+  Expired: 'Expired',
+};
+
+interface AftershippCheckpoint {
+  message?: string;
+  city?: string;
+  state?: string;
+  created_at?: string;
+}
+
+interface AftershippTracking {
+  tag?: string;
+  expected_delivery?: string;
+  checkpoints?: AftershippCheckpoint[];
+}
+
+interface AftershippResponse {
+  data?: {
+    tracking?: AftershippTracking;
+  };
+}
+
+interface PackageTrackingStatus {
+  summary: string;
+}
+
+function resolveSlug(carrier: string | undefined): string | undefined {
+  if (!carrier) return undefined;
+  const lower = carrier.toLowerCase();
+  for (const [fragment, slug] of CARRIER_SLUG_MAP) {
+    if (lower.includes(fragment)) return slug;
+  }
+  return undefined;
+}
+
+function formatExpectedDelivery(raw: string): string {
+  const date = new Date(raw);
+  if (isNaN(date.getTime())) return raw;
+  return date.toLocaleDateString('en-US', { month: 'short', day: 'numeric', year: 'numeric' });
+}
+
+function buildSummary(tracking: AftershippTracking): string {
+  const tag = tracking.tag ?? '';
+  const statusLabel = TAG_LABELS[tag] ?? tag;
+
+  const checkpoints = tracking.checkpoints ?? [];
+  const latest = checkpoints[checkpoints.length - 1];
+  const locationParts: string[] = [];
+  if (latest) {
+    if (latest.message) locationParts.push(latest.message);
+    const place = [latest.city, latest.state].filter(Boolean).join(', ');
+    if (place) locationParts.push(place);
+  }
+
+  let summary = statusLabel;
+  if (locationParts.length) summary += ` — ${locationParts.join(', ')}`;
+  if (tracking.expected_delivery) {
+    summary += `. Expected: ${formatExpectedDelivery(tracking.expected_delivery)}`;
+  }
+  return summary;
+}
+
+async function fetchStatus(trackingNumber: string, carrier: string | undefined, apiKey: string): Promise<PackageTrackingStatus | null> {
+  const slug = resolveSlug(carrier);
+  const body: Record<string, unknown> = { tracking_number: trackingNumber };
+  if (slug) body.slug = slug;
+
+  try {
+    const response = await fetch(`${AFTERSHIP_API_BASE}/trackings`, {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        'as-api-key': apiKey,
+      },
+      body: JSON.stringify({ tracking: body }),
+    });
+
+    // 201 Created or 409 Already Exists both include tracking data in the body.
+    if (response.status !== 201 && response.status !== 409) return null;
+
+    const json = (await response.json()) as AftershippResponse;
+    const tracking = json?.data?.tracking;
+    if (!tracking) return null;
+
+    return { summary: buildSummary(tracking) };
+  } catch {
+    return null;
+  }
+}
+
+export type { PackageTrackingStatus };
+export { fetchStatus, resolveSlug };

--- a/test/services/ActionService.test.ts
+++ b/test/services/ActionService.test.ts
@@ -60,6 +60,10 @@ vi.mock('@mail-otter/backend-runtime/config', () => ({
     getActionCallbackBaseUrl: vi.fn(() => ''),
     getActionDefaultExpiryHours: vi.fn(() => 24),
     getActionRetentionDays: vi.fn(() => 30),
+    digest: {
+      getPackageTrackingApiKey: vi.fn(() => ''),
+      getFlightTrackingApiKey: vi.fn(() => ''),
+    },
   },
 }));
 
@@ -82,6 +86,11 @@ vi.mock('../../packages/backend-services/src/oauth2/OAuth2AccessTokenService', (
   OAuth2AccessTokenService: vi.fn(function () {
     return { getAccessToken: vi.fn(async () => 'access-token') };
   }),
+}));
+
+const { mockFetchStatus } = vi.hoisted(() => ({ mockFetchStatus: vi.fn() }));
+vi.mock('../../packages/backend-services/src/action/PackageTrackingService', () => ({
+  fetchStatus: mockFetchStatus,
 }));
 
 vi.mock('@mail-otter/provider-clients/gmail', () => ({
@@ -1012,6 +1021,51 @@ describe('ActionService', () => {
 
       expect(mockMarkSucceeded).toHaveBeenCalledWith('action-1', expect.objectContaining({
         summary: 'Package tracking noted: 1Z999 via UPS.',
+      }));
+    });
+
+    it('executes delivery.track_package with Aftership API key and returns live status', async () => {
+      const { ConfigurationManager } = await import('@mail-otter/backend-runtime/config');
+      (ConfigurationManager.digest.getPackageTrackingApiKey as ReturnType<typeof vi.fn>).mockReturnValue('aftership-key');
+      mockFetchStatus.mockResolvedValue({ summary: 'In Transit — In transit, Louisville, KY' });
+
+      const payload = { type: 'delivery.track_package', trackingNumber: '1Z999', carrier: 'UPS', trackingUrl: 'https://track.example.com/1Z999' };
+      const action = makeAction({ actionType: 'delivery.track_package', payload });
+      const doneAction = makeAction({ status: 'succeeded' });
+      mockGetByTokenHash.mockResolvedValue(action);
+      mockClaimForExecution.mockResolvedValue(true);
+      mockMarkSucceeded.mockResolvedValue(undefined);
+      mockRecordExecution.mockResolvedValue(undefined);
+      mockGetForUser.mockResolvedValue(doneAction);
+
+      await ActionService.executeActionWithToken('action-1', 'token', new Request('https://example.com'), makeEnv() as never);
+
+      expect(mockFetchStatus).toHaveBeenCalledWith('1Z999', 'UPS', 'aftership-key');
+      expect(mockMarkSucceeded).toHaveBeenCalledWith('action-1', expect.objectContaining({
+        summary: 'In Transit — In transit, Louisville, KY',
+        externalUrl: 'https://track.example.com/1Z999',
+      }));
+    });
+
+    it('falls back to static behavior when Aftership API returns null', async () => {
+      const { ConfigurationManager } = await import('@mail-otter/backend-runtime/config');
+      (ConfigurationManager.digest.getPackageTrackingApiKey as ReturnType<typeof vi.fn>).mockReturnValue('aftership-key');
+      mockFetchStatus.mockResolvedValue(null);
+
+      const payload = { type: 'delivery.track_package', trackingNumber: '1Z999', carrier: 'UPS', trackingUrl: 'https://track.example.com/1Z999' };
+      const action = makeAction({ actionType: 'delivery.track_package', payload });
+      const doneAction = makeAction({ status: 'succeeded' });
+      mockGetByTokenHash.mockResolvedValue(action);
+      mockClaimForExecution.mockResolvedValue(true);
+      mockMarkSucceeded.mockResolvedValue(undefined);
+      mockRecordExecution.mockResolvedValue(undefined);
+      mockGetForUser.mockResolvedValue(doneAction);
+
+      await ActionService.executeActionWithToken('action-1', 'token', new Request('https://example.com'), makeEnv() as never);
+
+      expect(mockMarkSucceeded).toHaveBeenCalledWith('action-1', expect.objectContaining({
+        summary: 'Package tracking link opened.',
+        externalUrl: 'https://track.example.com/1Z999',
       }));
     });
 

--- a/test/services/PackageTrackingService.test.ts
+++ b/test/services/PackageTrackingService.test.ts
@@ -1,0 +1,151 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { fetchStatus, resolveSlug } from '@mail-otter/backend-services/action/PackageTrackingService';
+
+const API_KEY = 'test-aftership-key';
+
+function makeCheckpoint(overrides?: Record<string, unknown>) {
+  return { message: 'In transit', city: 'Louisville', state: 'KY', created_at: '2026-06-24T08:00:00Z', ...overrides };
+}
+
+function makeTrackingResponse(overrides?: Record<string, unknown>) {
+  return {
+    data: {
+      tracking: {
+        tag: 'InTransit',
+        expected_delivery: '2026-06-26T00:00:00Z',
+        checkpoints: [makeCheckpoint()],
+        ...overrides,
+      },
+    },
+  };
+}
+
+function mockFetch(status: number, body: unknown) {
+  return vi.spyOn(globalThis, 'fetch').mockResolvedValue(
+    new Response(JSON.stringify(body), { status }),
+  );
+}
+
+describe('PackageTrackingService', () => {
+  afterEach(() => vi.restoreAllMocks());
+
+  describe('resolveSlug', () => {
+    it('maps UPS to ups (case-insensitive)', () => expect(resolveSlug('UPS')).toBe('ups'));
+    it('maps FedEx Express to fedex', () => expect(resolveSlug('FedEx Express')).toBe('fedex'));
+    it('maps USPS to usps', () => expect(resolveSlug('USPS')).toBe('usps'));
+    it('maps DHL to dhl', () => expect(resolveSlug('DHL Express')).toBe('dhl'));
+    it('maps Amazon Logistics to amazon', () => expect(resolveSlug('Amazon Logistics')).toBe('amazon'));
+    it('maps OnTrac to ontrac', () => expect(resolveSlug('OnTrac')).toBe('ontrac'));
+    it('maps LaserShip to lasership', () => expect(resolveSlug('LaserShip')).toBe('lasership'));
+    it('maps LSO to lasership', () => expect(resolveSlug('LSO')).toBe('lasership'));
+    it('returns undefined for unrecognized carrier', () => expect(resolveSlug('SpeedyShip')).toBeUndefined());
+    it('returns undefined for undefined carrier', () => expect(resolveSlug(undefined)).toBeUndefined());
+  });
+
+  describe('fetchStatus', () => {
+    it('returns formatted summary for InTransit with location and expected delivery', async () => {
+      mockFetch(201, makeTrackingResponse());
+
+      const result = await fetchStatus('1Z999AA10123456784', 'UPS', API_KEY);
+
+      expect(result).not.toBeNull();
+      expect(result!.summary).toContain('In Transit');
+      expect(result!.summary).toContain('In transit');
+      expect(result!.summary).toContain('Louisville');
+      expect(result!.summary).toContain('Expected:');
+    });
+
+    it('returns Delivered label for Delivered tag', async () => {
+      mockFetch(201, makeTrackingResponse({ tag: 'Delivered', checkpoints: [makeCheckpoint({ message: 'Delivered' })], expected_delivery: undefined }));
+
+      const result = await fetchStatus('1Z999', 'UPS', API_KEY);
+
+      expect(result!.summary).toMatch(/^Delivered/);
+    });
+
+    it('returns Out For Delivery label for OutForDelivery tag', async () => {
+      mockFetch(201, makeTrackingResponse({ tag: 'OutForDelivery', expected_delivery: undefined }));
+
+      const result = await fetchStatus('1Z999', undefined, API_KEY);
+
+      expect(result!.summary).toContain('Out For Delivery');
+    });
+
+    it('handles 409 Already Exists by returning tracking data from the body', async () => {
+      mockFetch(409, makeTrackingResponse({ tag: 'InTransit' }));
+
+      const result = await fetchStatus('1Z999', 'UPS', API_KEY);
+
+      expect(result).not.toBeNull();
+      expect(result!.summary).toContain('In Transit');
+    });
+
+    it('returns null for unexpected HTTP status', async () => {
+      mockFetch(400, { meta: { code: 400, message: 'Bad Request' } });
+
+      const result = await fetchStatus('1Z999', 'UPS', API_KEY);
+
+      expect(result).toBeNull();
+    });
+
+    it('returns null for 500 server error', async () => {
+      mockFetch(500, {});
+
+      const result = await fetchStatus('1Z999', 'UPS', API_KEY);
+
+      expect(result).toBeNull();
+    });
+
+    it('returns null on network error', async () => {
+      vi.spyOn(globalThis, 'fetch').mockRejectedValue(new Error('Network error'));
+
+      const result = await fetchStatus('1Z999', 'UPS', API_KEY);
+
+      expect(result).toBeNull();
+    });
+
+    it('returns null when tracking data is missing from response body', async () => {
+      mockFetch(201, { data: {} });
+
+      const result = await fetchStatus('1Z999', 'UPS', API_KEY);
+
+      expect(result).toBeNull();
+    });
+
+    it('builds summary without location when checkpoints are empty', async () => {
+      mockFetch(201, makeTrackingResponse({ checkpoints: [], expected_delivery: undefined }));
+
+      const result = await fetchStatus('1Z999', undefined, API_KEY);
+
+      expect(result!.summary).toBe('In Transit');
+    });
+
+    it('sends no slug when carrier is unrecognized', async () => {
+      const spy = mockFetch(201, makeTrackingResponse());
+
+      await fetchStatus('1Z999', 'SpeedyShip', API_KEY);
+
+      const body = JSON.parse((spy.mock.calls[0][1] as RequestInit).body as string);
+      expect(body.tracking.slug).toBeUndefined();
+      expect(body.tracking.tracking_number).toBe('1Z999');
+    });
+
+    it('sends slug when carrier is recognized', async () => {
+      const spy = mockFetch(201, makeTrackingResponse());
+
+      await fetchStatus('1Z999', 'FedEx', API_KEY);
+
+      const body = JSON.parse((spy.mock.calls[0][1] as RequestInit).body as string);
+      expect(body.tracking.slug).toBe('fedex');
+    });
+
+    it('sends as-api-key header', async () => {
+      const spy = mockFetch(201, makeTrackingResponse());
+
+      await fetchStatus('1Z999', 'UPS', API_KEY);
+
+      const headers = spy.mock.calls[0][1]?.headers as Record<string, string>;
+      expect(headers['as-api-key']).toBe(API_KEY);
+    });
+  });
+});


### PR DESCRIPTION
When a `delivery.track_package` action is executed and `PACKAGE_TRACKING_API_KEY` is set, the Worker now calls the Aftership tracking API (2024-10) to fetch live carrier status instead of returning a static acknowledgment. The response is formatted into a human-readable summary (status, last checkpoint location, expected delivery date) and returned as the action result. The original `trackingUrl` from the email is preserved as `externalUrl` so users can still click through to the carrier page.

Carrier names are mapped to Aftership slugs (ups, fedex, usps, dhl, amazon, ontrac, lasership, and more); unrecognized carriers omit the slug so Aftership auto-detects. HTTP 201 (created) and 409 (already exists) are both accepted — both include `data.tracking` in the response body. Any error (network failure, unexpected status, missing body) returns `null` and the existing static fallback behavior is used, so deployments without an API key see no change.

`PACKAGE_TRACKING_API_KEY` and `FLIGHT_TRACKING_API_KEY` are added to `env.d.ts` (both were already defined in `ConfigurationDefaults` and `ConfigurationManager`).