### PR TITLE
Make Context Settings Fields Optional In PUT Body Schema

### DIFF
--- a/packages/shared/src/schema/input.ts
+++ b/packages/shared/src/schema/input.ts
@@ -67,7 +67,9 @@ const DeleteAppBodySchema = z.object({
 
 const UpdateAppContextBodySchema = z.object({
   applicationId: UuidSchema,
-  contextIndexingEnabled: z.boolean(),
+  contextIndexingEnabled: z.boolean().optional(),
+  ragRetrievalEnabled: z.boolean().optional(),
+  maxContextDocuments: z.number().int().positive().nullable().optional(),
 });
 
 const DeleteAppContextDocumentsBodySchema = z.object({

--- a/test/schema/RequestValidation.test.ts
+++ b/test/schema/RequestValidation.test.ts
@@ -107,6 +107,25 @@ describe('Request input schemas', () => {
     ).resolves.toMatchObject({ success: false, scope: 'body' });
   });
 
+  describe('PUT /user/application/context', () => {
+    const applicationId = '11111111-1111-4111-8111-111111111111';
+
+    it('accepts body with only contextIndexingEnabled', async () => {
+      const request = new Request('https://mail.example.com/user/application/context', { method: 'PUT' });
+      await expect(validateRequestInput(request, { applicationId, contextIndexingEnabled: false })).resolves.toMatchObject({ success: true });
+    });
+
+    it('accepts body with only ragRetrievalEnabled', async () => {
+      const request = new Request('https://mail.example.com/user/application/context', { method: 'PUT' });
+      await expect(validateRequestInput(request, { applicationId, ragRetrievalEnabled: false })).resolves.toMatchObject({ success: true });
+    });
+
+    it('accepts body with only maxContextDocuments', async () => {
+      const request = new Request('https://mail.example.com/user/application/context', { method: 'PUT' });
+      await expect(validateRequestInput(request, { applicationId, maxContextDocuments: 10 })).resolves.toMatchObject({ success: true });
+    });
+  });
+
   describe('EmailProcessingRuleSchema', () => {
     const validRule = {
       ruleId: '11111111-1111-4111-8111-111111111111',


### PR DESCRIPTION
`UpdateAppContextBodySchema` required `contextIndexingEnabled` as a non-optional boolean, but the UI calls `PUT /user/application/context` three ways — each sending only one of `contextIndexingEnabled`, `ragRetrievalEnabled`, or `maxContextDocuments`. Toggling "Retrieve Context For Summaries" failed with:

  contextIndexingEnabled: Invalid input: expected boolean, received undefined

The fix makes all three payload fields optional and adds the two previously missing fields (`ragRetrievalEnabled`, `maxContextDocuments`) to the schema, aligning it with the endpoint handler interface which already marks all fields optional. Three regression tests added to `RequestValidation.test.ts`.