### PR TITLE
Manual Run Now For Background Tasks

### DIFF
--- a/apps/api/src/endpoints/index.ts
+++ b/apps/api/src/endpoints/index.ts
@@ -44,6 +44,7 @@ import { OutlookLifecycleWebhookRoute as OriginalOutlookLifecycleWebhookRoute } 
 import { ListBackgroundTaskRunsRoute as OriginalListBackgroundTaskRunsRoute } from './user/processing/task-runs/GET';
 import { ListProcessingCalendarEventsRoute as OriginalListProcessingCalendarEventsRoute } from './user/processing/calendar-events/GET';
 import { ListProcessedMessagesRoute as OriginalListProcessedMessagesRoute } from './user/processing/messages/GET';
+import { RunTaskNowRoute as OriginalRunTaskNowRoute } from './user/processing/run-task/POST';
 
 export const GetAnalyticsRoute: any = OriginalGetAnalyticsRoute;
 export const GetCurrentUserRoute: any = OriginalGetCurrentUserRoute;
@@ -88,3 +89,4 @@ export const SendDigestNowRoute: any = OriginalSendDigestNowRoute;
 export const ListBackgroundTaskRunsRoute: any = OriginalListBackgroundTaskRunsRoute;
 export const ListProcessingCalendarEventsRoute: any = OriginalListProcessingCalendarEventsRoute;
 export const ListProcessedMessagesRoute: any = OriginalListProcessedMessagesRoute;
+export const RunTaskNowRoute: any = OriginalRunTaskNowRoute;

--- a/apps/api/src/endpoints/user/processing/run-task/POST.ts
+++ b/apps/api/src/endpoints/user/processing/run-task/POST.ts
@@ -1,0 +1,46 @@
+import { IUserRoute } from '@/endpoints/IUserRoute';
+import type { IUserEnv, IRequest, IResponse, RouteContext } from '@/endpoints/IUserRoute';
+import { ProcessingService } from '@mail-otter/backend-services/processing';
+
+class RunTaskNowRoute extends IUserRoute<RunTaskNowRequest, RunTaskNowResponse, RunTaskNowEnv> {
+  schema = {
+    tags: ['Processing'],
+    summary: 'Manually trigger a user-level scheduled task for a connected application',
+    responses: {
+      '200': {
+        description: 'Task triggered',
+      },
+    },
+  };
+
+  protected async handleRequest(
+    request: RunTaskNowRequest,
+    env: RunTaskNowEnv,
+    cxt: RouteContext<RunTaskNowEnv>,
+  ): Promise<RunTaskNowResponse> {
+    const userEmail = this.getAuthenticatedUserEmailAddress(cxt);
+    await ProcessingService.triggerTask(userEmail, request.taskType, request.applicationId, env);
+    return { triggered: true };
+  }
+}
+
+interface RunTaskNowRequest extends IRequest {
+  taskType: string;
+  applicationId: string;
+}
+
+interface RunTaskNowResponse extends IResponse {
+  triggered: boolean;
+}
+
+interface RunTaskNowEnv extends IUserEnv {
+  AES_ENCRYPTION_KEY_SECRET: SecretsStoreSecret;
+  ACTION_ENCRYPTION_KEY_SECRET: SecretsStoreSecret;
+  OAUTH2_TOKEN_CACHE: KVNamespace;
+  OAUTH2_TOKEN_REFRESHERS: DurableObjectNamespace;
+  PACKAGE_TRACKING_API_KEY?: string | undefined;
+  FLIGHT_TRACKING_API_KEY?: string | undefined;
+  OAUTH2_ACCESS_TOKEN_MIN_VALID_SECONDS?: string | undefined;
+}
+
+export { RunTaskNowRoute };

