### PR TITLE
Replace Polynomial Regex With O(n) State Machine In Drive DocumentUtil

### DIFF
--- a/packages/backend-services/src/drive/DriveDocumentUtil.ts
+++ b/packages/backend-services/src/drive/DriveDocumentUtil.ts
@@ -1,12 +1,11 @@
 const TEXT_MIME_TYPES = new Set(['text/plain', 'text/markdown', 'text/csv']);
 
-// Best-effort PDF content stream token patterns; input is bounded to MAX_ATTACHMENT_SIZE_BYTES.
-// eslint-disable-next-line sonarjs/super-linear-regex
-const TJ_RE = /\(([^)]*)\)\s*Tj/g;
-// eslint-disable-next-line sonarjs/super-linear-regex
-const TJ_ARRAY_RE = /\[([^\]]+)\]\s*TJ/g;
-// eslint-disable-next-line sonarjs/super-linear-regex
-const TJ_ARRAY_ITEM_RE = /\(([^)]*)\)/g;
+// PDF whitespace characters (spec §7.2.2) and delimiter characters (spec §7.2.3).
+const PDF_WS = new Set([' ', '\t', '\n', '\r', '\f', '\0']);
+const PDF_DELIMS = new Set([
+  ' ', '\t', '\n', '\r', '\f', '\0',
+  '(', ')', '[', ']', '{', '}', '/', '%',
+]);
 
 function unescapePdfString(s: string): string {
   return s
@@ -15,6 +14,65 @@ function unescapePdfString(s: string): string {
     .replaceAll(String.raw`\t`, '\t')
     .replaceAll('\\\\', '\\')
     .replaceAll(/\\([)(])/g, '$1');
+}
+
+// Reads a PDF literal string starting at index i (the '(' char).
+// Balanced nested parens are allowed per the PDF spec.
+// Returns [content, index_after_closing_paren], or ['', -1] if unclosed.
+function readPdfString(raw: string, i: number): [string, number] {
+  const len = raw.length;
+  let j = i + 1;
+  const start = j;
+  let depth = 1;
+  while (j < len) {
+    const ch = raw[j];
+    if (ch === '\\') { j += 2; continue; }
+    if (ch === '(') { depth++; j++; continue; }
+    if (ch === ')') {
+      depth--;
+      if (depth === 0) return [raw.slice(start, j), j + 1];
+      j++;
+      continue;
+    }
+    j++;
+  }
+  return ['', -1];
+}
+
+// Reads a PDF array starting at index i (the '[' char).
+// Collects only the literal string items; numbers and whitespace are skipped.
+// Returns [string_items, index_after_closing_bracket], or [[], -1] if unclosed.
+function readTjArray(raw: string, i: number): [string[], number] {
+  const len = raw.length;
+  const items: string[] = [];
+  let j = i + 1;
+  while (j < len) {
+    const ch = raw[j];
+    if (ch === ']') return [items, j + 1];
+    if (ch === '(') {
+      const [str, next] = readPdfString(raw, j);
+      if (next === -1) return [[], -1];
+      items.push(str);
+      j = next;
+    } else {
+      j++;
+    }
+  }
+  return [[], -1];
+}
+
+function skipWs(raw: string, len: number, start: number): number {
+  let k = start;
+  while (k < len && PDF_WS.has(raw[k])) k++;
+  return k;
+}
+
+function isTj(raw: string, len: number, k: number): boolean {
+  return raw[k] === 'T' && raw[k + 1] === 'j' && (k + 2 >= len || PDF_DELIMS.has(raw[k + 2]));
+}
+
+function isTJ(raw: string, len: number, k: number): boolean {
+  return raw[k] === 'T' && raw[k + 1] === 'J' && (k + 2 >= len || PDF_DELIMS.has(raw[k + 2]));
 }
 
 class DriveDocumentUtil {
@@ -31,33 +89,54 @@ class DriveDocumentUtil {
   }
 
   // Best-effort PDF text extraction via Tj/TJ content stream operators.
+  // Uses an O(n) character scan — no regex backtracking on uncontrolled input.
   // Works for most standard PDFs; encrypted or glyph-encoded PDFs may yield nothing.
   private static extractTextFromPdf(data: ArrayBuffer): string | null {
     const raw = new TextDecoder('utf-8', { fatal: false }).decode(data);
     const texts: string[] = [];
+    const len = raw.length;
+    let i = 0;
 
-    let m: RegExpExecArray | null;
-
-    TJ_RE.lastIndex = 0;
-    while ((m = TJ_RE.exec(raw)) !== null) {
-      const s = unescapePdfString(m[1]);
-      if (s.trim().length > 0) texts.push(s);
-    }
-
-    TJ_ARRAY_RE.lastIndex = 0;
-    while ((m = TJ_ARRAY_RE.exec(raw)) !== null) {
-      const block = m[1];
-      let item: RegExpExecArray | null;
-      TJ_ARRAY_ITEM_RE.lastIndex = 0;
-      while ((item = TJ_ARRAY_ITEM_RE.exec(block)) !== null) {
-        const s = unescapePdfString(item[1]);
-        if (s.trim().length > 0) texts.push(s);
+    while (i < len) {
+      const ch = raw[i];
+      if (ch === '(') {
+        i = this.collectTj(raw, len, i, texts);
+      } else if (ch === '[') {
+        i = this.collectTjArray(raw, len, i, texts);
+      } else {
+        i++;
       }
     }
 
     if (texts.length === 0) return null;
     const combined = texts.join(' ').trim();
     return combined.length > 0 ? combined : null;
+  }
+
+  private static collectTj(raw: string, len: number, i: number, texts: string[]): number {
+    const [str, next] = readPdfString(raw, i);
+    if (next === -1) return i + 1;
+    const k = skipWs(raw, len, next);
+    if (isTj(raw, len, k)) {
+      const s = unescapePdfString(str);
+      if (s.trim().length > 0) texts.push(s);
+      return k + 2;
+    }
+    return next;
+  }
+
+  private static collectTjArray(raw: string, len: number, i: number, texts: string[]): number {
+    const [items, next] = readTjArray(raw, i);
+    if (next === -1) return i + 1;
+    const k = skipWs(raw, len, next);
+    if (isTJ(raw, len, k)) {
+      for (const item of items) {
+        const s = unescapePdfString(item);
+        if (s.trim().length > 0) texts.push(s);
+      }
+      return k + 2;
+    }
+    return next;
   }
 
   public static buildIndexedText(filename: string, appName: string, body: string, maxChars: number): string {

--- a/test/services/DriveDocumentUtil.test.ts
+++ b/test/services/DriveDocumentUtil.test.ts
@@ -1,0 +1,179 @@
+import { describe, expect, it } from 'vitest';
+
+import { DriveDocumentUtil } from '@mail-otter/backend-services/drive/DriveDocumentUtil';
+
+function encode(s: string): ArrayBuffer {
+  return new TextEncoder().encode(s).buffer as ArrayBuffer;
+}
+
+function pdf(content: string): ArrayBuffer {
+  return encode(`%PDF-1.4\nstream\n${content}\nendstream`);
+}
+
+describe('DriveDocumentUtil', () => {
+  describe('extractText', () => {
+    it('decodes plain text', () => {
+      expect(DriveDocumentUtil.extractText(encode('hello world'), 'text/plain')).toBe('hello world');
+    });
+
+    it('decodes markdown', () => {
+      expect(DriveDocumentUtil.extractText(encode('# Title\nBody'), 'text/markdown')).toBe('# Title\nBody');
+    });
+
+    it('decodes csv', () => {
+      expect(DriveDocumentUtil.extractText(encode('a,b,c'), 'text/csv')).toBe('a,b,c');
+    });
+
+    it('returns null for whitespace-only text', () => {
+      expect(DriveDocumentUtil.extractText(encode('   '), 'text/plain')).toBeNull();
+    });
+
+    it('strips MIME type parameters', () => {
+      expect(DriveDocumentUtil.extractText(encode('hi'), 'text/plain; charset=utf-8')).toBe('hi');
+    });
+
+    it('returns null for unsupported MIME type', () => {
+      expect(DriveDocumentUtil.extractText(encode('data'), 'application/octet-stream')).toBeNull();
+    });
+
+    it('delegates application/pdf to PDF extractor', () => {
+      const result = DriveDocumentUtil.extractText(pdf('(Hello) Tj'), 'application/pdf');
+      expect(result).toBe('Hello');
+    });
+  });
+
+  describe('extractText — PDF Tj operator', () => {
+    it('extracts a single Tj string', () => {
+      expect(DriveDocumentUtil.extractText(pdf('(Hello World) Tj'), 'application/pdf')).toBe('Hello World');
+    });
+
+    it('handles no whitespace between string and operator', () => {
+      expect(DriveDocumentUtil.extractText(pdf('(Tight)Tj'), 'application/pdf')).toBe('Tight');
+    });
+
+    it('handles multiple spaces before Tj', () => {
+      expect(DriveDocumentUtil.extractText(pdf('(Spaced)   Tj'), 'application/pdf')).toBe('Spaced');
+    });
+
+    it('extracts multiple Tj strings', () => {
+      expect(DriveDocumentUtil.extractText(pdf('(Foo) Tj\n(Bar) Tj'), 'application/pdf')).toBe('Foo Bar');
+    });
+
+    it('ignores strings not followed by Tj', () => {
+      expect(DriveDocumentUtil.extractText(pdf('(Ignored) Tm\n(Kept) Tj'), 'application/pdf')).toBe('Kept');
+    });
+
+    it('returns null when no Tj strings found', () => {
+      expect(DriveDocumentUtil.extractText(pdf('BT ET'), 'application/pdf')).toBeNull();
+    });
+  });
+
+  describe('extractText — PDF TJ operator (array)', () => {
+    it('extracts strings from a TJ array', () => {
+      expect(DriveDocumentUtil.extractText(pdf('[(Hello) -200 (World)] TJ'), 'application/pdf')).toBe('Hello World');
+    });
+
+    it('extracts TJ array with no spacing numbers', () => {
+      expect(DriveDocumentUtil.extractText(pdf('[(Only)] TJ'), 'application/pdf')).toBe('Only');
+    });
+
+    it('handles mixed Tj and TJ operators', () => {
+      const result = DriveDocumentUtil.extractText(pdf('(First) Tj\n[(Second) 0 (Third)] TJ'), 'application/pdf');
+      expect(result).toBe('First Second Third');
+    });
+
+    it('ignores TJ arrays not followed by TJ', () => {
+      expect(DriveDocumentUtil.extractText(pdf('[(No)] Tm'), 'application/pdf')).toBeNull();
+    });
+  });
+
+  describe('extractText — PDF escape sequences', () => {
+    it('unescapes \\n in string', () => {
+      expect(DriveDocumentUtil.extractText(pdf('(line1\\nline2) Tj'), 'application/pdf')).toBe('line1\nline2');
+    });
+
+    it('unescapes \\t in string', () => {
+      expect(DriveDocumentUtil.extractText(pdf('(col1\\tcol2) Tj'), 'application/pdf')).toBe('col1\tcol2');
+    });
+
+    it('unescapes \\\\ to single backslash', () => {
+      expect(DriveDocumentUtil.extractText(pdf('(back\\\\slash) Tj'), 'application/pdf')).toBe('back\\slash');
+    });
+
+    it('unescapes escaped parentheses', () => {
+      expect(DriveDocumentUtil.extractText(pdf('(a\\(b\\)c) Tj'), 'application/pdf')).toBe('a(b)c');
+    });
+
+    it('handles balanced nested parentheses in string', () => {
+      expect(DriveDocumentUtil.extractText(pdf('(outer (inner) outer) Tj'), 'application/pdf')).toBe('outer (inner) outer');
+    });
+  });
+
+  describe('extractText — PDF adversarial / edge cases', () => {
+    it('returns null for empty ArrayBuffer', () => {
+      expect(DriveDocumentUtil.extractText(new ArrayBuffer(0), 'application/pdf')).toBeNull();
+    });
+
+    it('handles unclosed string gracefully', () => {
+      expect(DriveDocumentUtil.extractText(pdf('(unclosed'), 'application/pdf')).toBeNull();
+    });
+
+    it('handles unclosed array gracefully', () => {
+      expect(DriveDocumentUtil.extractText(pdf('[(unclosed)'), 'application/pdf')).toBeNull();
+    });
+
+    it('completes in O(n) time on adversarial input with no Tj operators', () => {
+      // 200k repetitions of ") " — crafted to trigger regex backtracking in the old approach
+      const adversarial = ') '.repeat(200_000);
+      const start = Date.now();
+      DriveDocumentUtil.extractText(encode(adversarial), 'application/pdf');
+      const elapsed = Date.now() - start;
+      // Linear scan should finish well under 500ms even for 400KB input
+      expect(elapsed).toBeLessThan(500);
+    });
+
+    it('skips whitespace-only extracted strings', () => {
+      expect(DriveDocumentUtil.extractText(pdf('(   ) Tj'), 'application/pdf')).toBeNull();
+    });
+
+    it('does not confuse Tjx token as Tj operator', () => {
+      // "Tjx" is not a valid PDF operator; string should not be captured
+      expect(DriveDocumentUtil.extractText(pdf('(Wrong) Tjx'), 'application/pdf')).toBeNull();
+    });
+
+    it('does not confuse TJx token as TJ operator', () => {
+      expect(DriveDocumentUtil.extractText(pdf('[(Wrong)] TJx'), 'application/pdf')).toBeNull();
+    });
+  });
+
+  describe('buildIndexedText', () => {
+    it('builds text with filename and mailbox header', () => {
+      const result = DriveDocumentUtil.buildIndexedText('doc.txt', 'work@example.com', 'body content', 1000);
+      expect(result).toBe('File: doc.txt\nMailbox: work@example.com\n\nbody content');
+    });
+
+    it('truncates to maxChars', () => {
+      const result = DriveDocumentUtil.buildIndexedText('f', 'm', 'body', 10);
+      expect(result.length).toBeLessThanOrEqual(10);
+    });
+
+    it('does not truncate when within limit', () => {
+      const result = DriveDocumentUtil.buildIndexedText('f', 'm', 'hi', 10_000);
+      expect(result).toContain('hi');
+    });
+  });
+
+  describe('truncateToMaxChars', () => {
+    it('returns text unchanged when within limit', () => {
+      expect(DriveDocumentUtil.truncateToMaxChars('hello', 10)).toBe('hello');
+    });
+
+    it('truncates when over limit', () => {
+      expect(DriveDocumentUtil.truncateToMaxChars('hello world', 5)).toBe('hello');
+    });
+
+    it('returns exact text when equal to limit', () => {
+      expect(DriveDocumentUtil.truncateToMaxChars('hello', 5)).toBe('hello');
+    });
+  });
+});


### PR DESCRIPTION
The three regex constants (TJ_RE, TJ_ARRAY_RE, TJ_ARRAY_ITEM_RE) applied quantifiers ([^)]*, [^\]]+, \s*) against full decoded PDF bytes sourced from user-controlled Google Drive/OneDrive files. The \s* before multi-character anchors (Tj, TJ) can cause polynomial backtracking with adversarially crafted input, a ReDoS risk even within the 2 MB file size bound.

Rewrites extractTextFromPdf as a single O(n) character scan using three module-level helpers: readPdfString walks parens with a depth counter, readTjArray collects string items from PDF arrays, and skipWs advances past PDF whitespace. Two private static methods collectTj and collectTjArray handle the Tj and TJ operator branches respectively, keeping the main loop's cognitive complexity within limits. All three regex constants and their eslint-disable-next-line suppressions are removed.

Adds a dedicated DriveDocumentUtil unit test file covering plain-text MIME types, Tj and TJ PDF operator extraction, escape sequence handling, nested parentheses, adversarial input (200k ") " repetitions must complete in under 500ms), and edge cases such as unclosed strings, whitespace-only results, and operator token boundary checks.