### PR TITLE
Fix OneDrive Sync Task Label And Improve 401 Scope Error

### DIFF
--- a/apps/web/src/services/processingService.ts
+++ b/apps/web/src/services/processingService.ts
@@ -52,6 +52,9 @@ export const TASK_TYPE_LABELS: Record<string, string> = {
   imap_polling: 'IMAP Polling',
   scheduled_digest: 'Scheduled Digest',
   oauth2_refresh: 'OAuth2 Token Refresh',
+  scheduled_action_execution: 'Scheduled Action Execution',
+  google_drive_sync: 'Google Drive Sync',
+  onedrive_sync: 'OneDrive Sync',
 };
 
 export function getTaskTypeLabel(taskType: string): string {

--- a/packages/backend-services/src/drive/OneDriveIngestionService.ts
+++ b/packages/backend-services/src/drive/OneDriveIngestionService.ts
@@ -55,9 +55,24 @@ class OneDriveIngestionService {
     try {
       delta = await OneDriveProviderUtil.getDelta(accessToken, storedLink ?? undefined, maxFiles);
     } catch (error: unknown) {
-      if (storedLink && error instanceof Error && error.message.includes('(401)')) {
+      const is401 = error instanceof Error && error.message.includes('(401)');
+      if (is401 && storedLink) {
+        // Stale delta link — clear it and retry from the beginning
         await applicationDAO.deleteProviderConfig(application.applicationId, 'onedrive_delta_link');
-        delta = await OneDriveProviderUtil.getDelta(accessToken, undefined, maxFiles);
+        try {
+          delta = await OneDriveProviderUtil.getDelta(accessToken, undefined, maxFiles);
+        } catch (retryError: unknown) {
+          if (retryError instanceof Error && retryError.message.includes('(401)')) {
+            throw new Error(
+              'OneDrive access token lacks the required scope. Re-authorize the application with OneDrive permissions enabled.',
+            );
+          }
+          throw retryError;
+        }
+      } else if (is401) {
+        throw new Error(
+          'OneDrive access token lacks the required scope. Re-authorize the application with OneDrive permissions enabled.',
+        );
       } else {
         throw error;
       }

--- a/packages/backend-services/src/drive/OneDriveIngestionService.ts
+++ b/packages/backend-services/src/drive/OneDriveIngestionService.ts
@@ -9,6 +9,7 @@ import {
   CONTEXT_AUDIT_LOG_SEVERITY_INFO,
   CONTEXT_SOURCE_TYPE_ONEDRIVE,
 } from '@mail-otter/shared/constants';
+import { UnauthorizedError } from '@mail-otter/backend-errors';
 import { CryptoUtil } from '@mail-otter/shared/utils';
 import { ConfigurationManager } from '@mail-otter/backend-runtime/config';
 import { EmailContextUtil, AiUsageUtil } from '../email';
@@ -63,14 +64,14 @@ class OneDriveIngestionService {
           delta = await OneDriveProviderUtil.getDelta(accessToken, undefined, maxFiles);
         } catch (retryError: unknown) {
           if (retryError instanceof Error && retryError.message.includes('(401)')) {
-            throw new Error(
+            throw new UnauthorizedError(
               'OneDrive access token lacks the required scope. Re-authorize the application with OneDrive permissions enabled.',
             );
           }
           throw retryError;
         }
       } else if (is401) {
-        throw new Error(
+        throw new UnauthorizedError(
           'OneDrive access token lacks the required scope. Re-authorize the application with OneDrive permissions enabled.',
         );
       } else {

--- a/test/services/OneDriveIngestionService.test.ts
+++ b/test/services/OneDriveIngestionService.test.ts
@@ -193,7 +193,9 @@ describe('OneDriveIngestionService', () => {
     mockGetProviderConfig.mockResolvedValue(null);
     mockGetDelta.mockRejectedValue(new Error('Microsoft Graph (OneDrive) get delta failed (401): unauthenticated'));
 
-    await expect(service().ingestForApplication(MOCK_APPLICATION, ACCESS_TOKEN)).rejects.toThrow('(401)');
+    await expect(service().ingestForApplication(MOCK_APPLICATION, ACCESS_TOKEN)).rejects.toThrow(
+      'OneDrive access token lacks the required scope. Re-authorize the application with OneDrive permissions enabled.',
+    );
 
     expect(mockDeleteProviderConfig).not.toHaveBeenCalled();
     expect(mockGetDelta).toHaveBeenCalledTimes(1);


### PR DESCRIPTION
- Add missing `TASK_TYPE_LABELS` entries for `onedrive_sync`, `google_drive_sync`, and `scheduled_action_execution` so the Processing view shows human-readable names instead of raw task type strings.
- Improve `OneDriveIngestionService` 401 handling: when the access token lacks the required OneDrive scope (either on the initial call or after a stale-delta-link reset retry), throw a clear message instructing the user to re-authorize rather than surfacing the raw Microsoft Graph API error JSON.