--- a/apps/api/src/workers/MailOtterWorker.ts
+++ b/apps/api/src/workers/MailOtterWorker.ts
@@ -6,6 +6,7 @@ import {
   ListBackgroundTaskRunsRoute,
   ListProcessingCalendarEventsRoute,
   ListProcessedMessagesRoute,
+  RunTaskNowRoute,
   CreateApplicationRoute,
   GetApplicationRulesRoute,
   UpdateApplicationRulesRoute,
@@ -157,6 +158,7 @@ class MailOtterWorker extends AbstractEntrypointWorker {
     openapi.get('/user/processing/task-runs', ListBackgroundTaskRunsRoute);
     openapi.get('/user/processing/calendar-events', ListProcessingCalendarEventsRoute);
     openapi.get('/user/processing/messages', ListProcessedMessagesRoute);
+    openapi.post('/user/processing/run-task', RunTaskNowRoute);
   }
 
   private registerPublicApiRoutes(openapi: AppRouter): void {

--- a/apps/web/src/SpaApp.tsx
+++ b/apps/web/src/SpaApp.tsx
@@ -230,6 +230,8 @@ export default function SpaApp() {
               processedMessagesCursor={processing.processedMessagesCursor}
               processedMessagesLoading={processing.processedMessagesLoading}
               onRefresh={() => processing.loadProcessing()}
+              onTriggerTaskRun={() => processing.triggerTaskRun()}
+              triggeringTask={processing.triggeringTask}
               onLoadMoreTaskRuns={() => processing.loadTaskRuns(true, processing.taskRunsCursor)}
               onLoadMoreCalendarEvents={() => processing.loadCalendarEvents(true, processing.calendarEventsCursor)}
               onLoadMoreProcessedMessages={() => processing.loadProcessedMessages(true, processing.processedMessagesCursor)}

--- a/apps/web/src/components/views/ProcessingView.tsx
+++ b/apps/web/src/components/views/ProcessingView.tsx
@@ -1,4 +1,4 @@
-import { RefreshCw, ChevronDown } from 'lucide-react';
+import { RefreshCw, ChevronDown, Play } from 'lucide-react';
 import type { ConnectedApplication } from '../../../components/types';
 import type {
   BackgroundTaskRun,
@@ -7,7 +7,7 @@ import type {
   ProcessedMessageStatus,
   SyncedCalendarEvent,
 } from '../../services/processingService';
-import { getTaskTypeLabel } from '../../services/processingService';
+import { getTaskTypeLabel, TRIGGERABLE_TASK_TYPES } from '../../services/processingService';
 import { TaskRunStatusBadge, ProcessedMessageStatusBadge } from '../ui/Badge';
 import { Button } from '../ui/Button';
 import { Card, CardHeader, CardTitle } from '../ui/Card';
@@ -132,6 +132,8 @@ export function ProcessingView({
   processedMessagesCursor,
   processedMessagesLoading,
   onRefresh,
+  onTriggerTaskRun,
+  triggeringTask,
   onLoadMoreTaskRuns,
   onLoadMoreCalendarEvents,
   onLoadMoreProcessedMessages,
@@ -155,6 +157,8 @@ export function ProcessingView({
   processedMessagesCursor?: string;
   processedMessagesLoading: boolean;
   onRefresh: () => void;
+  onTriggerTaskRun: () => void;
+  triggeringTask: boolean;
   onLoadMoreTaskRuns: () => void;
   onLoadMoreCalendarEvents: () => void;
   onLoadMoreProcessedMessages: () => void;
@@ -190,6 +194,15 @@ export function ProcessingView({
             <option key={o.value} value={o.value}>{o.label}</option>
           ))}
         </Select>
+        <Button
+          variant="secondary"
+          size="sm"
+          onClick={onTriggerTaskRun}
+          disabled={triggeringTask || !(TRIGGERABLE_TASK_TYPES as readonly string[]).includes(taskType) || !applicationId}
+        >
+          <Play className="h-3.5 w-3.5" />
+          Run Now
+        </Button>
         <Button variant="secondary" size="sm" onClick={onRefresh} className="ml-auto">
           <RefreshCw className="h-3.5 w-3.5" />
           Refresh

--- a/apps/web/src/hooks/useProcessing.ts
+++ b/apps/web/src/hooks/useProcessing.ts
@@ -24,6 +24,8 @@ export function useProcessing({ showNotice }: UseProcessingOptions) {
   const [processedMessagesCursor, setProcessedMessagesCursor] = useState<string | undefined>(undefined);
   const [processedMessagesLoading, setProcessedMessagesLoading] = useState(false);
 
+  const [triggeringTask, setTriggeringTask] = useState(false);
+
   const loadTaskRuns = async (append = false, cursor?: string) => {
     setTaskRunsLoading(true);
     try {
@@ -79,6 +81,19 @@ export function useProcessing({ showNotice }: UseProcessingOptions) {
     await Promise.all([loadTaskRuns(), loadCalendarEvents(), loadProcessedMessages()]);
   };
 
+  const triggerTaskRun = async () => {
+    setTriggeringTask(true);
+    try {
+      await processingService.triggerTaskRun(processingTaskType, processingApplicationId);
+      showNotice('success', 'Task Triggered Successfully.');
+      await loadTaskRuns();
+    } catch (e) {
+      showNotice('error', e instanceof Error ? e.message : 'Unable To Trigger Task.');
+    } finally {
+      setTriggeringTask(false);
+    }
+  };
+
   return {
     processingApplicationId,
     setProcessingApplicationId,
@@ -105,5 +120,7 @@ export function useProcessing({ showNotice }: UseProcessingOptions) {
     loadProcessedMessages,
 
     loadProcessing,
+    triggerTaskRun,
+    triggeringTask,
   };
 }

--- a/apps/web/src/services/processingService.ts
+++ b/apps/web/src/services/processingService.ts
@@ -1,5 +1,7 @@
 import { apiFetch, readJson } from '../../components/utils';
 
+export const TRIGGERABLE_TASK_TYPES = ['calendar_sync', 'action_status_sync'] as const;
+
 export type BackgroundTaskRunStatus = 'running' | 'success' | 'partial_success' | 'error' | 'skipped';
 export type ProcessedMessageStatus = 'processing' | 'summarized' | 'skipped' | 'error';
 
@@ -84,6 +86,15 @@ export async function loadCalendarEvents(options: {
   return readJson<{ events: SyncedCalendarEvent[]; nextCursor?: string }>(
     await apiFetch(`/user/processing/calendar-events${qs ? `?${qs}` : ''}`),
   );
+}
+
+export async function triggerTaskRun(taskType: string, applicationId: string): Promise<void> {
+  const response = await apiFetch('/user/processing/run-task', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ taskType, applicationId }),
+  });
+  await readJson(response);
 }
 
 export async function loadProcessedMessages(options: {

--- a/packages/backend-services/src/processing/ProcessingService.ts
+++ b/packages/backend-services/src/processing/ProcessingService.ts
@@ -1,4 +1,4 @@
-import { BackgroundTaskRunDAO, ProcessedMessageDAO, SyncedCalendarEventDAO } from '@mail-otter/backend-data/dao';
+import { BackgroundTaskRunDAO, ConnectedApplicationDAO, ProcessedMessageDAO, SyncedCalendarEventDAO } from '@mail-otter/backend-data/dao';
 import type {
   BackgroundTaskRunList,
   BackgroundTaskRunStatus,
@@ -8,9 +8,24 @@ import type {
 } from '@mail-otter/backend-data/dao';
 import type { ProcessedMessageList, SyncedCalendarEventList } from '@mail-otter/shared/model';
 import type { D1Queryable } from '@mail-otter/backend-data/utils';
+import { ConfigurationManager } from '@mail-otter/backend-runtime/config';
+import { BadRequestError } from '@mail-otter/backend-errors';
+import { ActionStatusSyncUtil, CalendarEventSyncUtil } from '../digest';
+import { OAuth2AccessTokenService } from '../oauth2';
+import { BACKGROUND_TASK_TYPE_ACTION_STATUS_SYNC, BACKGROUND_TASK_TYPE_CALENDAR_SYNC } from '@mail-otter/shared/constants';
 
 interface ProcessingServiceEnv {
   DB: D1Queryable;
+}
+
+interface TriggerTaskEnv extends ProcessingServiceEnv {
+  AES_ENCRYPTION_KEY_SECRET: SecretsStoreSecret;
+  ACTION_ENCRYPTION_KEY_SECRET: SecretsStoreSecret;
+  OAUTH2_TOKEN_CACHE: KVNamespace;
+  OAUTH2_TOKEN_REFRESHERS: DurableObjectNamespace;
+  PACKAGE_TRACKING_API_KEY?: string | undefined;
+  FLIGHT_TRACKING_API_KEY?: string | undefined;
+  OAUTH2_ACCESS_TOKEN_MIN_VALID_SECONDS?: string | undefined;
 }
 
 class ProcessingService {
@@ -49,7 +64,39 @@ class ProcessingService {
       cursor: options.cursor,
     });
   }
+
+  static async triggerTask(
+    userEmail: string,
+    taskType: string,
+    applicationId: string,
+    env: TriggerTaskEnv,
+  ): Promise<void> {
+    if (taskType !== BACKGROUND_TASK_TYPE_CALENDAR_SYNC && taskType !== BACKGROUND_TASK_TYPE_ACTION_STATUS_SYNC) {
+      throw new BadRequestError(`Task type '${taskType}' cannot be triggered manually.`);
+    }
+
+    const masterKey: string = await env.AES_ENCRYPTION_KEY_SECRET.get();
+    const applicationDAO = new ConnectedApplicationDAO(env.DB, masterKey);
+    const application = await applicationDAO.getByIdForUser(applicationId, userEmail);
+    if (!application) throw new BadRequestError('Connected application not found.');
+
+    if (taskType === BACKGROUND_TASK_TYPE_CALENDAR_SYNC) {
+      const now = new Date();
+      const windowStartIso = now.toISOString();
+      const windowEndIso = new Date(now.getTime() + 48 * 3600 * 1000).toISOString();
+      const accessToken = await new OAuth2AccessTokenService(env).getAccessToken(applicationId);
+      const syncUtil = new CalendarEventSyncUtil(env.DB);
+      await syncUtil.syncForApplication(application, accessToken, windowStartIso, windowEndIso);
+    } else {
+      const packageApiKey = ConfigurationManager.digest.getPackageTrackingApiKey(env);
+      const flightApiKey = ConfigurationManager.digest.getFlightTrackingApiKey(env);
+      const actionKey: string = await env.ACTION_ENCRYPTION_KEY_SECRET.get();
+      const syncUtil = new ActionStatusSyncUtil(env.DB, actionKey);
+      if (packageApiKey) await syncUtil.syncPackageActions(applicationId, packageApiKey);
+      if (flightApiKey) await syncUtil.syncFlightActions(applicationId, flightApiKey);
+    }
+  }
 }
 
 export { ProcessingService };
-export type { ProcessingServiceEnv };
+export type { ProcessingServiceEnv, TriggerTaskEnv };

--- a/packages/backend-services/src/processing/index.ts
+++ b/packages/backend-services/src/processing/index.ts
@@ -1,2 +1,2 @@
 export { ProcessingService } from './ProcessingService';
-export type { ProcessingServiceEnv } from './ProcessingService';
+export type { ProcessingServiceEnv, TriggerTaskEnv } from './ProcessingService';


### PR DESCRIPTION
Adds a "Run Now" button to the Processing view that lets users immediately trigger a `calendar_sync` or `action_status_sync` task for a selected mailbox, without waiting for the next scheduled cron window.

- `POST /user/processing/run-task` endpoint validates ownership and dispatches `CalendarEventSyncUtil` or `ActionStatusSyncUtil` inline
- `ProcessingService.triggerTask()` centralises the task-dispatch logic and `TriggerTaskEnv` interface exported alongside the existing env type
- Frontend adds `TRIGGERABLE_TASK_TYPES` constant, `triggerTaskRun()` service call, `triggeringTask` hook state, and a Play-icon Run Now button in the filter bar (disabled unless a triggerable task type and mailbox are selected)