### PR TITLE
Add Always Matcher To Match All Emails

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -257,7 +257,7 @@ Each application may define up to 20 `emailProcessingRules` (stored as a provide
 
 `EmailRulesUtil` in `packages/backend-services/src/email/` evaluates rules. `EmailRuleSuggestionUtil` in the same package generates AI-suggested rules from a plain-language description. The rules and suggest API routes are `GET|PUT /user/application/rules` and `POST /user/application/rules/suggest`. The `RulesSection` component in `apps/web/src/components/mailboxes/` owns the rules UI.
 
-Matcher fields: `from`, `subject`, `body`, `has_attachment`, `detected_action_type`. Ops: `contains`, `not_contains`, `matches_sender`, `is`, `includes`, `not_includes`.
+Matcher fields: `from`, `subject`, `body`, `has_attachment`, `detected_action_type`, `always`. Ops: `contains`, `not_contains`, `matches_sender`, `is`, `includes`, `not_includes`, `match_all`. The `always` field with op `match_all` (no `value`) unconditionally matches every email.
 
 ## Scheduled Digest
 

--- a/apps/web/components/types.ts
+++ b/apps/web/components/types.ts
@@ -1,14 +1,15 @@
 export type ProviderId = 'google-gmail' | 'microsoft-outlook' | 'fastmail-jmap' | 'yahoo-mail' | 'custom-imap' | 'apple-icloud';
 
-export type EmailRuleConditionMatcherField = 'from' | 'subject' | 'body' | 'has_attachment' | 'detected_action_type';
-export type EmailRuleConditionMatcherOp = 'contains' | 'not_contains' | 'matches_sender' | 'is' | 'includes' | 'not_includes';
+export type EmailRuleConditionMatcherField = 'from' | 'subject' | 'body' | 'has_attachment' | 'detected_action_type' | 'always';
+export type EmailRuleConditionMatcherOp = 'contains' | 'not_contains' | 'matches_sender' | 'is' | 'includes' | 'not_includes' | 'match_all';
 
 export type EmailRuleConditionMatcher =
   | { field: 'from'; op: 'contains' | 'not_contains' | 'matches_sender'; value: string }
   | { field: 'subject'; op: 'contains' | 'not_contains'; value: string }
   | { field: 'body'; op: 'contains' | 'not_contains'; value: string }
   | { field: 'has_attachment'; op: 'is'; value: 'true' | 'false' }
-  | { field: 'detected_action_type'; op: 'includes' | 'not_includes'; value: string };
+  | { field: 'detected_action_type'; op: 'includes' | 'not_includes'; value: string }
+  | { field: 'always'; op: 'match_all' };
 
 export interface EmailRuleCondition {
   operator: 'all' | 'any';

--- a/apps/web/src/components/mailboxes/RulesSection.tsx
+++ b/apps/web/src/components/mailboxes/RulesSection.tsx
@@ -25,6 +25,7 @@ const FIELD_LABELS: Record<EmailRuleConditionMatcherField, string> = {
   body: 'Body',
   has_attachment: 'Has Attachment',
   detected_action_type: 'Detected Action Type',
+  always: 'Always (Match All Emails)',
 };
 
 const DETECTED_ACTION_TYPE_OPTIONS = [
@@ -70,6 +71,7 @@ function formatConditionSummary(rule: EmailProcessingRule): string {
   const { operator, matchers } = rule.conditions;
   return matchers
     .map((m) => {
+      if (m.field === 'always') return 'Always (Match All Emails)';
       if (m.field === 'has_attachment') return `Has Attachment Is ${m.value === 'true' ? 'True' : 'False'}`;
       if (m.field === 'detected_action_type') {
         const opLabel = m.op === 'includes' ? 'Includes' : 'Does Not Include';
@@ -112,7 +114,7 @@ function ruleToDraft(rule: EmailProcessingRule): RuleDraft {
   return {
     name: rule.name,
     operator: rule.conditions.operator,
-    matchers: rule.conditions.matchers.map((m) => ({ field: m.field, op: m.op, value: m.value })),
+    matchers: rule.conditions.matchers.map((m) => ({ field: m.field, op: m.op, value: 'value' in m ? m.value : '' })),
     actionType: rule.action.type,
     instruction: rule.action.type === 'prepend_instruction' ? (rule.action.instruction ?? '') : '',
     labelName: rule.action.type === 'apply_label' ? rule.action.labelName : '',
@@ -120,6 +122,9 @@ function ruleToDraft(rule: EmailProcessingRule): RuleDraft {
 }
 
 function draftToMatcher(m: MatcherDraft): EmailRuleConditionMatcher {
+  if (m.field === 'always') {
+    return { field: 'always', op: 'match_all' };
+  }
   if (m.field === 'has_attachment') {
     return { field: 'has_attachment', op: 'is', value: (m.value === 'true' ? 'true' : 'false') };
   }
@@ -192,23 +197,29 @@ function RuleForm({
         const updated = { ...m, ...patch };
         if (patch.field) {
           switch (patch.field) {
+          case 'always': {
+            updated.op = 'match_all';
+            updated.value = '';
+
+          break;
+          }
           case 'has_attachment': {
             updated.op = 'is';
             updated.value = 'true';
-          
+
           break;
           }
           case 'detected_action_type': {
             updated.op = 'includes';
             updated.value ||= DETECTED_ACTION_TYPE_OPTIONS[0];
-          
+
           break;
           }
           case 'from': {
             if (updated.op !== 'contains' && updated.op !== 'not_contains' && updated.op !== 'matches_sender') {
               updated.op = 'contains';
             }
-          
+
           break;
           }
           default: {
@@ -220,6 +231,8 @@ function RuleForm({
         }
         return updated;
       });
+      const alwaysIdx = matchers.findIndex((m) => m.field === 'always');
+      if (alwaysIdx !== -1) return { ...d, matchers: [matchers[alwaysIdx]] };
       return { ...d, matchers };
     });
   };
@@ -252,7 +265,7 @@ function RuleForm({
   const isValid = (): boolean => {
     if (!draft.name.trim()) return false;
     if (draft.matchers.some((m) => {
-      if (m.field === 'has_attachment') return false;
+      if (m.field === 'has_attachment' || m.field === 'always') return false;
       return !m.value.trim();
     })) return false;
     if (draft.actionType === 'prepend_instruction' && !draft.instruction.trim()) return false;
@@ -277,6 +290,7 @@ function RuleForm({
   };
 
   const renderMatcherValueInput = (m: MatcherDraft, i: number) => {
+    if (m.field === 'always') return null;
     if (m.field === 'has_attachment') {
       return (
         <select
@@ -315,6 +329,7 @@ function RuleForm({
   };
 
   const renderOpSelect = (m: MatcherDraft, i: number) => {
+    if (m.field === 'always') return null;
     if (m.field === 'has_attachment') {
       return (
         <select
@@ -365,17 +380,19 @@ function RuleForm({
         />
       </div>
 
-      <div className="flex items-center gap-2">
-        <span className="text-xs text-[var(--color-text-muted)]">Match</span>
-        <select
-          value={draft.operator}
-          onChange={(e) => setDraft((d) => ({ ...d, operator: e.target.value as 'all' | 'any' }))}
-          className="text-xs border border-[var(--color-border)] rounded px-2 py-1 bg-[var(--color-surface-base)] text-[var(--color-text-primary)]"
-        >
-          <option value="any">Any Condition</option>
-          <option value="all">All Conditions</option>
-        </select>
-      </div>
+      {!(draft.matchers.length === 1 && draft.matchers[0].field === 'always') && (
+        <div className="flex items-center gap-2">
+          <span className="text-xs text-[var(--color-text-muted)]">Match</span>
+          <select
+            value={draft.operator}
+            onChange={(e) => setDraft((d) => ({ ...d, operator: e.target.value as 'all' | 'any' }))}
+            className="text-xs border border-[var(--color-border)] rounded px-2 py-1 bg-[var(--color-surface-base)] text-[var(--color-text-primary)]"
+          >
+            <option value="any">Any Condition</option>
+            <option value="all">All Conditions</option>
+          </select>
+        </div>
+      )}
 
       <div className="flex flex-col gap-2">
         {draft.matchers.map((m, i) => (
@@ -390,6 +407,7 @@ function RuleForm({
               <option value="body">Body</option>
               <option value="has_attachment">Has Attachment</option>
               <option value="detected_action_type">Detected Action Type</option>
+              <option value="always">Always (Match All Emails)</option>
             </select>
             {renderOpSelect(m, i)}
             {renderMatcherValueInput(m, i)}
@@ -405,7 +423,7 @@ function RuleForm({
             )}
           </div>
         ))}
-        {draft.matchers.length < MAX_MATCHERS && (
+        {draft.matchers.length < MAX_MATCHERS && draft.matchers[0]?.field !== 'always' && (
           <button
             type="button"
             onClick={addMatcher}

--- a/packages/backend-services/src/email/EmailRulesUtil.ts
+++ b/packages/backend-services/src/email/EmailRulesUtil.ts
@@ -51,6 +51,8 @@ class EmailRulesUtil {
   }
 
   public static matchesMatcher(matcher: EmailRuleConditionMatcher, ctx: EmailRuleContext): boolean {
+    if (matcher.field === 'always') return true;
+
     if (matcher.field === 'has_attachment') {
       const hasAttachment = ctx.hasAttachment === true;
       return matcher.value === 'true' ? hasAttachment : !hasAttachment;

--- a/packages/shared/src/model/EmailRule.ts
+++ b/packages/shared/src/model/EmailRule.ts
@@ -1,12 +1,13 @@
-type EmailRuleConditionMatcherField = 'from' | 'subject' | 'body' | 'has_attachment' | 'detected_action_type';
-type EmailRuleConditionMatcherOp = 'contains' | 'not_contains' | 'matches_sender' | 'is' | 'includes' | 'not_includes';
+type EmailRuleConditionMatcherField = 'from' | 'subject' | 'body' | 'has_attachment' | 'detected_action_type' | 'always';
+type EmailRuleConditionMatcherOp = 'contains' | 'not_contains' | 'matches_sender' | 'is' | 'includes' | 'not_includes' | 'match_all';
 
 type EmailRuleConditionMatcher =
   | { field: 'from'; op: 'contains' | 'not_contains' | 'matches_sender'; value: string }
   | { field: 'subject'; op: 'contains' | 'not_contains'; value: string }
   | { field: 'body'; op: 'contains' | 'not_contains'; value: string }
   | { field: 'has_attachment'; op: 'is'; value: 'true' | 'false' }
-  | { field: 'detected_action_type'; op: 'includes' | 'not_includes'; value: string };
+  | { field: 'detected_action_type'; op: 'includes' | 'not_includes'; value: string }
+  | { field: 'always'; op: 'match_all' };
 
 interface EmailRuleCondition {
   operator: 'all' | 'any';

--- a/packages/shared/src/schema/common.ts
+++ b/packages/shared/src/schema/common.ts
@@ -108,6 +108,10 @@ const EmailRuleConditionMatcherSchema = z.union([
     op: z.enum(['includes', 'not_includes']),
     value: z.string().min(1, 'value is required.').max(200, 'value must be 200 characters or less.'),
   }),
+  z.object({
+    field: z.literal('always'),
+    op: z.literal('match_all'),
+  }),
 ]);
 
 const EmailRuleConditionSchema = z.object({

--- a/test/schema/RequestValidation.test.ts
+++ b/test/schema/RequestValidation.test.ts
@@ -153,5 +153,20 @@ describe('Request input schemas', () => {
       const valid = { ...validRule, action: { type: 'prepend_instruction', instruction: 'Extract invoice number.' } };
       expect(EmailProcessingRuleSchema.safeParse(valid).success).toBe(true);
     });
+
+    it('accepts always matcher with match_all op on a pre-processing rule', () => {
+      const valid = { ...validRule, conditions: { operator: 'any', matchers: [{ field: 'always', op: 'match_all' }] } };
+      expect(EmailProcessingRuleSchema.safeParse(valid).success).toBe(true);
+    });
+
+    it('accepts always matcher with match_all op on a post-processing rule', () => {
+      const valid = { ...validRule, action: { type: 'star_message' }, conditions: { operator: 'any', matchers: [{ field: 'always', op: 'match_all' }] } };
+      expect(EmailProcessingRuleSchema.safeParse(valid).success).toBe(true);
+    });
+
+    it('rejects always matcher with wrong op', () => {
+      const invalid = { ...validRule, conditions: { operator: 'any', matchers: [{ field: 'always', op: 'contains' }] } };
+      expect(EmailProcessingRuleSchema.safeParse(invalid).success).toBe(false);
+    });
   });
 });

--- a/test/utils/EmailRulesUtil.test.ts
+++ b/test/utils/EmailRulesUtil.test.ts
@@ -272,6 +272,33 @@ describe('EmailRulesUtil', () => {
     });
   });
 
+  describe('matchesMatcher — always', () => {
+    it('returns true for a standard email context', () => {
+      expect(EmailRulesUtil.matchesMatcher({ field: 'always', op: 'match_all' }, ctx)).toBe(true);
+    });
+
+    it('returns true when context fields are empty strings', () => {
+      expect(EmailRulesUtil.matchesMatcher({ field: 'always', op: 'match_all' }, { from: '', subject: '', body: '' })).toBe(true);
+    });
+
+    it('returns true regardless of hasAttachment value', () => {
+      expect(EmailRulesUtil.matchesMatcher({ field: 'always', op: 'match_all' }, { ...ctx, hasAttachment: false })).toBe(true);
+      expect(EmailRulesUtil.matchesMatcher({ field: 'always', op: 'match_all' }, { ...ctx, hasAttachment: true })).toBe(true);
+    });
+
+    it('evaluatePreProcessing fires for any email with always matcher', () => {
+      const r = rule({ action: { type: 'skip' }, conditions: { operator: 'any', matchers: [{ field: 'always', op: 'match_all' }] } });
+      expect(EmailRulesUtil.evaluatePreProcessing([r], { from: '', subject: '', body: '' })).not.toBeNull();
+    });
+
+    it('evaluatePostProcessing includes always-matcher rule for any email', () => {
+      const r = rule({ action: { type: 'star_message' }, conditions: { operator: 'any', matchers: [{ field: 'always', op: 'match_all' }] } });
+      const result = EmailRulesUtil.evaluatePostProcessing([r], { from: '', subject: '', body: '' });
+      expect(result).toHaveLength(1);
+      expect(result[0].action.type).toBe('star_message');
+    });
+  });
+
   describe('edge cases', () => {
     it('empty body — contains returns false for non-empty value', () => {
       const emptyBodyCtx = { ...ctx, body: '' };


### PR DESCRIPTION
Adds an `always` matcher type (`field: 'always', op: 'match_all'`) that unconditionally matches every processed email, enabling rules like "always prepend this instruction to every email" or "always star every email."

- Extends `EmailRuleConditionMatcher` union with `{ field: 'always'; op: 'match_all' }` (no value) in the shared model and web types
- Adds `always` / `match_all` to `EmailRuleConditionMatcherField` and `EmailRuleConditionMatcherOp`
- Adds schema validation for the new union member in `EmailRuleConditionMatcherSchema`
- Short-circuits `matchesMatcher` to return `true` for `always` in `EmailRulesUtil`
- Updates `RulesSection` UI: new field option, hides op/value inputs, hides operator row and Add Condition button when always matcher is selected, collapses to a single always matcher on selection
- Adds 5 new `EmailRulesUtil` tests and 3 new `EmailProcessingRuleSchema` schema tests
- Updates AGENTS.md matcher/op documentation