### PR TITLE
Transition To Draft When Adding Scope-Requiring Feature

### DIFF
--- a/packages/backend-services/src/application/ApplicationService.ts
+++ b/packages/backend-services/src/application/ApplicationService.ts
@@ -3,6 +3,7 @@ import {
   CONNECTED_APPLICATION_STATUS_DRAFT,
   CONNECTION_METHOD_IMAP_PASSWORD,
   CONNECTION_METHOD_OAUTH2,
+  OAUTH2_FEATURE_SCOPES,
 } from '@mail-otter/shared/constants';
 import { AiDailyUsageDAO, ApplicationContextDAO, ApplicationIntegrationDAO, ConnectedApplicationDAO, IntegrationDeliveryLogDAO, OAuth2AccessTokenCacheDAO } from '@mail-otter/backend-data/dao';
 import type { D1Queryable } from '@mail-otter/backend-data/utils';
@@ -108,7 +109,9 @@ class ApplicationService {
         refreshToken: existingOAuth2.refreshToken,
       };
       const credentialsChanged = newClientId !== existingOAuth2.clientId || newClientSecret !== existingOAuth2.clientSecret;
-      if (credentialsChanged) newStatus = CONNECTED_APPLICATION_STATUS_DRAFT;
+      const newFeatures = (input.enabledFeatures ?? []).filter(f => !(existing.enabledFeatures ?? []).includes(f));
+      const scopeRequiringFeatureAdded = newFeatures.some(f => (OAUTH2_FEATURE_SCOPES[f]?.[existing.providerId]?.length ?? 0) > 0);
+      if (credentialsChanged || scopeRequiringFeatureAdded) newStatus = CONNECTED_APPLICATION_STATUS_DRAFT;
     }
 
     const imapConfig = (input.imapHost || input.imapPort || input.imapUsername || input.smtpHost || input.smtpPort)


### PR DESCRIPTION
When `enabledFeatures` is updated to include a feature that requires additional OAuth2 scopes for the application's provider (e.g. `onedrive` for Outlook, `google_drive` for Gmail), the application must be re-authorized to obtain the new scopes. Previously only credential changes (clientId/clientSecret) triggered a status transition to `DRAFT`; feature additions were silently ignored, leaving the application stuck in `Connected` with missing scopes.

The fix detects newly-added features that have scope entries in `OAUTH2_FEATURE_SCOPES` for the current provider and sets the status to `DRAFT` alongside the existing credentials-changed path.