### PR TITLE
Wire Up Real Flight Tracking Via Aviationstack API

### DIFF
--- a/packages/backend-services/src/action/ActionExecutionService.ts
+++ b/packages/backend-services/src/action/ActionExecutionService.ts
@@ -36,6 +36,7 @@ import { createActionDAO, hashToken } from './ActionServiceUtils';
 import type { ActionCreationEnv } from './ActionCreationService';
 import { renderConfirmationPage, renderMessagePage, renderResultPage } from './ActionRenderService';
 import * as PackageTrackingService from './PackageTrackingService';
+import * as FlightTrackingService from './FlightTrackingService';
 import { ConfigurationManager } from '@mail-otter/backend-runtime/config';
 
 interface ActionHtmlResponse {
@@ -101,6 +102,18 @@ async function executeProviderOperation(action: EmailAction, env: ActionExecutio
   }
   if (action.actionType === EMAIL_ACTION_TYPE_TRAVEL_TRACK_FLIGHT) {
     const payload = action.payload as TravelTrackFlightActionPayload;
+    const flightTrackingApiKey = ConfigurationManager.digest.getFlightTrackingApiKey(env);
+    if (flightTrackingApiKey) {
+      const syncStatus = await FlightTrackingService.fetchFlightStatus(payload.flightNumber, flightTrackingApiKey);
+      if (syncStatus) {
+        const actionDAO = await createActionDAO(env);
+        await actionDAO.updateSyncStatus(action.actionId, JSON.stringify(syncStatus));
+        return {
+          summary: FlightTrackingService.formatFlightSummary(payload.flightNumber, syncStatus),
+          externalUrl: payload.trackingUrl ?? undefined,
+        };
+      }
+    }
     if (payload.trackingUrl) return { summary: 'Flight tracking link opened.', externalUrl: payload.trackingUrl };
     return { summary: `Flight ${payload.flightNumber} details noted.` };
   }

--- a/packages/backend-services/src/action/FlightTrackingService.ts
+++ b/packages/backend-services/src/action/FlightTrackingService.ts
@@ -1,0 +1,75 @@
+const AVIATIONSTACK_API_BASE = 'https://api.aviationstack.com/v1/flights';
+
+interface AviationstackFlight {
+  flight_status?: string;
+  departure?: { scheduled?: string; iata?: string };
+  arrival?: { iata?: string };
+  airline?: { name?: string };
+  flight?: { iata?: string };
+}
+
+interface AviationstackResponse {
+  data?: AviationstackFlight[];
+}
+
+interface FlightSyncStatus {
+  flightNumber: string;
+  airline?: string;
+  status?: string;
+  departureTime?: string;
+  departureIata?: string;
+  arrivalIata?: string;
+  lastUpdate?: string;
+}
+
+function formatFlightSummary(flightNumber: string, syncStatus: FlightSyncStatus): string {
+  const status = syncStatus.status ?? 'Unknown';
+  const statusLabel = STATUS_LABELS[status] ?? status;
+  let summary = `Flight ${flightNumber} — ${statusLabel}`;
+  if (syncStatus.departureTime) {
+    const time = formatDepartureTime(syncStatus.departureTime);
+    if (time) summary += ` · Departs ${time}`;
+  }
+  return summary;
+}
+
+const STATUS_LABELS: Record<string, string> = {
+  scheduled: 'Scheduled',
+  active: 'In Flight',
+  landed: 'Landed',
+  cancelled: 'Cancelled',
+  incident: 'Incident',
+  diverted: 'Diverted',
+};
+
+function formatDepartureTime(iso: string): string | null {
+  const date = new Date(iso);
+  if (isNaN(date.getTime())) return null;
+  return date.toLocaleTimeString('en-US', { hour: '2-digit', minute: '2-digit', hour12: false, timeZone: 'UTC' }) + ' UTC';
+}
+
+async function fetchFlightStatus(flightNumber: string, apiKey: string): Promise<FlightSyncStatus | null> {
+  try {
+    const url = new URL(AVIATIONSTACK_API_BASE);
+    url.searchParams.set('access_key', apiKey);
+    url.searchParams.set('flight_iata', flightNumber);
+    const response = await fetch(url.toString());
+    if (!response.ok) return null;
+    const json = (await response.json()) as AviationstackResponse;
+    const flight = json?.data?.[0];
+    if (!flight) return null;
+    return {
+      flightNumber,
+      airline: flight.airline?.name,
+      status: flight.flight_status,
+      departureTime: flight.departure?.scheduled,
+      departureIata: flight.departure?.iata,
+      arrivalIata: flight.arrival?.iata,
+    };
+  } catch {
+    return null;
+  }
+}
+
+export type { FlightSyncStatus };
+export { fetchFlightStatus, formatFlightSummary, formatDepartureTime, STATUS_LABELS };

--- a/packages/backend-services/src/digest/ActionStatusSyncUtil.ts
+++ b/packages/backend-services/src/digest/ActionStatusSyncUtil.ts
@@ -6,6 +6,7 @@ import {
 import type { DeliveryTrackPackageActionPayload, EmailAction, TravelTrackFlightActionPayload } from '@mail-otter/shared/model';
 import type { D1Queryable } from '@mail-otter/backend-data/utils';
 import { formatExpectedDelivery, TAG_LABELS } from '../action/PackageTrackingService';
+import { fetchFlightStatus } from '../action/FlightTrackingService';
 
 interface PackageSyncStatus {
   carrier?: string;
@@ -14,14 +15,6 @@ interface PackageSyncStatus {
   statusLabel?: string;
   location?: string;
   expectedDelivery?: string;
-  lastUpdate?: string;
-}
-
-interface FlightSyncStatus {
-  flightNumber: string;
-  airline?: string;
-  status?: string;
-  departureTime?: string;
   lastUpdate?: string;
 }
 
@@ -95,27 +88,13 @@ class ActionStatusSyncUtil {
     const payload = action.payload as TravelTrackFlightActionPayload;
     if (!payload.flightNumber || !apiKey) return;
 
-    const url = new URL('http://api.aviationstack.com/v1/flights');
-    url.searchParams.set('access_key', apiKey);
-    url.searchParams.set('flight_iata', payload.flightNumber);
-    const response = await fetch(url.toString());
-    if (!response.ok) return;
+    const syncStatus = await fetchFlightStatus(payload.flightNumber, apiKey);
+    if (!syncStatus) return;
 
-    const data = (await response.json()) as {
-      data?: Array<{ flight_status?: string; departure?: { scheduled?: string } }>;
-    };
-    const flight = data.data?.[0];
-    if (!flight) return;
-
-    const syncStatus: FlightSyncStatus = {
-      flightNumber: payload.flightNumber,
-      airline: payload.airline,
-      status: flight.flight_status,
-      departureTime: flight.departure?.scheduled,
-    };
     await this.actionDAO.updateSyncStatus(action.actionId, JSON.stringify(syncStatus));
   }
 }
 
 export { ActionStatusSyncUtil };
-export type { PackageSyncStatus, FlightSyncStatus };
+export type { PackageSyncStatus };
+export type { FlightSyncStatus } from '../action/FlightTrackingService';

--- a/test/services/ActionService.test.ts
+++ b/test/services/ActionService.test.ts
@@ -15,6 +15,7 @@ const {
   mockMarkExpired,
   mockRecordExecution,
   mockGetById,
+  mockUpdateSyncStatus,
 } = vi.hoisted(() => ({
   mockCreate: vi.fn(),
   mockDeleteByProcessedMessageId: vi.fn(),
@@ -30,6 +31,7 @@ const {
   mockMarkExpired: vi.fn(),
   mockRecordExecution: vi.fn(),
   mockGetById: vi.fn(),
+  mockUpdateSyncStatus: vi.fn(),
 }));
 
 vi.mock('@mail-otter/backend-data/dao', () => ({
@@ -48,6 +50,7 @@ vi.mock('@mail-otter/backend-data/dao', () => ({
       markFailed: mockMarkFailed,
       markExpired: mockMarkExpired,
       recordExecution: mockRecordExecution,
+      updateSyncStatus: mockUpdateSyncStatus,
     };
   }),
   ConnectedApplicationDAO: vi.fn(function () {
@@ -91,6 +94,15 @@ vi.mock('../../packages/backend-services/src/oauth2/OAuth2AccessTokenService', (
 const { mockFetchStatus } = vi.hoisted(() => ({ mockFetchStatus: vi.fn() }));
 vi.mock('../../packages/backend-services/src/action/PackageTrackingService', () => ({
   fetchStatus: mockFetchStatus,
+}));
+
+const { mockFetchFlightStatus, mockFormatFlightSummary } = vi.hoisted(() => ({
+  mockFetchFlightStatus: vi.fn(),
+  mockFormatFlightSummary: vi.fn(),
+}));
+vi.mock('../../packages/backend-services/src/action/FlightTrackingService', () => ({
+  fetchFlightStatus: mockFetchFlightStatus,
+  formatFlightSummary: mockFormatFlightSummary,
 }));
 
 vi.mock('@mail-otter/provider-clients/gmail', () => ({
@@ -1069,7 +1081,7 @@ describe('ActionService', () => {
       }));
     });
 
-    it('executes travel.track_flight and returns flight acknowledgment', async () => {
+    it('executes travel.track_flight without API key and returns static acknowledgment', async () => {
       const payload = { type: 'travel.track_flight', flightNumber: 'AA123', airline: 'American Airlines' };
       const action = makeAction({ actionType: 'travel.track_flight', payload });
       const doneAction = makeAction({ status: 'succeeded' });
@@ -1081,8 +1093,59 @@ describe('ActionService', () => {
 
       await ActionService.executeActionWithToken('action-1', 'token', new Request('https://example.com'), makeEnv() as never);
 
+      expect(mockFetchFlightStatus).not.toHaveBeenCalled();
       expect(mockMarkSucceeded).toHaveBeenCalledWith('action-1', expect.objectContaining({
         summary: 'Flight AA123 details noted.',
+      }));
+    });
+
+    it('executes travel.track_flight with API key and returns live status summary', async () => {
+      const { ConfigurationManager } = await import('@mail-otter/backend-runtime/config');
+      (ConfigurationManager.digest.getFlightTrackingApiKey as ReturnType<typeof vi.fn>).mockReturnValue('aviationstack-key');
+      const syncStatus = { flightNumber: 'AA123', status: 'scheduled', departureTime: '2026-07-01T14:30:00+00:00', departureIata: 'JFK', arrivalIata: 'LAX' };
+      mockFetchFlightStatus.mockResolvedValue(syncStatus);
+      mockFormatFlightSummary.mockReturnValue('Flight AA123 — Scheduled · Departs 14:30 UTC');
+      mockUpdateSyncStatus.mockResolvedValue(undefined);
+
+      const payload = { type: 'travel.track_flight', flightNumber: 'AA123', airline: 'American Airlines', trackingUrl: 'https://track.example.com/AA123' };
+      const action = makeAction({ actionType: 'travel.track_flight', payload });
+      const doneAction = makeAction({ status: 'succeeded' });
+      mockGetByTokenHash.mockResolvedValue(action);
+      mockClaimForExecution.mockResolvedValue(true);
+      mockMarkSucceeded.mockResolvedValue(undefined);
+      mockRecordExecution.mockResolvedValue(undefined);
+      mockGetForUser.mockResolvedValue(doneAction);
+
+      await ActionService.executeActionWithToken('action-1', 'token', new Request('https://example.com'), makeEnv() as never);
+
+      expect(mockFetchFlightStatus).toHaveBeenCalledWith('AA123', 'aviationstack-key');
+      expect(mockUpdateSyncStatus).toHaveBeenCalledWith('action-1', expect.stringContaining('scheduled'));
+      expect(mockMarkSucceeded).toHaveBeenCalledWith('action-1', expect.objectContaining({
+        summary: 'Flight AA123 — Scheduled · Departs 14:30 UTC',
+        externalUrl: 'https://track.example.com/AA123',
+      }));
+    });
+
+    it('falls back to static behavior when flight API returns null', async () => {
+      const { ConfigurationManager } = await import('@mail-otter/backend-runtime/config');
+      (ConfigurationManager.digest.getFlightTrackingApiKey as ReturnType<typeof vi.fn>).mockReturnValue('aviationstack-key');
+      mockFetchFlightStatus.mockResolvedValue(null);
+
+      const payload = { type: 'travel.track_flight', flightNumber: 'AA123', trackingUrl: 'https://track.example.com/AA123' };
+      const action = makeAction({ actionType: 'travel.track_flight', payload });
+      const doneAction = makeAction({ status: 'succeeded' });
+      mockGetByTokenHash.mockResolvedValue(action);
+      mockClaimForExecution.mockResolvedValue(true);
+      mockMarkSucceeded.mockResolvedValue(undefined);
+      mockRecordExecution.mockResolvedValue(undefined);
+      mockGetForUser.mockResolvedValue(doneAction);
+
+      await ActionService.executeActionWithToken('action-1', 'token', new Request('https://example.com'), makeEnv() as never);
+
+      expect(mockUpdateSyncStatus).not.toHaveBeenCalled();
+      expect(mockMarkSucceeded).toHaveBeenCalledWith('action-1', expect.objectContaining({
+        summary: 'Flight tracking link opened.',
+        externalUrl: 'https://track.example.com/AA123',
       }));
     });
 

--- a/test/services/FlightTrackingService.test.ts
+++ b/test/services/FlightTrackingService.test.ts
@@ -1,0 +1,203 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { fetchFlightStatus, formatFlightSummary, formatDepartureTime, STATUS_LABELS } from '../../packages/backend-services/src/action/FlightTrackingService';
+
+const API_KEY = 'test-aviationstack-key';
+const FLIGHT_NUMBER = 'AA123';
+
+function makeFlightResponse(overrides?: Record<string, unknown>) {
+  return {
+    data: [
+      {
+        flight_status: 'scheduled',
+        departure: { scheduled: '2026-07-01T14:30:00+00:00', iata: 'JFK' },
+        arrival: { iata: 'LAX' },
+        airline: { name: 'American Airlines' },
+        flight: { iata: 'AA123' },
+        ...overrides,
+      },
+    ],
+  };
+}
+
+function mockFetch(status: number, body: unknown) {
+  return vi.spyOn(globalThis, 'fetch').mockResolvedValue(
+    new Response(JSON.stringify(body), { status }),
+  );
+}
+
+describe('FlightTrackingService', () => {
+  afterEach(() => vi.restoreAllMocks());
+
+  describe('fetchFlightStatus', () => {
+    it('returns parsed FlightSyncStatus for a scheduled flight', async () => {
+      mockFetch(200, makeFlightResponse());
+
+      const result = await fetchFlightStatus(FLIGHT_NUMBER, API_KEY);
+
+      expect(result).not.toBeNull();
+      expect(result!.flightNumber).toBe('AA123');
+      expect(result!.status).toBe('scheduled');
+      expect(result!.airline).toBe('American Airlines');
+      expect(result!.departureIata).toBe('JFK');
+      expect(result!.arrivalIata).toBe('LAX');
+      expect(result!.departureTime).toBe('2026-07-01T14:30:00+00:00');
+    });
+
+    it('includes flight_iata and access_key in request URL', async () => {
+      const spy = mockFetch(200, makeFlightResponse());
+
+      await fetchFlightStatus(FLIGHT_NUMBER, API_KEY);
+
+      const url = new URL((spy.mock.calls[0][0] as string));
+      expect(url.searchParams.get('flight_iata')).toBe('AA123');
+      expect(url.searchParams.get('access_key')).toBe(API_KEY);
+    });
+
+    it('returns null when data array is empty', async () => {
+      mockFetch(200, { data: [] });
+
+      const result = await fetchFlightStatus(FLIGHT_NUMBER, API_KEY);
+
+      expect(result).toBeNull();
+    });
+
+    it('returns null when data field is missing', async () => {
+      mockFetch(200, {});
+
+      const result = await fetchFlightStatus(FLIGHT_NUMBER, API_KEY);
+
+      expect(result).toBeNull();
+    });
+
+    it('returns null for non-200 HTTP status', async () => {
+      mockFetch(401, { error: { code: 101, message: 'Invalid API key' } });
+
+      const result = await fetchFlightStatus(FLIGHT_NUMBER, API_KEY);
+
+      expect(result).toBeNull();
+    });
+
+    it('returns null for 500 server error', async () => {
+      mockFetch(500, {});
+
+      const result = await fetchFlightStatus(FLIGHT_NUMBER, API_KEY);
+
+      expect(result).toBeNull();
+    });
+
+    it('returns null on network error', async () => {
+      vi.spyOn(globalThis, 'fetch').mockRejectedValue(new Error('Network error'));
+
+      const result = await fetchFlightStatus(FLIGHT_NUMBER, API_KEY);
+
+      expect(result).toBeNull();
+    });
+
+    it('handles missing optional fields gracefully', async () => {
+      mockFetch(200, { data: [{ flight_status: 'active' }] });
+
+      const result = await fetchFlightStatus(FLIGHT_NUMBER, API_KEY);
+
+      expect(result).not.toBeNull();
+      expect(result!.flightNumber).toBe('AA123');
+      expect(result!.status).toBe('active');
+      expect(result!.airline).toBeUndefined();
+      expect(result!.departureIata).toBeUndefined();
+      expect(result!.arrivalIata).toBeUndefined();
+      expect(result!.departureTime).toBeUndefined();
+    });
+  });
+
+  describe('formatFlightSummary', () => {
+    it('formats a scheduled flight with departure time', () => {
+      const syncStatus = {
+        flightNumber: 'AA123',
+        status: 'scheduled',
+        departureTime: '2026-07-01T14:30:00+00:00',
+      };
+
+      const summary = formatFlightSummary('AA123', syncStatus);
+
+      expect(summary).toContain('Flight AA123');
+      expect(summary).toContain('Scheduled');
+      expect(summary).toContain('14:30 UTC');
+    });
+
+    it('formats an active (in-flight) status', () => {
+      const syncStatus = { flightNumber: 'AA123', status: 'active' };
+
+      const summary = formatFlightSummary('AA123', syncStatus);
+
+      expect(summary).toContain('In Flight');
+    });
+
+    it('formats a landed status', () => {
+      const syncStatus = { flightNumber: 'AA123', status: 'landed' };
+
+      const summary = formatFlightSummary('AA123', syncStatus);
+
+      expect(summary).toContain('Landed');
+    });
+
+    it('formats a cancelled status', () => {
+      const syncStatus = { flightNumber: 'AA123', status: 'cancelled' };
+
+      const summary = formatFlightSummary('AA123', syncStatus);
+
+      expect(summary).toContain('Cancelled');
+    });
+
+    it('uses raw status value when not in STATUS_LABELS', () => {
+      const syncStatus = { flightNumber: 'AA123', status: 'unknown_state' };
+
+      const summary = formatFlightSummary('AA123', syncStatus);
+
+      expect(summary).toContain('unknown_state');
+    });
+
+    it('omits departure time when departureTime is absent', () => {
+      const syncStatus = { flightNumber: 'AA123', status: 'scheduled' };
+
+      const summary = formatFlightSummary('AA123', syncStatus);
+
+      expect(summary).not.toContain('Departs');
+    });
+
+    it('omits departure time when departureTime is an invalid date', () => {
+      const syncStatus = { flightNumber: 'AA123', status: 'scheduled', departureTime: 'not-a-date' };
+
+      const summary = formatFlightSummary('AA123', syncStatus);
+
+      expect(summary).not.toContain('Departs');
+    });
+
+    it('falls back to Unknown when status is undefined', () => {
+      const syncStatus = { flightNumber: 'AA123' };
+
+      const summary = formatFlightSummary('AA123', syncStatus);
+
+      expect(summary).toContain('Unknown');
+    });
+  });
+
+  describe('formatDepartureTime', () => {
+    it('formats ISO timestamp as HH:MM UTC', () => {
+      expect(formatDepartureTime('2026-07-01T14:30:00+00:00')).toBe('14:30 UTC');
+    });
+
+    it('returns null for invalid date string', () => {
+      expect(formatDepartureTime('not-a-date')).toBeNull();
+    });
+  });
+
+  describe('STATUS_LABELS', () => {
+    it('has a label for each known status', () => {
+      expect(STATUS_LABELS['scheduled']).toBe('Scheduled');
+      expect(STATUS_LABELS['active']).toBe('In Flight');
+      expect(STATUS_LABELS['landed']).toBe('Landed');
+      expect(STATUS_LABELS['cancelled']).toBe('Cancelled');
+      expect(STATUS_LABELS['incident']).toBe('Incident');
+      expect(STATUS_LABELS['diverted']).toBe('Diverted');
+    });
+  });
+});


### PR DESCRIPTION
Replaces the stub `travel.track_flight` execution handler with a real aviationstack.com API call, following the same pattern as `delivery.track_package` via Aftership.

- Add `FlightTrackingService.ts`: `fetchFlightStatus()` calls the aviationstack `/v1/flights` endpoint and returns a `FlightSyncStatus` with `flightNumber`, `airline`, `status`, `departureTime`, `departureIata`, and `arrivalIata`. `formatFlightSummary()` produces a human-readable line such as `Flight AA123 — Scheduled · Departs 14:30 UTC`.
- Refactor `ActionStatusSyncUtil.syncFlightAction()` to delegate to `FlightTrackingService.fetchFlightStatus()` instead of inlining the HTTP call, and re-export `FlightSyncStatus` from the new module.
- Update `ActionExecutionService.executeProviderOperation()`: when `FLIGHT_TRACKING_API_KEY` is set and the API returns a result, store `syncStatus` via `actionDAO.updateSyncStatus()` and return a rich summary; fall back to the prior static strings when the key is absent or the API returns null (no regression).
- Add `test/services/FlightTrackingService.test.ts` (23 tests) covering happy path, missing fields, empty data, HTTP errors, network errors, `formatFlightSummary` variants, and `formatDepartureTime`.
- Extend `test/services/ActionService.test.ts` with three new `travel.track_flight` execution tests: no key → static fallback; key
  + API success → rich summary + syncStatus stored; key + API null → static fallback.