### PR TITLE
Add Dismiss Label And Icon To Error Metric Button

### DIFF
--- a/apps/web/src/components/shared/Metric.tsx
+++ b/apps/web/src/components/shared/Metric.tsx
@@ -1,4 +1,5 @@
 import { cn } from '../../lib/utils';
+import { X } from 'lucide-react';
 
 export function Metric({
   label,
@@ -24,9 +25,9 @@ export function Metric({
         <button
           onClick={onDismiss}
           title="Dismiss Error"
-          className="absolute top-2 right-2 text-[var(--color-text-muted)] hover:text-[var(--color-text-primary)] leading-none text-base"
+          className="absolute top-2 right-2 text-[var(--color-text-muted)] hover:text-[var(--color-text-primary)] leading-none text-sm flex items-center gap-1 whitespace-nowrap"
         >
-          ×
+          Dismiss <X className="h-3.5 w-3.5" />
         </button>
       )}
     </div>


### PR DESCRIPTION
The dismiss button on error Metric cards was just a bare `x` character with no visible label, making it hard to notice. Replaced the plain `x` with a `Dismiss` label and a Lucide `X` icon, matching the close-button pattern used elsewhere in the app.

- Added `flex items-center gap-1 whitespace-nowrap` for proper layout
- Changed font size to `text-sm` for better visual balance
- Used `h-3.5 w-3.5` Lucide X icon consistent with modal close buttons