### PR TITLE
Show Latest Task Run Per Type When No Filter Is Selected

### DIFF
--- a/packages/backend-data/src/dao/BackgroundTaskRunDAO.ts
+++ b/packages/backend-data/src/dao/BackgroundTaskRunDAO.ts
@@ -58,6 +58,7 @@ interface ListTaskRunsOptions {
   status?: BackgroundTaskRunStatus;
   cursor?: string;
   limit?: number;
+  latestPerType?: boolean;
 }
 
 class BackgroundTaskRunDAO extends BaseDAO {
@@ -161,6 +162,40 @@ class BackgroundTaskRunDAO extends BaseDAO {
     if (options.status) {
       conditions.push('btr.status = ?');
       bindings.push(options.status);
+    }
+
+    // When latestPerType is requested and no specific task type is selected,
+    // use a window function to return only the most recent run per task type.
+    if (options.latestPerType && !options.taskType) {
+      const whereClause = conditions.join(' AND ');
+      const rows: BackgroundTaskRunInternal[] = await this.database
+        .prepare(
+          `SELECT run_id, task_type, application_id, status,
+                  items_processed, items_failed, summary, details,
+                  error_message, started_at, completed_at, created_at
+           FROM (
+             SELECT btr.run_id, btr.task_type, btr.application_id, btr.status,
+                    btr.items_processed, btr.items_failed, btr.summary, btr.details,
+                    btr.error_message, btr.started_at, btr.completed_at, btr.created_at,
+                    ROW_NUMBER() OVER (
+                      PARTITION BY btr.task_type
+                      ORDER BY btr.started_at DESC, btr.run_id DESC
+                    ) AS rn
+             FROM background_task_runs btr
+             INNER JOIN connected_applications ca ON ca.application_id = btr.application_id
+             WHERE ${whereClause}
+           )
+           WHERE rn = 1
+           ORDER BY started_at DESC, run_id DESC`,
+        )
+        .bind(...bindings)
+        .all<BackgroundTaskRunInternal>()
+        .then((result: D1Result<BackgroundTaskRunInternal>): BackgroundTaskRunInternal[] => result.results || []);
+
+      return {
+        runs: rows.map((r) => BackgroundTaskRunDAO.toRun(r)),
+        nextCursor: undefined,
+      };
     }
 
     const cursor = BackgroundTaskRunDAO.parseCursor(options.cursor);

--- a/packages/backend-services/src/processing/ProcessingService.ts
+++ b/packages/backend-services/src/processing/ProcessingService.ts
@@ -30,7 +30,7 @@ interface TriggerTaskEnv extends ProcessingServiceEnv {
 const ProcessingService = {
   async listTaskRuns(
     userEmail: string,
-    options: Pick<ListTaskRunsOptions, 'taskType' | 'applicationId' | 'status' | 'cursor'>,
+    options: Pick<ListTaskRunsOptions, 'taskType' | 'applicationId' | 'status' | 'cursor' | 'latestPerType'>,
     env: ProcessingServiceEnv,
   ): Promise<BackgroundTaskRunList> {
     const dao = new BackgroundTaskRunDAO(env.DB);
@@ -39,6 +39,7 @@ const ProcessingService = {
       applicationId: options.applicationId,
       status: options.status,
       cursor: options.cursor,
+      latestPerType: !options.taskType,
     });
   },
 


### PR DESCRIPTION
When the Background Task Runs list has no specific task type filter (i.e. "All Task Types"), the UI previously returned all runs across every type, flooding the view with redundant entries from frequent cron cycles.

A new `latestPerType` option on `BackgroundTaskRunDAO.listForUser` uses a SQL window function (`ROW_NUMBER() OVER (PARTITION BY task_type ORDER BY started_at DESC, run_id DESC)`) to return only the most recent run per task type when no type filter is active.

`ProcessingService.listTaskRuns` automatically sets `latestPerType: !options.taskType`, so the compact view is the default when no specific type is selected. Selecting a specific task type still shows all runs of that type with cursor pagination, unchanged.