### PR TITLE
Add RAG Retrieval Toggle

### DIFF
--- a/apps/api/src/endpoints/user/application/context/PUT.ts
+++ b/apps/api/src/endpoints/user/application/context/PUT.ts
@@ -43,6 +43,7 @@ class UpdateApplicationContextRoute extends IUserRoute<
 interface UpdateApplicationContextRequest extends IRequest {
   applicationId: string;
   contextIndexingEnabled?: boolean | undefined;
+  ragRetrievalEnabled?: boolean | undefined;
   maxContextDocuments?: number | null | undefined;
 }
 

--- a/apps/web/components/types.ts
+++ b/apps/web/components/types.ts
@@ -102,6 +102,7 @@ export interface ConnectedApplication {
   lastError?: string | null;
   lastErrorAt?: number | null;
   contextIndexingEnabled: boolean;
+  ragRetrievalEnabled: boolean;
   maxContextDocuments?: number | null;
   contextDocumentCount?: number;
   contextLastIndexedAt?: number | null;

--- a/apps/web/src/components/mailboxes/ContextSection.tsx
+++ b/apps/web/src/components/mailboxes/ContextSection.tsx
@@ -8,7 +8,7 @@ import { useCurrentUserData } from '../../contexts/UserContext';
 
 export function ContextSection({ application }: { application: ConnectedApplication }) {
   const user = useCurrentUserData();
-  const { busy, onUpdateContextIndexing, onUpdateMaxContextDocuments, onOpenContextAudit, onDeleteContextDocuments, onDismissContextError } = useMailboxCallbacks();
+  const { busy, onUpdateContextIndexing, onUpdateRagRetrieval, onUpdateMaxContextDocuments, onOpenContextAudit, onDeleteContextDocuments, onDismissContextError } = useMailboxCallbacks();
 
   return (
     <CollapsibleSection title="RAG Context">
@@ -22,6 +22,16 @@ export function ContextSection({ application }: { application: ConnectedApplicat
             className="h-4 w-4 accent-[var(--color-accent)] rounded"
           />
           Index New Emails
+        </label>
+        <label className="inline-flex items-center gap-2.5 text-sm text-[var(--color-text-secondary)] cursor-pointer">
+          <input
+            type="checkbox"
+            checked={application.ragRetrievalEnabled}
+            onChange={(e) => onUpdateRagRetrieval(application.applicationId, e.target.checked)}
+            disabled={busy}
+            className="h-4 w-4 accent-[var(--color-accent)] rounded"
+          />
+          Retrieve Context For Summaries
         </label>
         <label className="inline-flex items-center gap-2 text-sm text-[var(--color-text-secondary)]">
           Max Docs

--- a/apps/web/src/contexts/MailboxCallbacksContext.tsx
+++ b/apps/web/src/contexts/MailboxCallbacksContext.tsx
@@ -15,6 +15,7 @@ export interface MailboxCallbacksContextValue {
   onSaveDigestConfig: (id: string, config: Pick<DigestConfig, 'enabled' | 'sendTime' | 'sections'>) => Promise<void>;
   onSendDigestNow: (id: string) => Promise<void>;
   onUpdateContextIndexing: (id: string, enabled: boolean) => void;
+  onUpdateRagRetrieval: (id: string, enabled: boolean) => void;
   onUpdateMaxContextDocuments: (id: string, max: number | null) => void;
   onOpenContextAudit: (id: string) => void;
   onDeleteContextDocuments: (id: string) => void;

--- a/apps/web/src/hooks/useMailboxCallbacksValue.ts
+++ b/apps/web/src/hooks/useMailboxCallbacksValue.ts
@@ -33,6 +33,7 @@ export function useMailboxCallbacksValue(
     onSaveDigestConfig: mailboxes.saveDigestConfig,
     onSendDigestNow: mailboxes.sendDigestNow,
     onUpdateContextIndexing: mailboxes.updateContextIndexing,
+    onUpdateRagRetrieval: mailboxes.updateRagRetrieval,
     onUpdateMaxContextDocuments: mailboxes.updateMaxContextDocuments,
     onOpenContextAudit: (id: string) => {
       contextAudit.setAuditApplicationId(id);

--- a/apps/web/src/hooks/useMailboxes.ts
+++ b/apps/web/src/hooks/useMailboxes.ts
@@ -146,6 +146,19 @@ export function useMailboxes({ setIsBusy, showNotice, onContextChanged }: UseMai
     }
   };
 
+  const updateRagRetrieval = async (applicationId: string, enabled: boolean) => {
+    setIsBusy(true);
+    try {
+      const data = await appSvc.updateRagRetrieval(applicationId, enabled);
+      setApplications((c) => c.map((a) => (a.applicationId === data.application.applicationId ? data.application : a)));
+      showNotice('success', enabled ? 'Context Retrieval Enabled.' : 'Context Retrieval Disabled.');
+    } catch (e) {
+      showNotice('error', e instanceof Error ? e.message : 'Unable To Update Context Retrieval Setting.');
+    } finally {
+      setIsBusy(false);
+    }
+  };
+
   const updateMaxContextDocuments = async (applicationId: string, maxContextDocuments: number | null) => {
     setIsBusy(true);
     try {
@@ -410,6 +423,7 @@ export function useMailboxes({ setIsBusy, showNotice, onContextChanged }: UseMai
     startWatch,
     stopWatch,
     updateContextIndexing,
+    updateRagRetrieval,
     updateMaxContextDocuments,
     loadFolders,
     updateWatchedFolderIds,

--- a/apps/web/src/services/applicationService.ts
+++ b/apps/web/src/services/applicationService.ts
@@ -87,6 +87,19 @@ export async function updateContextIndexing(
   );
 }
 
+export async function updateRagRetrieval(
+  applicationId: string,
+  ragRetrievalEnabled: boolean,
+): Promise<{ application: ConnectedApplication }> {
+  return readJson<{ application: ConnectedApplication }>(
+    await apiFetch('/user/application/context', {
+      method: 'PUT',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ applicationId, ragRetrievalEnabled }),
+    }),
+  );
+}
+
 export async function updateMaxContextDocuments(
   applicationId: string,
   maxContextDocuments: number | null,

--- a/migrations/0024_rag_retrieval_toggle.sql
+++ b/migrations/0024_rag_retrieval_toggle.sql
@@ -1,0 +1,2 @@
+ALTER TABLE connected_applications
+  ADD COLUMN rag_retrieval_enabled INTEGER NOT NULL DEFAULT 1;

--- a/packages/backend-data/src/dao/ConnectedApplicationDAO.ts
+++ b/packages/backend-data/src/dao/ConnectedApplicationDAO.ts
@@ -87,7 +87,7 @@ class ConnectedApplicationDAO extends EncryptedDAO {
     const rows: ConnectedApplicationInternal[] = await this.database
       .prepare(
         `
-          SELECT application_id, user_email, provider_email, display_name, provider_id, connection_method, encrypted_credentials, credentials_iv, status, context_indexing_enabled, max_context_documents, last_error_acknowledged_at, context_last_error_acknowledged_at, created_at, updated_at
+          SELECT application_id, user_email, provider_email, display_name, provider_id, connection_method, encrypted_credentials, credentials_iv, status, context_indexing_enabled, rag_retrieval_enabled, max_context_documents, last_error_acknowledged_at, context_last_error_acknowledged_at, created_at, updated_at
           FROM connected_applications
           WHERE user_email = ?
           ORDER BY updated_at DESC, created_at DESC
@@ -313,6 +313,29 @@ class ConnectedApplicationDAO extends EncryptedDAO {
     return this.getMetadataByIdForUser(applicationId, userEmail);
   }
 
+  public async updateRagRetrievalForUser(
+    applicationId: string,
+    userEmail: string,
+    ragRetrievalEnabled: boolean,
+  ): Promise<ConnectedApplicationMetadata | undefined> {
+    const now: number = TimestampUtil.getCurrentUnixTimestampInSeconds();
+    await executeD1WithRetry(
+      (): Promise<D1Result> =>
+        this.database
+          .prepare(
+            `
+              UPDATE connected_applications
+              SET rag_retrieval_enabled = ?, updated_at = ?
+              WHERE application_id = ? AND user_email = ?
+            `,
+          )
+          .bind(ragRetrievalEnabled ? 1 : 0, now, applicationId, userEmail)
+          .run(),
+      'update rag retrieval setting',
+    );
+    return this.getMetadataByIdForUser(applicationId, userEmail);
+  }
+
   public async updateWatchedFolderIdsForUser(
     applicationId: string,
     userEmail: string,
@@ -457,7 +480,7 @@ class ConnectedApplicationDAO extends EncryptedDAO {
     const row: ConnectedApplicationInternal | null = await this.database
       .prepare(
         `
-          SELECT application_id, user_email, provider_email, display_name, provider_id, connection_method, encrypted_credentials, credentials_iv, status, context_indexing_enabled, max_context_documents, last_error_acknowledged_at, context_last_error_acknowledged_at, created_at, updated_at
+          SELECT application_id, user_email, provider_email, display_name, provider_id, connection_method, encrypted_credentials, credentials_iv, status, context_indexing_enabled, rag_retrieval_enabled, max_context_documents, last_error_acknowledged_at, context_last_error_acknowledged_at, created_at, updated_at
           FROM connected_applications
           WHERE application_id = ?${whereUser}
           LIMIT 1
@@ -555,6 +578,7 @@ class ConnectedApplicationDAO extends EncryptedDAO {
       connectionMethod: row.connection_method,
       status,
       contextIndexingEnabled: row.context_indexing_enabled !== 0,
+      ragRetrievalEnabled: row.rag_retrieval_enabled !== 0,
       maxContextDocuments: row.max_context_documents ?? null,
       enabledFeatures: enabledFeaturesJson ? (JSON.parse(enabledFeaturesJson) as string[]) : null,
       timeZone: timeZone ?? null,

--- a/packages/backend-services/src/email/ContextService.ts
+++ b/packages/backend-services/src/email/ContextService.ts
@@ -33,6 +33,11 @@ class ContextService {
       if (!application) throw new BadRequestError('Connected application was not found.');
     }
 
+    if (input.ragRetrievalEnabled !== undefined) {
+      application = await applicationDAO.updateRagRetrievalForUser(input.applicationId, userEmail, input.ragRetrievalEnabled);
+      if (!application) throw new BadRequestError('Connected application was not found.');
+    }
+
     if ('maxContextDocuments' in input) {
       application = await applicationDAO.updateMaxContextDocumentsForUser(input.applicationId, userEmail, input.maxContextDocuments ?? null);
       if (!application) throw new BadRequestError('Connected application was not found.');
@@ -203,6 +208,7 @@ class ContextServiceFactory {
 interface UpdateContextSettingsInput {
   applicationId: string;
   contextIndexingEnabled?: boolean | undefined;
+  ragRetrievalEnabled?: boolean | undefined;
   maxContextDocuments?: number | null | undefined;
 }
 

--- a/packages/backend-services/src/email/EmailContextUtil.ts
+++ b/packages/backend-services/src/email/EmailContextUtil.ts
@@ -19,7 +19,7 @@ class EmailContextUtil {
   public static async prepareEmailRagContext(input: PrepareEmailRagContextInput): Promise<string | undefined> {
     if (!input.env.EMAIL_CONTEXT_INDEX) return undefined;
     const enabledApplicationIds: Set<string> = new Set(input.enabledApplicationIds);
-    const shouldRetrieve: boolean = enabledApplicationIds.size > 0;
+    const shouldRetrieve: boolean = input.application.ragRetrievalEnabled !== false && enabledApplicationIds.size > 0;
     const shouldStore: boolean = input.application.contextIndexingEnabled;
     if (!shouldRetrieve && !shouldStore) return undefined;
     if (await EmailContextUtil.shouldSkipWorkersAiForDailyUsage(input.env)) return undefined;

--- a/packages/shared/src/model/ConnectedApplication.ts
+++ b/packages/shared/src/model/ConnectedApplication.ts
@@ -27,6 +27,7 @@ interface ConnectedApplicationMetadata {
   connectionMethod: ConnectionMethod;
   status: ConnectedApplicationStatus;
   contextIndexingEnabled: boolean;
+  ragRetrievalEnabled: boolean;
   maxContextDocuments?: number | null | undefined;
   enabledFeatures?: string[] | null | undefined;
   timeZone?: string | null | undefined;
@@ -75,6 +76,7 @@ interface ConnectedApplicationInternal {
   credentials_iv: string;
   status: ConnectedApplicationStatus;
   context_indexing_enabled: number;
+  rag_retrieval_enabled: number;
   max_context_documents: number | null;
   last_error_acknowledged_at: number | null;
   context_last_error_acknowledged_at: number | null;


### PR DESCRIPTION
Adds a second independent per-application toggle, `ragRetrievalEnabled`, that controls whether previously indexed context is retrieved from Vectorize and injected into the AI prompt. Previously, enabling context indexing for any of a user's applications implicitly enabled retrieval for all of them.

- Migration 0024 adds `rag_retrieval_enabled INTEGER NOT NULL DEFAULT 1` to `connected_applications`, defaulting to enabled so existing rows keep current behaviour.
- `ConnectedApplicationMetadata`/`ConnectedApplicationInternal` carry the new field; DAO reads it in all SELECT queries and maps it to a boolean in `toMetadata()`.
- `ConnectedApplicationDAO.updateRagRetrievalForUser()` mirrors the existing `updateContextIndexingForUser()` pattern.
- `ContextService.updateContextSettings()` handles the new `ragRetrievalEnabled` input branch.
- `PUT /user/application/context` now accepts `ragRetrievalEnabled`.
- `EmailContextUtil.prepareEmailRagContext` guards `shouldRetrieve` with `application.ragRetrievalEnabled !== false` so retrieval can be disabled independently of indexing.
- Frontend: `ConnectedApplication` type, `applicationService`, callbacks context, `useMailboxes`, `useMailboxCallbacksValue`, and `ContextSection` all wired up; a second checkbox "Retrieve Context For Summaries" appears in the RAG Context section alongside "Index New Emails".