### PR TITLE
Increase Unit Test Coverage For Uncovered Modules

### DIFF
--- a/test/dao/ApplicationIntegrationDAO.test.ts
+++ b/test/dao/ApplicationIntegrationDAO.test.ts
@@ -1,0 +1,284 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const mockNow = 1_778_200_000;
+const mockUUID = 'integ-uuid-1';
+const mockEncrypted = { encrypted: 'enc-url', iv: 'url-iv' };
+
+vi.mock('@mail-otter/backend-data/crypto', () => ({
+  encryptData: vi.fn(() => Promise.resolve(mockEncrypted)),
+  decryptData: vi.fn(() => Promise.resolve('https://hooks.example.com/webhook/abcdefg')),
+}));
+
+vi.mock('@mail-otter/shared/utils', () => ({
+  TimestampUtil: { getCurrentUnixTimestampInSeconds: vi.fn(() => mockNow) },
+  UUIDUtil: { getRandomUUID: vi.fn(() => mockUUID) },
+}));
+
+import { ApplicationIntegrationDAO } from '@mail-otter/backend-data/dao';
+import { BadRequestError } from '@mail-otter/backend-errors';
+
+const WEBHOOK_URL = 'https://hooks.example.com/webhook/abcdefg-long-suffix';
+const MASKED_URL = WEBHOOK_URL.slice(0, 30);
+
+function makeDb(overrides?: { firstResult?: unknown; allResults?: unknown[]; countResult?: { cnt: number }; runMeta?: { changes: number } }): D1Database {
+  const runFn = vi.fn().mockResolvedValue({ success: true, meta: overrides?.runMeta ?? { changes: 1 } });
+  const firstFn = vi.fn().mockResolvedValue(overrides?.firstResult ?? null);
+  const allFn = vi.fn().mockResolvedValue({ results: overrides?.allResults ?? [] });
+  return {
+    prepare: vi.fn(() => ({
+      bind: vi.fn(() => ({ run: runFn, first: firstFn, all: allFn })),
+    })),
+  };
+}
+
+function makeIntegrationRow(overrides?: Record<string, unknown>) {
+  return {
+    integration_id: mockUUID,
+    application_id: 'app-1',
+    integration_type: 'webhook',
+    name: 'My Integration',
+    encrypted_webhook_url: mockEncrypted.encrypted,
+    webhook_url_iv: mockEncrypted.iv,
+    webhook_url_prefix: MASKED_URL,
+    enabled: 1,
+    created_at: mockNow,
+    updated_at: mockNow,
+    last_delivery_at: null,
+    last_delivery_status: null,
+    consecutive_failures: 0,
+    ...overrides,
+  };
+}
+
+describe('ApplicationIntegrationDAO', () => {
+  let dao: ApplicationIntegrationDAO;
+  let db: D1Database;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    db = makeDb();
+    dao = new ApplicationIntegrationDAO(db, 'master-key');
+  });
+
+  describe('create', () => {
+    it('inserts integration and returns public view', async () => {
+      // first() call for countByApplicationId returns 0
+      const firstFn = vi.fn().mockResolvedValueOnce({ cnt: 0 }).mockResolvedValueOnce(null);
+      const runFn = vi.fn().mockResolvedValue({ success: true, meta: { changes: 1 } });
+      db = {
+        prepare: vi.fn(() => ({
+          bind: vi.fn(() => ({ first: firstFn, run: runFn, all: vi.fn().mockResolvedValue({ results: [] }) }),
+          ),
+        })),
+      };
+      dao = new ApplicationIntegrationDAO(db, 'master-key');
+
+      const result = await dao.create('app-1', 'webhook', 'My Integration', WEBHOOK_URL);
+
+      expect(result.integrationId).toBe(mockUUID);
+      expect(result.applicationId).toBe('app-1');
+      expect(result.integrationType).toBe('webhook');
+      expect(result.name).toBe('My Integration');
+      expect(result.maskedWebhookUrl).toContain('...');
+      expect(result.enabled).toBe(true);
+      expect(result.createdAt).toBe(mockNow);
+    });
+
+    it('throws BadRequestError when max integrations reached', async () => {
+      const firstFn = vi.fn().mockResolvedValue({ cnt: 5 });
+      db = {
+        prepare: vi.fn(() => ({
+          bind: vi.fn(() => ({ first: firstFn })),
+        })),
+      };
+      dao = new ApplicationIntegrationDAO(db, 'master-key');
+
+      await expect(dao.create('app-1', 'webhook', 'Extra', WEBHOOK_URL)).rejects.toThrow(BadRequestError);
+    });
+  });
+
+  describe('listByApplicationId', () => {
+    it('returns mapped integrations', async () => {
+      const row = makeIntegrationRow();
+      db = makeDb({ allResults: [row] });
+      dao = new ApplicationIntegrationDAO(db, 'master-key');
+
+      const results = await dao.listByApplicationId('app-1');
+      expect(results).toHaveLength(1);
+      expect(results[0].integrationId).toBe(mockUUID);
+      expect(results[0].maskedWebhookUrl).toBe(`${MASKED_URL}...`);
+    });
+
+    it('returns empty array when no integrations', async () => {
+      const results = await dao.listByApplicationId('app-1');
+      expect(results).toHaveLength(0);
+    });
+  });
+
+  describe('listEnabled', () => {
+    it('returns only enabled integrations', async () => {
+      const row = makeIntegrationRow({ enabled: 1 });
+      db = makeDb({ allResults: [row] });
+      dao = new ApplicationIntegrationDAO(db, 'master-key');
+
+      const results = await dao.listEnabled('app-1');
+      expect(results).toHaveLength(1);
+      expect(results[0].enabled).toBe(true);
+    });
+  });
+
+  describe('getByIdForUser', () => {
+    it('returns integration when found', async () => {
+      const row = makeIntegrationRow();
+      db = makeDb({ firstResult: row });
+      dao = new ApplicationIntegrationDAO(db, 'master-key');
+
+      const result = await dao.getByIdForUser(mockUUID, 'user@example.com');
+      expect(result?.integrationId).toBe(mockUUID);
+    });
+
+    it('returns null when not found', async () => {
+      const result = await dao.getByIdForUser('no-such-id', 'user@example.com');
+      expect(result).toBeNull();
+    });
+  });
+
+  describe('getApplicationIdForUser', () => {
+    it('returns applicationId when found', async () => {
+      db = makeDb({ firstResult: { application_id: 'app-1' } });
+      dao = new ApplicationIntegrationDAO(db, 'master-key');
+
+      const result = await dao.getApplicationIdForUser(mockUUID, 'user@example.com');
+      expect(result).toBe('app-1');
+    });
+
+    it('returns null when not found', async () => {
+      const result = await dao.getApplicationIdForUser('no-such-id', 'user@example.com');
+      expect(result).toBeNull();
+    });
+  });
+
+  describe('getDecryptedWebhookUrl', () => {
+    it('returns decrypted URL', async () => {
+      db = makeDb({ firstResult: { encrypted_webhook_url: mockEncrypted.encrypted, webhook_url_iv: mockEncrypted.iv } });
+      dao = new ApplicationIntegrationDAO(db, 'master-key');
+
+      const url = await dao.getDecryptedWebhookUrl(mockUUID);
+      expect(url).toBe('https://hooks.example.com/webhook/abcdefg');
+    });
+
+    it('throws BadRequestError when integration not found', async () => {
+      await expect(dao.getDecryptedWebhookUrl('no-such-id')).rejects.toThrow(BadRequestError);
+    });
+  });
+
+  describe('update', () => {
+    it('updates name and returns updated integration', async () => {
+      const updatedRow = makeIntegrationRow({ name: 'Updated Name' });
+      const firstFn = vi.fn().mockResolvedValue(updatedRow);
+      const runFn = vi.fn().mockResolvedValue({ success: true, meta: { changes: 1 } });
+      db = {
+        prepare: vi.fn(() => ({
+          bind: vi.fn(() => ({ first: firstFn, run: runFn, all: vi.fn().mockResolvedValue({ results: [] }) })),
+        })),
+      };
+      dao = new ApplicationIntegrationDAO(db, 'master-key');
+
+      const result = await dao.update(mockUUID, { name: 'Updated Name' });
+      expect(result.name).toBe('Updated Name');
+    });
+
+    it('updates enabled state', async () => {
+      const updatedRow = makeIntegrationRow({ enabled: 0 });
+      const firstFn = vi.fn().mockResolvedValue(updatedRow);
+      const runFn = vi.fn().mockResolvedValue({ success: true, meta: { changes: 1 } });
+      db = {
+        prepare: vi.fn(() => ({
+          bind: vi.fn(() => ({ first: firstFn, run: runFn, all: vi.fn().mockResolvedValue({ results: [] }) })),
+        })),
+      };
+      dao = new ApplicationIntegrationDAO(db, 'master-key');
+
+      const result = await dao.update(mockUUID, { enabled: false });
+      expect(result.enabled).toBe(false);
+    });
+
+    it('updates webhook URL with re-encryption', async () => {
+      const updatedRow = makeIntegrationRow({ webhook_url_prefix: 'https://new-hook.example.com/' });
+      const firstFn = vi.fn().mockResolvedValue(updatedRow);
+      const runFn = vi.fn().mockResolvedValue({ success: true, meta: { changes: 1 } });
+      db = {
+        prepare: vi.fn(() => ({
+          bind: vi.fn(() => ({ first: firstFn, run: runFn, all: vi.fn().mockResolvedValue({ results: [] }) })),
+        })),
+      };
+      dao = new ApplicationIntegrationDAO(db, 'master-key');
+
+      await dao.update(mockUUID, { webhookUrl: 'https://new-hook.example.com/abc' });
+      expect(runFn).toHaveBeenCalled();
+    });
+
+    it('throws BadRequestError when integration not found after update', async () => {
+      const firstFn = vi.fn().mockResolvedValue(null);
+      const runFn = vi.fn().mockResolvedValue({ success: true, meta: { changes: 0 } });
+      db = {
+        prepare: vi.fn(() => ({
+          bind: vi.fn(() => ({ first: firstFn, run: runFn })),
+        })),
+      };
+      dao = new ApplicationIntegrationDAO(db, 'master-key');
+
+      await expect(dao.update(mockUUID, { name: 'X' })).rejects.toThrow(BadRequestError);
+    });
+  });
+
+  describe('deleteById', () => {
+    it('executes delete query', async () => {
+      const runFn = vi.fn().mockResolvedValue({ success: true, meta: { changes: 1 } });
+      db = {
+        prepare: vi.fn(() => ({
+          bind: vi.fn(() => ({ run: runFn })),
+        })),
+      };
+      dao = new ApplicationIntegrationDAO(db, 'master-key');
+
+      await dao.deleteById(mockUUID);
+      expect(runFn).toHaveBeenCalled();
+    });
+  });
+
+  describe('countByApplicationId', () => {
+    it('returns count from database', async () => {
+      db = makeDb({ firstResult: { cnt: 3 } });
+      dao = new ApplicationIntegrationDAO(db, 'master-key');
+
+      const count = await dao.countByApplicationId('app-1');
+      expect(count).toBe(3);
+    });
+
+    it('returns 0 when no integrations exist', async () => {
+      const count = await dao.countByApplicationId('app-empty');
+      expect(count).toBe(0);
+    });
+  });
+
+  describe('toPublic (masking)', () => {
+    it('produces masked URL with ellipsis', async () => {
+      const row = makeIntegrationRow({ webhook_url_prefix: 'https://hooks.example.com/abc' });
+      db = makeDb({ allResults: [row] });
+      dao = new ApplicationIntegrationDAO(db, 'master-key');
+
+      const results = await dao.listByApplicationId('app-1');
+      expect(results[0].maskedWebhookUrl).toBe('https://hooks.example.com/abc...');
+    });
+
+    it('returns empty string for null webhook_url_prefix', async () => {
+      const row = makeIntegrationRow({ webhook_url_prefix: null });
+      db = makeDb({ allResults: [row] });
+      dao = new ApplicationIntegrationDAO(db, 'master-key');
+
+      const results = await dao.listByApplicationId('app-1');
+      expect(results[0].maskedWebhookUrl).toBe('');
+    });
+  });
+});

--- a/test/dao/BackgroundTaskRunDAO.test.ts
+++ b/test/dao/BackgroundTaskRunDAO.test.ts
@@ -1,0 +1,316 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const mockNow = 1_778_200_000;
+const mockUUID = 'run-uuid-1';
+
+vi.mock('@mail-otter/shared/utils', () => ({
+  TimestampUtil: { getCurrentUnixTimestampInSeconds: vi.fn(() => mockNow) },
+  UUIDUtil: { getRandomUUID: vi.fn(() => mockUUID) },
+}));
+
+import { BackgroundTaskRunDAO } from '@mail-otter/backend-data/dao';
+
+function makeDb(overrides?: { firstResult?: unknown; allResults?: unknown[]; runMeta?: { changes: number } }): D1Database {
+  const runFn = vi.fn().mockResolvedValue({ success: true, meta: overrides?.runMeta ?? { changes: 1 } });
+  const firstFn = vi.fn().mockResolvedValue(overrides?.firstResult ?? null);
+  const allFn = vi.fn().mockResolvedValue({ results: overrides?.allResults ?? [] });
+  return {
+    prepare: vi.fn(() => ({
+      bind: vi.fn(() => ({ run: runFn, first: firstFn, all: allFn })),
+    })),
+  };
+}
+
+function makeRunRow(overrides?: Record<string, unknown>) {
+  return {
+    run_id: mockUUID,
+    task_type: 'calendar_sync',
+    application_id: 'app-1',
+    status: 'success',
+    items_processed: 5,
+    items_failed: 0,
+    summary: 'Synced 5 events',
+    details: null,
+    error_message: null,
+    started_at: mockNow - 30,
+    completed_at: mockNow,
+    created_at: mockNow - 30,
+    ...overrides,
+  };
+}
+
+describe('BackgroundTaskRunDAO', () => {
+  let dao: BackgroundTaskRunDAO;
+  let db: D1Database;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    db = makeDb();
+    dao = new BackgroundTaskRunDAO(db);
+  });
+
+  describe('startRun', () => {
+    it('inserts a running record and returns the runId', async () => {
+      const runId = await dao.startRun({ taskType: 'calendar_sync', applicationId: 'app-1' });
+      expect(runId).toBe(mockUUID);
+      expect((db.prepare as ReturnType<typeof vi.fn>)).toHaveBeenCalled();
+    });
+
+    it('accepts undefined applicationId', async () => {
+      const runId = await dao.startRun({ taskType: 'some_task' });
+      expect(runId).toBe(mockUUID);
+    });
+  });
+
+  describe('succeedRun', () => {
+    it('updates status to success when no failures', async () => {
+      const runFn = vi.fn().mockResolvedValue({ success: true, meta: { changes: 1 } });
+      db = {
+        prepare: vi.fn(() => ({
+          bind: vi.fn(() => ({ run: runFn })),
+        })),
+      };
+      dao = new BackgroundTaskRunDAO(db);
+
+      await dao.succeedRun(mockUUID, { itemsProcessed: 5, itemsFailed: 0 });
+      expect(runFn).toHaveBeenCalled();
+    });
+
+    it('updates status to partial_success when some failures exist', async () => {
+      const bindFn = vi.fn();
+      const runFn = vi.fn().mockResolvedValue({ success: true, meta: { changes: 1 } });
+      db = {
+        prepare: vi.fn(() => ({
+          bind: bindFn.mockReturnValue({ run: runFn }),
+        })),
+      };
+      dao = new BackgroundTaskRunDAO(db);
+
+      await dao.succeedRun(mockUUID, { itemsProcessed: 5, itemsFailed: 2, summary: 'partial' });
+      const bindArgs = bindFn.mock.calls[0];
+      expect(bindArgs[0]).toBe('partial_success');
+    });
+
+    it('serializes details as JSON', async () => {
+      const bindFn = vi.fn();
+      const runFn = vi.fn().mockResolvedValue({ success: true, meta: { changes: 1 } });
+      db = {
+        prepare: vi.fn(() => ({
+          bind: bindFn.mockReturnValue({ run: runFn }),
+        })),
+      };
+      dao = new BackgroundTaskRunDAO(db);
+
+      await dao.succeedRun(mockUUID, {
+        itemsProcessed: 1,
+        itemsFailed: 0,
+        details: { indexed: 3 },
+      });
+      // bind args: status, itemsProcessed, itemsFailed, summary, details, completedAt, runId
+      const allArgs: unknown[] = bindFn.mock.calls[0];
+      const detailsArg = allArgs.find((a) => typeof a === 'string' && a.startsWith('{'));
+      expect(detailsArg).toBe(JSON.stringify({ indexed: 3 }));
+    });
+  });
+
+  describe('failRun', () => {
+    it('marks run as error with error message', async () => {
+      const bindFn = vi.fn();
+      const runFn = vi.fn().mockResolvedValue({ success: true, meta: { changes: 1 } });
+      db = {
+        prepare: vi.fn(() => ({
+          bind: bindFn.mockReturnValue({ run: runFn }),
+        })),
+      };
+      dao = new BackgroundTaskRunDAO(db);
+
+      await dao.failRun(mockUUID, 'Something exploded', { itemsProcessed: 2, itemsFailed: 1 });
+      expect(bindFn.mock.calls[0][0]).toBe('Something exploded');
+    });
+
+    it('uses defaults when partial input is omitted', async () => {
+      const bindFn = vi.fn();
+      const runFn = vi.fn().mockResolvedValue({ success: true, meta: { changes: 1 } });
+      db = {
+        prepare: vi.fn(() => ({
+          bind: bindFn.mockReturnValue({ run: runFn }),
+        })),
+      };
+      dao = new BackgroundTaskRunDAO(db);
+
+      await dao.failRun(mockUUID, 'Error');
+      expect(bindFn.mock.calls[0][1]).toBe(0); // itemsProcessed
+      expect(bindFn.mock.calls[0][2]).toBe(0); // itemsFailed
+    });
+  });
+
+  describe('skipRun', () => {
+    it('marks run as skipped with optional reason', async () => {
+      const bindFn = vi.fn();
+      const runFn = vi.fn().mockResolvedValue({ success: true, meta: { changes: 1 } });
+      db = {
+        prepare: vi.fn(() => ({
+          bind: bindFn.mockReturnValue({ run: runFn }),
+        })),
+      };
+      dao = new BackgroundTaskRunDAO(db);
+
+      await dao.skipRun(mockUUID, 'no-op');
+      expect(bindFn.mock.calls[0][0]).toBe('no-op');
+    });
+
+    it('uses null reason when none provided', async () => {
+      const bindFn = vi.fn();
+      const runFn = vi.fn().mockResolvedValue({ success: true, meta: { changes: 1 } });
+      db = {
+        prepare: vi.fn(() => ({
+          bind: bindFn.mockReturnValue({ run: runFn }),
+        })),
+      };
+      dao = new BackgroundTaskRunDAO(db);
+
+      await dao.skipRun(mockUUID);
+      expect(bindFn.mock.calls[0][0]).toBeNull();
+    });
+  });
+
+  describe('listForUser', () => {
+    it('returns empty list when no runs', async () => {
+      const result = await dao.listForUser('user@example.com');
+      expect(result.runs).toHaveLength(0);
+      expect(result.nextCursor).toBeUndefined();
+    });
+
+    it('returns mapped runs', async () => {
+      db = makeDb({ allResults: [makeRunRow()] });
+      dao = new BackgroundTaskRunDAO(db);
+
+      const result = await dao.listForUser('user@example.com');
+      expect(result.runs).toHaveLength(1);
+      expect(result.runs[0].runId).toBe(mockUUID);
+      expect(result.runs[0].taskType).toBe('calendar_sync');
+      expect(result.runs[0].status).toBe('success');
+      expect(result.runs[0].itemsProcessed).toBe(5);
+    });
+
+    it('parses JSON details when present', async () => {
+      db = makeDb({ allResults: [makeRunRow({ details: '{"count":3}' })] });
+      dao = new BackgroundTaskRunDAO(db);
+
+      const result = await dao.listForUser('user@example.com');
+      expect(result.runs[0].details).toEqual({ count: 3 });
+    });
+
+    it('returns null details when details column is null', async () => {
+      db = makeDb({ allResults: [makeRunRow({ details: null })] });
+      dao = new BackgroundTaskRunDAO(db);
+
+      const result = await dao.listForUser('user@example.com');
+      expect(result.runs[0].details).toBeNull();
+    });
+
+    it('provides nextCursor when more rows than limit', async () => {
+      const rows = Array.from({ length: 26 }, (_, i) =>
+        makeRunRow({ run_id: `run-${i}`, started_at: mockNow - i }),
+      );
+      db = makeDb({ allResults: rows });
+      dao = new BackgroundTaskRunDAO(db);
+
+      const result = await dao.listForUser('user@example.com', { limit: 25 });
+      expect(result.runs).toHaveLength(25);
+      expect(result.nextCursor).toBeDefined();
+    });
+
+    it('applies cursor to filter older entries', async () => {
+      const cursor = btoa(JSON.stringify({ startedAt: mockNow - 100, runId: 'some-run' }));
+      db = makeDb({ allResults: [] });
+      dao = new BackgroundTaskRunDAO(db);
+
+      const result = await dao.listForUser('user@example.com', { cursor });
+      expect(result.runs).toHaveLength(0);
+    });
+
+    it('filters by taskType', async () => {
+      db = makeDb({ allResults: [] });
+      dao = new BackgroundTaskRunDAO(db);
+
+      await dao.listForUser('user@example.com', { taskType: 'calendar_sync' });
+      expect((db.prepare as ReturnType<typeof vi.fn>)).toHaveBeenCalled();
+    });
+
+    it('filters by applicationId', async () => {
+      db = makeDb({ allResults: [] });
+      dao = new BackgroundTaskRunDAO(db);
+
+      await dao.listForUser('user@example.com', { applicationId: 'app-1' });
+      expect((db.prepare as ReturnType<typeof vi.fn>)).toHaveBeenCalled();
+    });
+
+    it('filters by status', async () => {
+      db = makeDb({ allResults: [] });
+      dao = new BackgroundTaskRunDAO(db);
+
+      await dao.listForUser('user@example.com', { status: 'error' });
+      expect((db.prepare as ReturnType<typeof vi.fn>)).toHaveBeenCalled();
+    });
+
+    it('uses latestPerType query when no taskType specified', async () => {
+      db = makeDb({ allResults: [makeRunRow()] });
+      dao = new BackgroundTaskRunDAO(db);
+
+      const result = await dao.listForUser('user@example.com', { latestPerType: true });
+      expect(result.runs).toHaveLength(1);
+      expect(result.nextCursor).toBeUndefined();
+    });
+
+    it('ignores latestPerType when taskType is specified', async () => {
+      db = makeDb({ allResults: [] });
+      dao = new BackgroundTaskRunDAO(db);
+
+      const result = await dao.listForUser('user@example.com', { latestPerType: true, taskType: 'calendar_sync' });
+      expect(result.runs).toHaveLength(0);
+    });
+
+    it('ignores invalid cursor gracefully', async () => {
+      const result = await dao.listForUser('user@example.com', { cursor: 'not-valid-base64!!!' });
+      expect(result.runs).toHaveLength(0);
+    });
+
+    it('clamps limit to 50', async () => {
+      const rows = Array.from({ length: 51 }, (_, i) => makeRunRow({ run_id: `run-${i}` }));
+      db = makeDb({ allResults: rows });
+      dao = new BackgroundTaskRunDAO(db);
+
+      const result = await dao.listForUser('user@example.com', { limit: 200 });
+      expect(result.runs).toHaveLength(50);
+    });
+  });
+
+  describe('pruneOldRuns', () => {
+    it('returns number of deleted rows', async () => {
+      const runFn = vi.fn().mockResolvedValue({ success: true, meta: { changes: 7 } });
+      db = {
+        prepare: vi.fn(() => ({
+          bind: vi.fn(() => ({ run: runFn })),
+        })),
+      };
+      dao = new BackgroundTaskRunDAO(db);
+
+      const count = await dao.pruneOldRuns(mockNow - 86_400 * 30, 500);
+      expect(count).toBe(7);
+    });
+
+    it('returns 0 when nothing deleted', async () => {
+      const runFn = vi.fn().mockResolvedValue({ success: true, meta: { changes: 0 } });
+      db = {
+        prepare: vi.fn(() => ({
+          bind: vi.fn(() => ({ run: runFn })),
+        })),
+      };
+      dao = new BackgroundTaskRunDAO(db);
+
+      const count = await dao.pruneOldRuns(mockNow - 86_400 * 30, 500);
+      expect(count).toBe(0);
+    });
+  });
+});

--- a/test/dao/SyncedCalendarEventDAO.test.ts
+++ b/test/dao/SyncedCalendarEventDAO.test.ts
@@ -1,0 +1,243 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const mockNow = 1_778_200_000;
+const mockUUID = 'sync-evt-uuid-1';
+
+vi.mock('@mail-otter/shared/utils', () => ({
+  TimestampUtil: { getCurrentUnixTimestampInSeconds: vi.fn(() => mockNow) },
+  UUIDUtil: { getRandomUUID: vi.fn(() => mockUUID) },
+}));
+
+import { SyncedCalendarEventDAO } from '@mail-otter/backend-data/dao';
+
+function makeDb(overrides?: { allResults?: unknown[]; runMeta?: { changes: number } }): D1Database {
+  const runFn = vi.fn().mockResolvedValue({ success: true, meta: overrides?.runMeta ?? { changes: 1 } });
+  const allFn = vi.fn().mockResolvedValue({ results: overrides?.allResults ?? [] });
+  return {
+    prepare: vi.fn(() => ({
+      bind: vi.fn(() => ({ run: runFn, all: allFn })),
+    })),
+  };
+}
+
+function makeEventRow(overrides?: Record<string, unknown>) {
+  return {
+    sync_event_id: mockUUID,
+    application_id: 'app-1',
+    provider_event_id: 'provider-evt-1',
+    event_title: 'Team Standup',
+    start_time: mockNow + 3600,
+    end_time: mockNow + 7200,
+    time_zone: 'America/New_York',
+    location: 'Zoom',
+    notes: 'Daily sync',
+    synced_at: mockNow,
+    ...overrides,
+  };
+}
+
+describe('SyncedCalendarEventDAO', () => {
+  let dao: SyncedCalendarEventDAO;
+  let db: D1Database;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    db = makeDb();
+    dao = new SyncedCalendarEventDAO(db);
+  });
+
+  describe('upsertEvents', () => {
+    it('does nothing when events array is empty', async () => {
+      await dao.upsertEvents('app-1', []);
+      expect((db.prepare as ReturnType<typeof vi.fn>)).not.toHaveBeenCalled();
+    });
+
+    it('inserts a single event', async () => {
+      const runFn = vi.fn().mockResolvedValue({ success: true, meta: { changes: 1 } });
+      db = {
+        prepare: vi.fn(() => ({
+          bind: vi.fn(() => ({ run: runFn })),
+        })),
+      };
+      dao = new SyncedCalendarEventDAO(db);
+
+      await dao.upsertEvents('app-1', [
+        {
+          providerEventId: 'provider-evt-1',
+          eventTitle: 'Team Standup',
+          startTime: mockNow + 3600,
+          endTime: mockNow + 7200,
+          timeZone: 'UTC',
+        },
+      ]);
+      expect(runFn).toHaveBeenCalledOnce();
+    });
+
+    it('inserts multiple events with separate queries', async () => {
+      const runFn = vi.fn().mockResolvedValue({ success: true, meta: { changes: 1 } });
+      db = {
+        prepare: vi.fn(() => ({
+          bind: vi.fn(() => ({ run: runFn })),
+        })),
+      };
+      dao = new SyncedCalendarEventDAO(db);
+
+      await dao.upsertEvents('app-1', [
+        { providerEventId: 'evt-1', eventTitle: 'Meeting 1', startTime: mockNow, endTime: mockNow + 3600, timeZone: 'UTC' },
+        { providerEventId: 'evt-2', eventTitle: 'Meeting 2', startTime: mockNow + 7200, endTime: mockNow + 10800, timeZone: 'UTC' },
+      ]);
+      expect(runFn).toHaveBeenCalledTimes(2);
+    });
+
+    it('passes optional location and notes', async () => {
+      const bindFn = vi.fn();
+      const runFn = vi.fn().mockResolvedValue({ success: true, meta: { changes: 1 } });
+      db = {
+        prepare: vi.fn(() => ({
+          bind: bindFn.mockReturnValue({ run: runFn }),
+        })),
+      };
+      dao = new SyncedCalendarEventDAO(db);
+
+      await dao.upsertEvents('app-1', [
+        {
+          providerEventId: 'evt-1',
+          eventTitle: 'Doctor Appointment',
+          startTime: mockNow,
+          endTime: mockNow + 3600,
+          timeZone: 'UTC',
+          location: 'Clinic',
+          notes: 'Annual checkup',
+        },
+      ]);
+      const args = bindFn.mock.calls[0];
+      expect(args).toContain('Clinic');
+      expect(args).toContain('Annual checkup');
+    });
+
+    it('uses null for missing optional fields', async () => {
+      const bindFn = vi.fn();
+      const runFn = vi.fn().mockResolvedValue({ success: true, meta: { changes: 1 } });
+      db = {
+        prepare: vi.fn(() => ({
+          bind: bindFn.mockReturnValue({ run: runFn }),
+        })),
+      };
+      dao = new SyncedCalendarEventDAO(db);
+
+      await dao.upsertEvents('app-1', [
+        { providerEventId: 'evt-1', eventTitle: 'No Details', startTime: mockNow, endTime: mockNow + 3600, timeZone: 'UTC' },
+      ]);
+      const args = bindFn.mock.calls[0];
+      expect(args).toContain(null); // location and notes are null
+    });
+  });
+
+  describe('listEventsForRange', () => {
+    it('returns empty array when no events in range', async () => {
+      const events = await dao.listEventsForRange('app-1', mockNow, mockNow + 86400);
+      expect(events).toHaveLength(0);
+    });
+
+    it('returns mapped events', async () => {
+      db = makeDb({ allResults: [makeEventRow()] });
+      dao = new SyncedCalendarEventDAO(db);
+
+      const events = await dao.listEventsForRange('app-1', mockNow, mockNow + 86400);
+      expect(events).toHaveLength(1);
+      expect(events[0].syncEventId).toBe(mockUUID);
+      expect(events[0].eventTitle).toBe('Team Standup');
+      expect(events[0].timeZone).toBe('America/New_York');
+    });
+  });
+
+  describe('listForUser', () => {
+    it('returns empty list when no events', async () => {
+      const result = await dao.listForUser('user@example.com');
+      expect(result.events).toHaveLength(0);
+      expect(result.nextCursor).toBeUndefined();
+    });
+
+    it('returns mapped events for user', async () => {
+      db = makeDb({ allResults: [makeEventRow()] });
+      dao = new SyncedCalendarEventDAO(db);
+
+      const result = await dao.listForUser('user@example.com');
+      expect(result.events).toHaveLength(1);
+      expect(result.events[0].providerEventId).toBe('provider-evt-1');
+      expect(result.events[0].location).toBe('Zoom');
+      expect(result.events[0].notes).toBe('Daily sync');
+    });
+
+    it('filters by applicationId', async () => {
+      db = makeDb({ allResults: [] });
+      dao = new SyncedCalendarEventDAO(db);
+
+      await dao.listForUser('user@example.com', { applicationId: 'app-1' });
+      expect((db.prepare as ReturnType<typeof vi.fn>)).toHaveBeenCalled();
+    });
+
+    it('provides nextCursor when more rows than limit', async () => {
+      const rows = Array.from({ length: 26 }, (_, i) =>
+        makeEventRow({ sync_event_id: `evt-${i}`, synced_at: mockNow - i }),
+      );
+      db = makeDb({ allResults: rows });
+      dao = new SyncedCalendarEventDAO(db);
+
+      const result = await dao.listForUser('user@example.com', { limit: 25 });
+      expect(result.events).toHaveLength(25);
+      expect(result.nextCursor).toBeDefined();
+    });
+
+    it('applies cursor for pagination', async () => {
+      const cursor = btoa(JSON.stringify({ syncedAt: mockNow - 100, syncEventId: 'some-evt' }));
+      db = makeDb({ allResults: [] });
+      dao = new SyncedCalendarEventDAO(db);
+
+      const result = await dao.listForUser('user@example.com', { cursor });
+      expect(result.events).toHaveLength(0);
+    });
+
+    it('ignores invalid cursor gracefully', async () => {
+      const result = await dao.listForUser('user@example.com', { cursor: '!!!invalid' });
+      expect(result.events).toHaveLength(0);
+    });
+
+    it('clamps limit to 50', async () => {
+      const rows = Array.from({ length: 51 }, (_, i) => makeEventRow({ sync_event_id: `evt-${i}` }));
+      db = makeDb({ allResults: rows });
+      dao = new SyncedCalendarEventDAO(db);
+
+      const result = await dao.listForUser('user@example.com', { limit: 100 });
+      expect(result.events).toHaveLength(50);
+    });
+  });
+
+  describe('pruneOldEvents', () => {
+    it('returns number of deleted events', async () => {
+      const runFn = vi.fn().mockResolvedValue({ success: true, meta: { changes: 4 } });
+      db = {
+        prepare: vi.fn(() => ({
+          bind: vi.fn(() => ({ run: runFn })),
+        })),
+      };
+      dao = new SyncedCalendarEventDAO(db);
+
+      const count = await dao.pruneOldEvents(mockNow - 86_400 * 7, 100);
+      expect(count).toBe(4);
+    });
+
+    it('returns 0 when nothing pruned', async () => {
+      const runFn = vi.fn().mockResolvedValue({ success: true, meta: { changes: 0 } });
+      db = {
+        prepare: vi.fn(() => ({
+          bind: vi.fn(() => ({ run: runFn })),
+        })),
+      };
+      dao = new SyncedCalendarEventDAO(db);
+
+      const count = await dao.pruneOldEvents(mockNow - 86_400 * 7, 100);
+      expect(count).toBe(0);
+    });
+  });
+});

--- a/test/services/ActionStatusSyncUtil.test.ts
+++ b/test/services/ActionStatusSyncUtil.test.ts
@@ -1,0 +1,254 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const {
+  mockListPendingActionsByTypes,
+  mockUpdateSyncStatus,
+  mockFetchFlightStatus,
+} = vi.hoisted(() => ({
+  mockListPendingActionsByTypes: vi.fn().mockResolvedValue([]),
+  mockUpdateSyncStatus: vi.fn().mockResolvedValue(undefined),
+  mockFetchFlightStatus: vi.fn(),
+}));
+
+vi.mock('@mail-otter/backend-data/dao', () => ({
+  EmailActionDAO: vi.fn(function () {
+    return {
+      listPendingActionsByTypes: mockListPendingActionsByTypes,
+      updateSyncStatus: mockUpdateSyncStatus,
+    };
+  }),
+}));
+
+vi.mock('../../packages/backend-services/src/action/FlightTrackingService', () => ({
+  fetchFlightStatus: mockFetchFlightStatus,
+}));
+
+import { ActionStatusSyncUtil } from '../../packages/backend-services/src/digest/ActionStatusSyncUtil';
+
+function makePackageAction(overrides?: Record<string, unknown>) {
+  return {
+    actionId: 'action-pkg-1',
+    actionType: 'delivery.track_package',
+    title: 'Track Package',
+    description: 'Your package is shipping',
+    status: 'pending',
+    payload: {
+      trackingNumber: 'TRK123456',
+      carrier: 'UPS',
+    },
+    syncStatus: null,
+    ...overrides,
+  };
+}
+
+function makeFlightAction(overrides?: Record<string, unknown>) {
+  return {
+    actionId: 'action-flt-1',
+    actionType: 'travel.track_flight',
+    title: 'Track Flight',
+    description: 'Your flight is AA100',
+    status: 'pending',
+    payload: {
+      flightNumber: 'AA100',
+    },
+    syncStatus: null,
+    ...overrides,
+  };
+}
+
+function makeAftershipResponse(trackings: Array<Record<string, unknown>>) {
+  return JSON.stringify({ data: { trackings } });
+}
+
+describe('ActionStatusSyncUtil', () => {
+  let util: ActionStatusSyncUtil;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    util = new ActionStatusSyncUtil({} as D1Database, 'action-key');
+  });
+
+  describe('syncPackageActions', () => {
+    it('does nothing when no pending package actions', async () => {
+      mockListPendingActionsByTypes.mockResolvedValue([]);
+
+      await util.syncPackageActions('app-1', 'api-key');
+
+      expect(mockUpdateSyncStatus).not.toHaveBeenCalled();
+    });
+
+    it('fetches tracking and updates sync status on success', async () => {
+      mockListPendingActionsByTypes.mockResolvedValue([makePackageAction()]);
+      global.fetch = vi.fn().mockResolvedValue({
+        ok: true,
+        text: vi.fn().mockResolvedValue(
+          makeAftershipResponse([
+            {
+              tag: 'InTransit',
+              expected_delivery: '2026-06-28',
+              checkpoints: [{ city: 'Los Angeles', state: 'CA', message: 'Arrived at hub' }],
+            },
+          ]),
+        ),
+      });
+
+      await util.syncPackageActions('app-1', 'api-key');
+
+      expect(mockUpdateSyncStatus).toHaveBeenCalledOnce();
+      const [actionId, syncStatusJson] = mockUpdateSyncStatus.mock.calls[0];
+      expect(actionId).toBe('action-pkg-1');
+      const syncStatus = JSON.parse(syncStatusJson as string);
+      expect(syncStatus.status).toBe('InTransit');
+      expect(syncStatus.location).toBe('Los Angeles, CA');
+      expect(syncStatus.lastUpdate).toBe('Arrived at hub');
+      expect(syncStatus.carrier).toBe('UPS');
+      expect(syncStatus.trackingNumber).toBe('TRK123456');
+    });
+
+    it('skips update when Aftership returns no trackings', async () => {
+      mockListPendingActionsByTypes.mockResolvedValue([makePackageAction()]);
+      global.fetch = vi.fn().mockResolvedValue({
+        ok: true,
+        text: vi.fn().mockResolvedValue(makeAftershipResponse([])),
+      });
+
+      await util.syncPackageActions('app-1', 'api-key');
+
+      expect(mockUpdateSyncStatus).not.toHaveBeenCalled();
+    });
+
+    it('skips update when API returns non-OK status', async () => {
+      mockListPendingActionsByTypes.mockResolvedValue([makePackageAction()]);
+      global.fetch = vi.fn().mockResolvedValue({ ok: false, status: 403 });
+
+      await util.syncPackageActions('app-1', 'api-key');
+
+      expect(mockUpdateSyncStatus).not.toHaveBeenCalled();
+    });
+
+    it('skips action when tracking number is missing', async () => {
+      mockListPendingActionsByTypes.mockResolvedValue([
+        makePackageAction({ payload: { carrier: 'FedEx' } }),
+      ]);
+
+      await util.syncPackageActions('app-1', 'api-key');
+
+      expect(global.fetch).not.toHaveBeenCalled();
+      expect(mockUpdateSyncStatus).not.toHaveBeenCalled();
+    });
+
+    it('continues processing remaining actions when one fetch throws', async () => {
+      mockListPendingActionsByTypes.mockResolvedValue([
+        makePackageAction({ actionId: 'action-fail', payload: { trackingNumber: 'BAD1' } }),
+        makePackageAction({ actionId: 'action-ok', payload: { trackingNumber: 'GOOD2' } }),
+      ]);
+      global.fetch = vi.fn()
+        .mockRejectedValueOnce(new Error('Network error'))
+        .mockResolvedValueOnce({
+          ok: true,
+          text: vi.fn().mockResolvedValue(
+            makeAftershipResponse([{ tag: 'Delivered', checkpoints: [] }]),
+          ),
+        });
+
+      await util.syncPackageActions('app-1', 'api-key');
+
+      expect(mockUpdateSyncStatus).toHaveBeenCalledOnce();
+      expect(mockUpdateSyncStatus.mock.calls[0][0]).toBe('action-ok');
+    });
+
+    it('handles checkpoint with no city/state gracefully', async () => {
+      mockListPendingActionsByTypes.mockResolvedValue([makePackageAction()]);
+      global.fetch = vi.fn().mockResolvedValue({
+        ok: true,
+        text: vi.fn().mockResolvedValue(
+          makeAftershipResponse([
+            {
+              tag: 'Delivered',
+              checkpoints: [{ message: 'Package delivered' }],
+            },
+          ]),
+        ),
+      });
+
+      await util.syncPackageActions('app-1', 'api-key');
+
+      const syncStatus = JSON.parse(mockUpdateSyncStatus.mock.calls[0][1] as string);
+      expect(syncStatus.location).toBeUndefined();
+    });
+
+    it('handles expected_delivery absent gracefully', async () => {
+      mockListPendingActionsByTypes.mockResolvedValue([makePackageAction()]);
+      global.fetch = vi.fn().mockResolvedValue({
+        ok: true,
+        text: vi.fn().mockResolvedValue(
+          makeAftershipResponse([
+            { tag: 'Pending', checkpoints: [] },
+          ]),
+        ),
+      });
+
+      await util.syncPackageActions('app-1', 'api-key');
+
+      const syncStatus = JSON.parse(mockUpdateSyncStatus.mock.calls[0][1] as string);
+      expect(syncStatus.expectedDelivery).toBeUndefined();
+    });
+  });
+
+  describe('syncFlightActions', () => {
+    it('does nothing when no pending flight actions', async () => {
+      mockListPendingActionsByTypes.mockResolvedValue([]);
+
+      await util.syncFlightActions('app-1', 'api-key');
+
+      expect(mockFetchFlightStatus).not.toHaveBeenCalled();
+    });
+
+    it('updates sync status when flight status fetched', async () => {
+      mockListPendingActionsByTypes.mockResolvedValue([makeFlightAction()]);
+      const flightStatus = { status: 'On Time', departureDelay: 0, arrivalDelay: 0 };
+      mockFetchFlightStatus.mockResolvedValue(flightStatus);
+
+      await util.syncFlightActions('app-1', 'api-key');
+
+      expect(mockFetchFlightStatus).toHaveBeenCalledWith('AA100', 'api-key');
+      expect(mockUpdateSyncStatus).toHaveBeenCalledOnce();
+      const syncJson = JSON.parse(mockUpdateSyncStatus.mock.calls[0][1] as string);
+      expect(syncJson.status).toBe('On Time');
+    });
+
+    it('skips update when flight status returns null', async () => {
+      mockListPendingActionsByTypes.mockResolvedValue([makeFlightAction()]);
+      mockFetchFlightStatus.mockResolvedValue(null);
+
+      await util.syncFlightActions('app-1', 'api-key');
+
+      expect(mockUpdateSyncStatus).not.toHaveBeenCalled();
+    });
+
+    it('skips action when flight number is missing', async () => {
+      mockListPendingActionsByTypes.mockResolvedValue([
+        makeFlightAction({ payload: {} }),
+      ]);
+
+      await util.syncFlightActions('app-1', 'api-key');
+
+      expect(mockFetchFlightStatus).not.toHaveBeenCalled();
+    });
+
+    it('continues processing remaining actions when one throws', async () => {
+      mockListPendingActionsByTypes.mockResolvedValue([
+        makeFlightAction({ actionId: 'flt-1', payload: { flightNumber: 'BAD1' } }),
+        makeFlightAction({ actionId: 'flt-2', payload: { flightNumber: 'GOOD2' } }),
+      ]);
+      mockFetchFlightStatus
+        .mockRejectedValueOnce(new Error('API error'))
+        .mockResolvedValueOnce({ status: 'Delayed', departureDelay: 30 });
+
+      await util.syncFlightActions('app-1', 'api-key');
+
+      expect(mockUpdateSyncStatus).toHaveBeenCalledOnce();
+      expect(mockUpdateSyncStatus.mock.calls[0][0]).toBe('flt-2');
+    });
+  });
+});

--- a/test/services/CalendarEventSyncUtil.test.ts
+++ b/test/services/CalendarEventSyncUtil.test.ts
@@ -1,0 +1,233 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const {
+  mockListCalendarEventsGmail,
+  mockListCalendarEventsOutlook,
+  mockUpsertEvents,
+} = vi.hoisted(() => ({
+  mockListCalendarEventsGmail: vi.fn(),
+  mockListCalendarEventsOutlook: vi.fn(),
+  mockUpsertEvents: vi.fn().mockResolvedValue(undefined),
+}));
+
+vi.mock('@mail-otter/provider-clients/gmail', () => ({
+  GmailProviderUtil: {
+    listCalendarEventsByDateRange: mockListCalendarEventsGmail,
+  },
+}));
+
+vi.mock('@mail-otter/provider-clients/outlook', () => ({
+  OutlookProviderUtil: {
+    listCalendarEventsByDateRange: mockListCalendarEventsOutlook,
+  },
+}));
+
+vi.mock('@mail-otter/backend-data/dao', () => ({
+  SyncedCalendarEventDAO: vi.fn(function () {
+    return { upsertEvents: mockUpsertEvents };
+  }),
+}));
+
+import { CalendarEventSyncUtil } from '../../packages/backend-services/src/digest/CalendarEventSyncUtil';
+
+const NOW_ISO = '2026-06-26T00:00:00.000Z';
+const END_ISO = '2026-06-28T00:00:00.000Z';
+
+function makeGmailApplication() {
+  return {
+    applicationId: 'app-1',
+    providerId: 'google-gmail',
+    userEmail: 'user@gmail.com',
+    providerEmail: 'user@gmail.com',
+    timeZone: 'UTC',
+  };
+}
+
+function makeOutlookApplication() {
+  return {
+    applicationId: 'app-1',
+    providerId: 'microsoft-outlook',
+    userEmail: 'user@outlook.com',
+    providerEmail: 'user@outlook.com',
+    timeZone: 'UTC',
+  };
+}
+
+function makeGmailEvent(overrides?: Record<string, unknown>) {
+  return {
+    id: 'gmail-evt-1',
+    summary: 'Team Standup',
+    start: { dateTime: '2026-06-26T09:00:00Z', timeZone: 'UTC' },
+    end: { dateTime: '2026-06-26T09:30:00Z', timeZone: 'UTC' },
+    location: 'Zoom',
+    description: 'Daily sync call',
+    ...overrides,
+  };
+}
+
+function makeOutlookEvent(overrides?: Record<string, unknown>) {
+  return {
+    id: 'outlook-evt-1',
+    subject: 'Planning Session',
+    start: { dateTime: '2026-06-26T10:00:00', timeZone: 'UTC' },
+    end: { dateTime: '2026-06-26T11:00:00', timeZone: 'UTC' },
+    location: { displayName: 'Conference Room A' },
+    ...overrides,
+  };
+}
+
+describe('CalendarEventSyncUtil', () => {
+  let util: CalendarEventSyncUtil;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    util = new CalendarEventSyncUtil({} as D1Database);
+    mockListCalendarEventsGmail.mockResolvedValue([]);
+    mockListCalendarEventsOutlook.mockResolvedValue([]);
+  });
+
+  describe('syncForApplication — Gmail', () => {
+    it('does not upsert when no events returned', async () => {
+      mockListCalendarEventsGmail.mockResolvedValue([]);
+
+      await util.syncForApplication(makeGmailApplication() as any, 'access-token', NOW_ISO, END_ISO);
+
+      expect(mockUpsertEvents).not.toHaveBeenCalled();
+    });
+
+    it('upserts Gmail events', async () => {
+      mockListCalendarEventsGmail.mockResolvedValue([makeGmailEvent()]);
+
+      await util.syncForApplication(makeGmailApplication() as any, 'access-token', NOW_ISO, END_ISO);
+
+      expect(mockUpsertEvents).toHaveBeenCalledOnce();
+      const [appId, events] = mockUpsertEvents.mock.calls[0];
+      expect(appId).toBe('app-1');
+      expect(events).toHaveLength(1);
+      expect(events[0].providerEventId).toBe('gmail-evt-1');
+      expect(events[0].eventTitle).toBe('Team Standup');
+      expect(events[0].timeZone).toBe('UTC');
+      expect(events[0].location).toBe('Zoom');
+      expect(events[0].notes).toBe('Daily sync call');
+    });
+
+    it('filters out Gmail events without dateTime', async () => {
+      mockListCalendarEventsGmail.mockResolvedValue([
+        makeGmailEvent({ start: { date: '2026-06-26' } }),  // all-day event — no dateTime
+        makeGmailEvent({ id: 'evt-2', start: { dateTime: '2026-06-26T14:00:00Z' } }),
+      ]);
+
+      await util.syncForApplication(makeGmailApplication() as any, 'access-token', NOW_ISO, END_ISO);
+
+      const [, events] = mockUpsertEvents.mock.calls[0];
+      expect(events).toHaveLength(1);
+      expect(events[0].providerEventId).toBe('evt-2');
+    });
+
+    it('falls back to title "(no title)" for missing summary', async () => {
+      mockListCalendarEventsGmail.mockResolvedValue([makeGmailEvent({ summary: undefined })]);
+
+      await util.syncForApplication(makeGmailApplication() as any, 'access-token', NOW_ISO, END_ISO);
+
+      const [, events] = mockUpsertEvents.mock.calls[0];
+      expect(events[0].eventTitle).toBe('(no title)');
+    });
+
+    it('computes endTime as startTime + 3600 when end.dateTime is absent', async () => {
+      const evt = makeGmailEvent({ end: undefined });
+      mockListCalendarEventsGmail.mockResolvedValue([evt]);
+
+      await util.syncForApplication(makeGmailApplication() as any, 'access-token', NOW_ISO, END_ISO);
+
+      const [, events] = mockUpsertEvents.mock.calls[0];
+      const expectedEnd = events[0].startTime + 3600;
+      expect(events[0].endTime).toBe(expectedEnd);
+    });
+
+    it('sets location and notes to null when absent', async () => {
+      mockListCalendarEventsGmail.mockResolvedValue([
+        makeGmailEvent({ location: undefined, description: undefined }),
+      ]);
+
+      await util.syncForApplication(makeGmailApplication() as any, 'access-token', NOW_ISO, END_ISO);
+
+      const [, events] = mockUpsertEvents.mock.calls[0];
+      expect(events[0].location).toBeNull();
+      expect(events[0].notes).toBeNull();
+    });
+  });
+
+  describe('syncForApplication — Outlook', () => {
+    it('does not upsert when no events returned', async () => {
+      mockListCalendarEventsOutlook.mockResolvedValue([]);
+
+      await util.syncForApplication(makeOutlookApplication() as any, 'access-token', NOW_ISO, END_ISO);
+
+      expect(mockUpsertEvents).not.toHaveBeenCalled();
+    });
+
+    it('upserts Outlook events', async () => {
+      mockListCalendarEventsOutlook.mockResolvedValue([makeOutlookEvent()]);
+
+      await util.syncForApplication(makeOutlookApplication() as any, 'access-token', NOW_ISO, END_ISO);
+
+      expect(mockUpsertEvents).toHaveBeenCalledOnce();
+      const [appId, events] = mockUpsertEvents.mock.calls[0];
+      expect(appId).toBe('app-1');
+      expect(events[0].eventTitle).toBe('Planning Session');
+      expect(events[0].location).toBe('Conference Room A');
+      expect(events[0].notes).toBeNull();
+    });
+
+    it('filters out Outlook events without dateTime', async () => {
+      mockListCalendarEventsOutlook.mockResolvedValue([
+        makeOutlookEvent({ start: { date: '2026-06-26' } }),
+        makeOutlookEvent({ id: 'evt-2', subject: 'Late Meeting', start: { dateTime: '2026-06-26T15:00:00' } }),
+      ]);
+
+      await util.syncForApplication(makeOutlookApplication() as any, 'access-token', NOW_ISO, END_ISO);
+
+      const [, events] = mockUpsertEvents.mock.calls[0];
+      expect(events).toHaveLength(1);
+      expect(events[0].eventTitle).toBe('Late Meeting');
+    });
+
+    it('falls back to "(no title)" when subject is absent', async () => {
+      mockListCalendarEventsOutlook.mockResolvedValue([makeOutlookEvent({ subject: undefined })]);
+
+      await util.syncForApplication(makeOutlookApplication() as any, 'access-token', NOW_ISO, END_ISO);
+
+      const [, events] = mockUpsertEvents.mock.calls[0];
+      expect(events[0].eventTitle).toBe('(no title)');
+    });
+
+    it('sets location to null when displayName absent', async () => {
+      mockListCalendarEventsOutlook.mockResolvedValue([
+        makeOutlookEvent({ location: {} }),
+      ]);
+
+      await util.syncForApplication(makeOutlookApplication() as any, 'access-token', NOW_ISO, END_ISO);
+
+      const [, events] = mockUpsertEvents.mock.calls[0];
+      expect(events[0].location).toBeNull();
+    });
+  });
+
+  describe('syncForApplication — unsupported provider', () => {
+    it('returns without fetching or upserting for Fastmail', async () => {
+      const fastmailApp = {
+        applicationId: 'app-2',
+        providerId: 'fastmail-jmap',
+        userEmail: 'user@fastmail.com',
+        providerEmail: 'user@fastmail.com',
+        timeZone: 'UTC',
+      };
+
+      await util.syncForApplication(fastmailApp as any, 'access-token', NOW_ISO, END_ISO);
+
+      expect(mockListCalendarEventsGmail).not.toHaveBeenCalled();
+      expect(mockListCalendarEventsOutlook).not.toHaveBeenCalled();
+      expect(mockUpsertEvents).not.toHaveBeenCalled();
+    });
+  });
+});

--- a/test/services/DigestConfigService.test.ts
+++ b/test/services/DigestConfigService.test.ts
@@ -1,0 +1,211 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const {
+  mockGetProviderConfig,
+  mockSetProviderConfig,
+} = vi.hoisted(() => ({
+  mockGetProviderConfig: vi.fn(),
+  mockSetProviderConfig: vi.fn().mockResolvedValue(undefined),
+}));
+
+vi.mock('@mail-otter/backend-data/dao', () => ({
+  ConnectedApplicationDAO: vi.fn(function () {
+    return {
+      getProviderConfig: mockGetProviderConfig,
+      setProviderConfig: mockSetProviderConfig,
+    };
+  }),
+}));
+
+import { DigestConfigService, createDigestConfigService } from '../../packages/backend-services/src/digest/DigestConfigService';
+import { DIGEST_ALL_SECTIONS } from '@mail-otter/shared/constants';
+
+const APP_ID = 'app-1';
+
+describe('DigestConfigService', () => {
+  let service: DigestConfigService;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    service = createDigestConfigService({ db: {} as D1Database, masterKey: 'mk' });
+  });
+
+  describe('getConfig', () => {
+    it('returns defaults when no config rows exist', async () => {
+      mockGetProviderConfig.mockResolvedValue(null);
+
+      const config = await service.getConfig(APP_ID);
+
+      expect(config.enabled).toBe(false);
+      expect(config.sendTime).toBe('08:00');
+      expect(config.sections).toEqual(DIGEST_ALL_SECTIONS);
+      expect(config.lastSentAt).toBeNull();
+    });
+
+    it('returns stored enabled:true', async () => {
+      mockGetProviderConfig
+        .mockResolvedValueOnce('true')   // enabled
+        .mockResolvedValueOnce('09:30')  // sendTime
+        .mockResolvedValueOnce(JSON.stringify(['calendar', 'tasks']))  // sections
+        .mockResolvedValueOnce('2026-06-25T09:30:00.000Z');  // lastSentAt
+
+      const config = await service.getConfig(APP_ID);
+
+      expect(config.enabled).toBe(true);
+      expect(config.sendTime).toBe('09:30');
+      expect(config.sections).toEqual(['calendar', 'tasks']);
+      expect(config.lastSentAt).toBe('2026-06-25T09:30:00.000Z');
+    });
+
+    it('returns enabled:false for non-"true" value', async () => {
+      mockGetProviderConfig.mockResolvedValueOnce('false').mockResolvedValue(null);
+
+      const config = await service.getConfig(APP_ID);
+      expect(config.enabled).toBe(false);
+    });
+  });
+
+  describe('saveConfig', () => {
+    it('saves enabled, sendTime, and sections', async () => {
+      mockGetProviderConfig.mockResolvedValue(null);
+
+      await service.saveConfig(APP_ID, { enabled: true, sendTime: '07:00', sections: ['calendar', 'tasks'] });
+
+      expect(mockSetProviderConfig).toHaveBeenCalledWith(APP_ID, 'digest_enabled', 'true');
+      expect(mockSetProviderConfig).toHaveBeenCalledWith(APP_ID, 'digest_send_time', '07:00');
+      expect(mockSetProviderConfig).toHaveBeenCalledWith(APP_ID, 'digest_sections', JSON.stringify(['calendar', 'tasks']));
+    });
+
+    it('normalizes invalid sendTime to 08:00', async () => {
+      mockGetProviderConfig.mockResolvedValue(null);
+
+      await service.saveConfig(APP_ID, { enabled: false, sendTime: 'not-a-time', sections: [] });
+
+      expect(mockSetProviderConfig).toHaveBeenCalledWith(APP_ID, 'digest_send_time', '08:00');
+    });
+
+    it('normalizes sendTime with out-of-range hour', async () => {
+      mockGetProviderConfig.mockResolvedValue(null);
+
+      await service.saveConfig(APP_ID, { enabled: false, sendTime: '25:00', sections: [] });
+
+      expect(mockSetProviderConfig).toHaveBeenCalledWith(APP_ID, 'digest_send_time', '08:00');
+    });
+
+    it('normalizes sendTime with out-of-range minute', async () => {
+      mockGetProviderConfig.mockResolvedValue(null);
+
+      await service.saveConfig(APP_ID, { enabled: false, sendTime: '08:99', sections: [] });
+
+      expect(mockSetProviderConfig).toHaveBeenCalledWith(APP_ID, 'digest_send_time', '08:00');
+    });
+
+    it('pads single-digit hours and minutes', async () => {
+      mockGetProviderConfig.mockResolvedValue(null);
+
+      await service.saveConfig(APP_ID, { enabled: false, sendTime: '09:05', sections: [] });
+
+      expect(mockSetProviderConfig).toHaveBeenCalledWith(APP_ID, 'digest_send_time', '09:05');
+    });
+
+    it('filters out invalid sections', async () => {
+      mockGetProviderConfig.mockResolvedValue(null);
+
+      await service.saveConfig(APP_ID, { enabled: false, sendTime: '08:00', sections: ['calendar', 'invalid_section', 'tasks'] });
+
+      const sectionsCall = mockSetProviderConfig.mock.calls.find((c) => c[1] === 'digest_sections');
+      expect(sectionsCall).toBeDefined();
+      const saved = JSON.parse(sectionsCall![2] as string) as string[];
+      expect(saved).toContain('calendar');
+      expect(saved).toContain('tasks');
+      expect(saved).not.toContain('invalid_section');
+    });
+  });
+
+  describe('markSent', () => {
+    it('sets last_sent_at to current ISO timestamp', async () => {
+      const before = Date.now();
+      await service.markSent(APP_ID);
+      const after = Date.now();
+
+      expect(mockSetProviderConfig).toHaveBeenCalledOnce();
+      const [, key, value] = mockSetProviderConfig.mock.calls[0] as [string, string, string];
+      expect(key).toBe('digest_last_sent_at');
+      const ts = new Date(value).getTime();
+      expect(ts).toBeGreaterThanOrEqual(before);
+      expect(ts).toBeLessThanOrEqual(after);
+    });
+  });
+
+  describe('isDueToSend', () => {
+    it('returns false when digest is disabled', async () => {
+      mockGetProviderConfig.mockResolvedValue(null);
+
+      const result = await service.isDueToSend(APP_ID, 'UTC');
+      expect(result).toBe(false);
+    });
+
+    it('returns true when in the send window and not yet sent today', async () => {
+      const now = new Date();
+      const hh = String(now.getUTCHours()).padStart(2, '0');
+      const mm = String(now.getUTCMinutes()).padStart(2, '0');
+      const sendTime = `${hh}:${mm}`;
+
+      mockGetProviderConfig
+        .mockResolvedValueOnce('true')
+        .mockResolvedValueOnce(sendTime)
+        .mockResolvedValueOnce(null)
+        .mockResolvedValueOnce(null);
+
+      const result = await service.isDueToSend(APP_ID, 'UTC');
+      expect(result).toBe(true);
+    });
+
+    it('returns false when not in the send window', async () => {
+      mockGetProviderConfig
+        .mockResolvedValueOnce('true')
+        .mockResolvedValueOnce('03:00')
+        .mockResolvedValueOnce(null)
+        .mockResolvedValueOnce(null);
+
+      const result = await service.isDueToSend(APP_ID, 'UTC');
+      expect(result).toBe(false);
+    });
+
+    it('returns false when already sent today', async () => {
+      const now = new Date();
+      const hh = String(now.getUTCHours()).padStart(2, '0');
+      const mm = String(now.getUTCMinutes()).padStart(2, '0');
+      const sendTime = `${hh}:${mm}`;
+      const todayIso = now.toISOString();
+
+      mockGetProviderConfig
+        .mockResolvedValueOnce('true')
+        .mockResolvedValueOnce(sendTime)
+        .mockResolvedValueOnce(null)
+        .mockResolvedValueOnce(todayIso);
+
+      const result = await service.isDueToSend(APP_ID, 'UTC');
+      expect(result).toBe(false);
+    });
+
+    it('returns true when sent yesterday (different calendar day)', async () => {
+      const now = new Date();
+      const hh = String(now.getUTCHours()).padStart(2, '0');
+      const mm = String(now.getUTCMinutes()).padStart(2, '0');
+      const sendTime = `${hh}:${mm}`;
+
+      const yesterday = new Date(now.getTime() - 86_400_000);
+      const yesterdayIso = yesterday.toISOString();
+
+      mockGetProviderConfig
+        .mockResolvedValueOnce('true')
+        .mockResolvedValueOnce(sendTime)
+        .mockResolvedValueOnce(null)
+        .mockResolvedValueOnce(yesterdayIso);
+
+      const result = await service.isDueToSend(APP_ID, 'UTC');
+      expect(result).toBe(true);
+    });
+  });
+});

--- a/test/services/DigestEmailUtil.test.ts
+++ b/test/services/DigestEmailUtil.test.ts
@@ -1,0 +1,289 @@
+import { describe, expect, it } from 'vitest';
+import { DigestEmailUtil } from '../../packages/backend-services/src/digest/DigestEmailUtil';
+import {
+  DIGEST_SECTION_APPOINTMENTS,
+  DIGEST_SECTION_BILLS,
+  DIGEST_SECTION_CALENDAR,
+  DIGEST_SECTION_FLIGHTS,
+  DIGEST_SECTION_PACKAGES,
+  DIGEST_SECTION_TASKS,
+  DIGEST_ALL_SECTIONS,
+} from '@mail-otter/shared/constants';
+
+function makeSections() {
+  return {
+    calendarEvents: [],
+    tasks: [],
+    packages: [],
+    flights: [],
+    bills: [],
+    appointments: [],
+  };
+}
+
+function makeCalendarEvent(overrides?: Record<string, unknown>) {
+  return {
+    syncEventId: 'sync-1',
+    applicationId: 'app-1',
+    providerEventId: 'evt-1',
+    eventTitle: 'Team Meeting',
+    startTime: 1_778_200_000,
+    endTime: 1_778_203_600,
+    timeZone: 'UTC',
+    location: 'Zoom',
+    notes: null,
+    syncedAt: 1_778_200_000,
+    ...overrides,
+  };
+}
+
+function makeAction(actionType: string, payload: Record<string, unknown>) {
+  return {
+    actionId: 'action-1',
+    processedMessageId: 'pm-1',
+    applicationId: 'app-1',
+    actionType,
+    title: `${actionType} Title`,
+    description: `${actionType} description`,
+    status: 'pending',
+    riskLevel: 'low',
+    payload,
+    syncStatus: null,
+    createdAt: 1_778_200_000,
+    updatedAt: 1_778_200_000,
+    expiresAt: null,
+    executedAt: null,
+  };
+}
+
+describe('DigestEmailUtil', () => {
+  describe('buildSubject', () => {
+    it('includes the date formatted in the given timezone', () => {
+      const date = new Date('2026-06-26T10:00:00Z');
+      const subject = DigestEmailUtil.buildSubject(date, 'UTC');
+      expect(subject).toContain('Mail-Otter Daily Digest');
+      expect(subject).toContain('2026');
+      expect(subject).toContain('June');
+    });
+
+    it('formats date in specified timezone', () => {
+      const date = new Date('2026-06-26T10:00:00Z');
+      const utcSubject = DigestEmailUtil.buildSubject(date, 'UTC');
+      expect(utcSubject).toContain('Friday');
+    });
+
+    it('falls back to UTC for empty timezone', () => {
+      const date = new Date('2026-06-26T00:00:00Z');
+      const subject = DigestEmailUtil.buildSubject(date, '');
+      expect(subject).toContain('Mail-Otter Daily Digest');
+    });
+  });
+
+  describe('hasContent', () => {
+    it('returns false when all sections are empty', () => {
+      expect(DigestEmailUtil.hasContent(makeSections(), DIGEST_ALL_SECTIONS)).toBe(false);
+    });
+
+    it('returns true when calendar has events', () => {
+      const sections = { ...makeSections(), calendarEvents: [makeCalendarEvent()] };
+      expect(DigestEmailUtil.hasContent(sections, [DIGEST_SECTION_CALENDAR])).toBe(true);
+    });
+
+    it('returns true when tasks has items', () => {
+      const sections = {
+        ...makeSections(),
+        tasks: [makeAction('manual.todo', { instructions: 'Do something' })],
+      };
+      expect(DigestEmailUtil.hasContent(sections, [DIGEST_SECTION_TASKS])).toBe(true);
+    });
+
+    it('returns true when packages has items', () => {
+      const sections = {
+        ...makeSections(),
+        packages: [makeAction('delivery.track_package', { trackingNumber: 'ABC123' })],
+      };
+      expect(DigestEmailUtil.hasContent(sections, [DIGEST_SECTION_PACKAGES])).toBe(true);
+    });
+
+    it('returns true when flights has items', () => {
+      const sections = {
+        ...makeSections(),
+        flights: [makeAction('travel.track_flight', { flightNumber: 'AA100' })],
+      };
+      expect(DigestEmailUtil.hasContent(sections, [DIGEST_SECTION_FLIGHTS])).toBe(true);
+    });
+
+    it('returns true when bills has items', () => {
+      const sections = {
+        ...makeSections(),
+        bills: [makeAction('finance.pay_bill', { payee: 'Electric Co', amount: '150', currency: 'USD' })],
+      };
+      expect(DigestEmailUtil.hasContent(sections, [DIGEST_SECTION_BILLS])).toBe(true);
+    });
+
+    it('returns true when appointments has items', () => {
+      const sections = {
+        ...makeSections(),
+        appointments: [makeAction('appointment.confirm', { serviceType: 'Dentist' })],
+      };
+      expect(DigestEmailUtil.hasContent(sections, [DIGEST_SECTION_APPOINTMENTS])).toBe(true);
+    });
+
+    it('returns false when section has items but is not in enabledSections', () => {
+      const sections = { ...makeSections(), calendarEvents: [makeCalendarEvent()] };
+      expect(DigestEmailUtil.hasContent(sections, [DIGEST_SECTION_TASKS])).toBe(false);
+    });
+  });
+
+  describe('buildHtml', () => {
+    it('shows empty state message when no content', () => {
+      const html = DigestEmailUtil.buildHtml(makeSections(), DIGEST_ALL_SECTIONS);
+      expect(html).toContain('Nothing to report today');
+    });
+
+    it('includes calendar section when events present', () => {
+      const sections = { ...makeSections(), calendarEvents: [makeCalendarEvent()] };
+      const html = DigestEmailUtil.buildHtml(sections, [DIGEST_SECTION_CALENDAR]);
+      expect(html).toContain('Team Meeting');
+      expect(html).toContain("Today's Calendar Events");
+    });
+
+    it('includes location in calendar event', () => {
+      const sections = { ...makeSections(), calendarEvents: [makeCalendarEvent({ location: 'Conference Room B' })] };
+      const html = DigestEmailUtil.buildHtml(sections, [DIGEST_SECTION_CALENDAR]);
+      expect(html).toContain('Conference Room B');
+    });
+
+    it('renders calendar event without location when absent', () => {
+      const sections = { ...makeSections(), calendarEvents: [makeCalendarEvent({ location: null })] };
+      const html = DigestEmailUtil.buildHtml(sections, [DIGEST_SECTION_CALENDAR]);
+      expect(html).toContain('Team Meeting');
+    });
+
+    it('includes tasks section when tasks present', () => {
+      const sections = {
+        ...makeSections(),
+        tasks: [makeAction('manual.todo', { instructions: 'Renew passport' })],
+      };
+      const html = DigestEmailUtil.buildHtml(sections, [DIGEST_SECTION_TASKS]);
+      expect(html).toContain('Pending Tasks');
+      expect(html).toContain('Renew passport');
+    });
+
+    it('falls back to action description when task has no instructions', () => {
+      const task = makeAction('manual.todo', {});
+      const sections = { ...makeSections(), tasks: [task] };
+      const html = DigestEmailUtil.buildHtml(sections, [DIGEST_SECTION_TASKS]);
+      expect(html).toContain(task.description);
+    });
+
+    it('includes packages section with tracking info', () => {
+      const sections = {
+        ...makeSections(),
+        packages: [
+          makeAction('delivery.track_package', {
+            trackingNumber: 'TRK123456',
+            carrier: 'UPS',
+            trackingUrl: 'https://track.ups.com/abc',
+          }),
+        ],
+      };
+      const html = DigestEmailUtil.buildHtml(sections, [DIGEST_SECTION_PACKAGES]);
+      expect(html).toContain('Package Deliveries');
+      expect(html).toContain('TRK123456');
+      expect(html).toContain('UPS');
+    });
+
+    it('includes package sync status when present', () => {
+      const pkg = makeAction('delivery.track_package', { trackingNumber: 'TRK999' });
+      (pkg as any).syncStatus = JSON.stringify({ statusLabel: 'In Transit', location: 'Los Angeles, CA', expectedDelivery: 'Tomorrow' });
+      const sections = { ...makeSections(), packages: [pkg] };
+      const html = DigestEmailUtil.buildHtml(sections, [DIGEST_SECTION_PACKAGES]);
+      expect(html).toContain('In Transit');
+      expect(html).toContain('Los Angeles, CA');
+      expect(html).toContain('Tomorrow');
+    });
+
+    it('handles malformed package syncStatus without throwing', () => {
+      const pkg = makeAction('delivery.track_package', { trackingNumber: 'TRK999' });
+      (pkg as any).syncStatus = 'not-json';
+      const sections = { ...makeSections(), packages: [pkg] };
+      expect(() => DigestEmailUtil.buildHtml(sections, [DIGEST_SECTION_PACKAGES])).not.toThrow();
+    });
+
+    it('includes flights section', () => {
+      const sections = {
+        ...makeSections(),
+        flights: [
+          makeAction('travel.track_flight', {
+            flightNumber: 'AA100',
+            departureAirport: 'JFK',
+            arrivalAirport: 'LAX',
+            trackingUrl: 'https://flightaware.com/AA100',
+          }),
+        ],
+      };
+      const html = DigestEmailUtil.buildHtml(sections, [DIGEST_SECTION_FLIGHTS]);
+      expect(html).toContain('Upcoming Flights');
+      expect(html).toContain('AA100');
+      expect(html).toContain('JFK → LAX');
+    });
+
+    it('includes flight sync status when present', () => {
+      const flight = makeAction('travel.track_flight', { flightNumber: 'UA200' });
+      (flight as any).syncStatus = JSON.stringify({ status: 'On Time', departureDelay: 0 });
+      const sections = { ...makeSections(), flights: [flight] };
+      const html = DigestEmailUtil.buildHtml(sections, [DIGEST_SECTION_FLIGHTS]);
+      expect(html).toContain('On Time');
+    });
+
+    it('includes bills section with amount and due date', () => {
+      const sections = {
+        ...makeSections(),
+        bills: [
+          makeAction('finance.pay_bill', {
+            payee: 'Electricity Co',
+            amount: '120.50',
+            currency: 'USD',
+            dueDate: '2026-07-01',
+            paymentUrl: 'https://pay.example.com',
+          }),
+        ],
+      };
+      const html = DigestEmailUtil.buildHtml(sections, [DIGEST_SECTION_BILLS]);
+      expect(html).toContain('Bills Due Soon');
+      expect(html).toContain('Electricity Co');
+      expect(html).toContain('120.50');
+      expect(html).toContain('2026-07-01');
+    });
+
+    it('includes appointments section with time and location', () => {
+      const sections = {
+        ...makeSections(),
+        appointments: [
+          makeAction('appointment.confirm', {
+            serviceType: 'Dentist',
+            appointmentTime: '2026-07-01T10:00:00',
+            location: '123 Main St',
+          }),
+        ],
+      };
+      const html = DigestEmailUtil.buildHtml(sections, [DIGEST_SECTION_APPOINTMENTS]);
+      expect(html).toContain('Upcoming Appointments');
+      expect(html).toContain('Dentist');
+      expect(html).toContain('2026-07-01T10:00:00');
+      expect(html).toContain('123 Main St');
+    });
+
+    it('skips section when disabled in enabledSections', () => {
+      const sections = { ...makeSections(), calendarEvents: [makeCalendarEvent()] };
+      const html = DigestEmailUtil.buildHtml(sections, [DIGEST_SECTION_TASKS]);
+      expect(html).not.toContain("Today's Calendar Events");
+    });
+
+    it('wraps output in mail-otter attribution footer', () => {
+      const html = DigestEmailUtil.buildHtml(makeSections(), []);
+      expect(html).toContain('Mail-Otter');
+    });
+  });
+});

--- a/test/services/DigestService.test.ts
+++ b/test/services/DigestService.test.ts
@@ -1,0 +1,231 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const {
+  mockGetConfig,
+  mockMarkSent,
+  mockListEventsForRange,
+  mockListPendingActionsByTypes,
+  mockSendStandaloneEmailGmail,
+  mockSendStandaloneEmailOutlook,
+} = vi.hoisted(() => ({
+  mockGetConfig: vi.fn(),
+  mockMarkSent: vi.fn().mockResolvedValue(undefined),
+  mockListEventsForRange: vi.fn().mockResolvedValue([]),
+  mockListPendingActionsByTypes: vi.fn().mockResolvedValue([]),
+  mockSendStandaloneEmailGmail: vi.fn().mockResolvedValue(undefined),
+  mockSendStandaloneEmailOutlook: vi.fn().mockResolvedValue(undefined),
+}));
+
+vi.mock('../../packages/backend-services/src/digest/DigestConfigService', () => ({
+  DigestConfigService: vi.fn(function () {
+    return { getConfig: mockGetConfig, markSent: mockMarkSent };
+  }),
+}));
+
+vi.mock('@mail-otter/backend-data/dao', () => ({
+  ConnectedApplicationDAO: vi.fn(function () {
+    return {};
+  }),
+  EmailActionDAO: vi.fn(function () {
+    return { listPendingActionsByTypes: mockListPendingActionsByTypes };
+  }),
+  SyncedCalendarEventDAO: vi.fn(function () {
+    return { listEventsForRange: mockListEventsForRange };
+  }),
+}));
+
+vi.mock('@mail-otter/provider-clients/gmail', () => ({
+  GmailProviderUtil: {
+    sendStandaloneEmail: mockSendStandaloneEmailGmail,
+  },
+}));
+
+vi.mock('@mail-otter/provider-clients/outlook', () => ({
+  OutlookProviderUtil: {
+    sendStandaloneEmail: mockSendStandaloneEmailOutlook,
+  },
+}));
+
+import { DigestService } from '../../packages/backend-services/src/digest/DigestService';
+import { DIGEST_ALL_SECTIONS } from '@mail-otter/shared/constants';
+
+function makeEnv() {
+  return {
+    DB: {} as D1Database,
+    AES_ENCRYPTION_KEY_SECRET: { get: vi.fn().mockResolvedValue('mk') } as unknown as SecretsStoreSecret,
+    ACTION_ENCRYPTION_KEY_SECRET: { get: vi.fn().mockResolvedValue('ak') } as unknown as SecretsStoreSecret,
+    OAUTH2_TOKEN_CACHE: {} as KVNamespace,
+    OAUTH2_TOKEN_REFRESHERS: {} as DurableObjectNamespace,
+  };
+}
+
+function makeApplication(providerId: string = 'google-gmail', overrides?: Record<string, unknown>) {
+  return {
+    applicationId: 'app-1',
+    userEmail: 'user@example.com',
+    providerId,
+    providerEmail: 'user@gmail.com',
+    timeZone: 'UTC',
+    ...overrides,
+  };
+}
+
+function makeCalendarEvent(overrides?: Record<string, unknown>) {
+  return {
+    syncEventId: 'sync-1',
+    applicationId: 'app-1',
+    providerEventId: 'evt-1',
+    eventTitle: 'Standup',
+    startTime: Math.floor(Date.now() / 1000) + 3600,
+    endTime: Math.floor(Date.now() / 1000) + 7200,
+    timeZone: 'UTC',
+    location: null,
+    notes: null,
+    syncedAt: Math.floor(Date.now() / 1000),
+    ...overrides,
+  };
+}
+
+function makeEnabledConfig() {
+  return {
+    enabled: true,
+    sendTime: '08:00',
+    sections: DIGEST_ALL_SECTIONS,
+    lastSentAt: null,
+  };
+}
+
+describe('DigestService', () => {
+  let service: DigestService;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    service = new DigestService(makeEnv() as any, 'master-key', 'action-key');
+    mockListPendingActionsByTypes.mockResolvedValue([]);
+    mockListEventsForRange.mockResolvedValue([]);
+  });
+
+  describe('sendDigest', () => {
+    it('returns without sending when digest is disabled', async () => {
+      mockGetConfig.mockResolvedValue({ enabled: false, sendTime: '08:00', sections: DIGEST_ALL_SECTIONS, lastSentAt: null });
+
+      await service.sendDigest(makeApplication() as any, 'access-token');
+
+      expect(mockSendStandaloneEmailGmail).not.toHaveBeenCalled();
+      expect(mockMarkSent).not.toHaveBeenCalled();
+    });
+
+    it('marks sent and returns without sending when no content', async () => {
+      mockGetConfig.mockResolvedValue(makeEnabledConfig());
+      // All sections return empty
+
+      await service.sendDigest(makeApplication() as any, 'access-token');
+
+      expect(mockMarkSent).toHaveBeenCalled();
+      expect(mockSendStandaloneEmailGmail).not.toHaveBeenCalled();
+    });
+
+    it('sends gmail email when content is available', async () => {
+      mockGetConfig.mockResolvedValue(makeEnabledConfig());
+      mockListEventsForRange.mockResolvedValue([makeCalendarEvent()]);
+
+      await service.sendDigest(makeApplication('google-gmail') as any, 'access-token');
+
+      expect(mockSendStandaloneEmailGmail).toHaveBeenCalled();
+      expect(mockMarkSent).toHaveBeenCalled();
+    });
+
+    it('sends outlook email for outlook provider', async () => {
+      mockGetConfig.mockResolvedValue(makeEnabledConfig());
+      mockListEventsForRange.mockResolvedValue([makeCalendarEvent()]);
+
+      await service.sendDigest(makeApplication('microsoft-outlook') as any, 'access-token');
+
+      expect(mockSendStandaloneEmailOutlook).toHaveBeenCalled();
+      expect(mockMarkSent).toHaveBeenCalled();
+    });
+
+    it('does not send when providerEmail is empty', async () => {
+      mockGetConfig.mockResolvedValue(makeEnabledConfig());
+      mockListEventsForRange.mockResolvedValue([makeCalendarEvent()]);
+
+      await service.sendDigest(makeApplication('google-gmail', { providerEmail: '' }) as any, 'access-token');
+
+      expect(mockSendStandaloneEmailGmail).not.toHaveBeenCalled();
+    });
+
+    it('does not send when providerEmail is null', async () => {
+      mockGetConfig.mockResolvedValue(makeEnabledConfig());
+      mockListEventsForRange.mockResolvedValue([makeCalendarEvent()]);
+
+      await service.sendDigest(makeApplication('google-gmail', { providerEmail: null }) as any, 'access-token');
+
+      expect(mockSendStandaloneEmailGmail).not.toHaveBeenCalled();
+    });
+
+    it('skips email for unsupported provider type', async () => {
+      mockGetConfig.mockResolvedValue(makeEnabledConfig());
+      mockListEventsForRange.mockResolvedValue([makeCalendarEvent()]);
+
+      await service.sendDigest(makeApplication('fastmail-jmap', { providerEmail: 'user@fastmail.com' }) as any, 'access-token');
+
+      expect(mockSendStandaloneEmailGmail).not.toHaveBeenCalled();
+      expect(mockSendStandaloneEmailOutlook).not.toHaveBeenCalled();
+      expect(mockMarkSent).toHaveBeenCalled();
+    });
+
+    it('filters bills by due date within 7 days', async () => {
+      mockGetConfig.mockResolvedValue(makeEnabledConfig());
+      const now = Math.floor(Date.now() / 1000);
+      const soonDueDate = new Date((now + 3 * 86400) * 1000).toISOString().split('T')[0];
+      const lateDueDate = new Date((now + 30 * 86400) * 1000).toISOString().split('T')[0];
+
+      const soonBill = {
+        actionId: 'bill-1',
+        title: 'Soon Bill',
+        description: '',
+        payload: { payee: 'Early Electric', dueDate: soonDueDate },
+        syncStatus: null,
+      };
+      const lateBill = {
+        actionId: 'bill-2',
+        title: 'Late Bill',
+        description: '',
+        payload: { payee: 'Late Telecom', dueDate: lateDueDate },
+        syncStatus: null,
+      };
+
+      mockListPendingActionsByTypes.mockImplementation((appId: string, types: string[]) => {
+        if (types.includes('finance.pay_bill')) return Promise.resolve([soonBill, lateBill]);
+        return Promise.resolve([]);
+      });
+      mockListEventsForRange.mockResolvedValue([]);
+
+      await service.sendDigest(makeApplication() as any, 'access-token');
+
+      // Even though there's a bill, it's filtered — only early one remains. But sendDigest only sends if there's content.
+      // Since calendar events are empty and tasks/packages/flights/appointments are empty, only the soon bill triggers content.
+      expect(mockMarkSent).toHaveBeenCalled();
+    });
+  });
+
+  describe('sendDigestForced', () => {
+    it('sends even when enabled is false (forced)', async () => {
+      mockGetConfig.mockResolvedValue({ enabled: false, sendTime: '08:00', sections: DIGEST_ALL_SECTIONS, lastSentAt: null });
+      mockListEventsForRange.mockResolvedValue([makeCalendarEvent()]);
+
+      await service.sendDigestForced(makeApplication('google-gmail') as any, 'access-token');
+
+      expect(mockSendStandaloneEmailGmail).toHaveBeenCalled();
+    });
+
+    it('marks sent even for disabled digest', async () => {
+      mockGetConfig.mockResolvedValue({ enabled: false, sendTime: '08:00', sections: DIGEST_ALL_SECTIONS, lastSentAt: null });
+      mockListEventsForRange.mockResolvedValue([makeCalendarEvent()]);
+
+      await service.sendDigestForced(makeApplication('google-gmail') as any, 'access-token');
+
+      expect(mockMarkSent).toHaveBeenCalled();
+    });
+  });
+});

--- a/test/services/IntegrationService.test.ts
+++ b/test/services/IntegrationService.test.ts
@@ -1,0 +1,255 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const {
+  mockListEnabled,
+  mockGetDecryptedWebhookUrl,
+  mockLogCreate,
+  mockCountByApplicationId,
+} = vi.hoisted(() => ({
+  mockListEnabled: vi.fn(),
+  mockGetDecryptedWebhookUrl: vi.fn(),
+  mockLogCreate: vi.fn(),
+  mockCountByApplicationId: vi.fn().mockResolvedValue(0),
+}));
+
+vi.mock('@mail-otter/backend-data/dao', () => ({
+  ApplicationIntegrationDAO: vi.fn(function () {
+    return {
+      listEnabled: mockListEnabled,
+      getDecryptedWebhookUrl: mockGetDecryptedWebhookUrl,
+      countByApplicationId: mockCountByApplicationId,
+    };
+  }),
+  IntegrationDeliveryLogDAO: vi.fn(function () {
+    return { create: mockLogCreate };
+  }),
+}));
+
+import { IntegrationService } from '@mail-otter/backend-services/integration';
+
+function makeEnv() {
+  return {
+    DB: {} as D1Database,
+    AES_ENCRYPTION_KEY_SECRET: { get: vi.fn().mockResolvedValue('master-key') } as unknown as SecretsStoreSecret,
+  };
+}
+
+function makeSummaryData(overrides?: Record<string, unknown>) {
+  return {
+    application: { applicationId: 'app-1' },
+    emailSubject: 'Order Confirmed',
+    emailFrom: 'shop@example.com',
+    rawSummary: {
+      gist: 'Your order has been confirmed.',
+      keyDetails: ['Order #12345', 'Ships in 3-5 days'],
+    },
+    actions: [
+      {
+        action: {
+          actionType: 'delivery.track_package',
+          title: 'Track Package',
+          description: 'Track your shipment.',
+          riskLevel: 'low',
+        },
+        confirmationUrl: 'https://app.example.com/actions/abc123',
+      },
+    ],
+    ...overrides,
+  };
+}
+
+function makeIntegration(type: 'slack' | 'discord' | 'webhook', overrides?: Record<string, unknown>) {
+  return {
+    integrationId: `integ-${type}`,
+    applicationId: 'app-1',
+    integrationType: type,
+    name: `${type} Integration`,
+    maskedWebhookUrl: 'https://hooks.example.com/...',
+    enabled: true,
+    createdAt: 1_778_200_000,
+    updatedAt: 1_778_200_000,
+    lastDeliveryAt: null,
+    lastDeliveryStatus: null,
+    consecutiveFailures: 0,
+    ...overrides,
+  };
+}
+
+describe('IntegrationService', () => {
+  let service: IntegrationService;
+  let env: ReturnType<typeof makeEnv>;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    env = makeEnv();
+    service = new IntegrationService(env);
+    mockGetDecryptedWebhookUrl.mockResolvedValue('https://hooks.example.com/webhook/secret');
+    mockLogCreate.mockResolvedValue({});
+  });
+
+  describe('sendToIntegrations', () => {
+    it('returns early when no integrations are enabled', async () => {
+      mockListEnabled.mockResolvedValue([]);
+      const summaryData = makeSummaryData();
+
+      await service.sendToIntegrations(summaryData as any);
+
+      expect(mockGetDecryptedWebhookUrl).not.toHaveBeenCalled();
+      expect(mockLogCreate).not.toHaveBeenCalled();
+    });
+
+    it('dispatches to webhook integration successfully', async () => {
+      mockListEnabled.mockResolvedValue([makeIntegration('webhook')]);
+      const fetchMock = vi.fn().mockResolvedValue({ ok: true, status: 200 });
+      global.fetch = fetchMock;
+
+      await service.sendToIntegrations(makeSummaryData() as any);
+
+      expect(fetchMock).toHaveBeenCalledOnce();
+      expect(mockLogCreate).toHaveBeenCalledWith(
+        expect.objectContaining({ status: 'success', httpStatus: 200 }),
+      );
+    });
+
+    it('dispatches to slack integration successfully', async () => {
+      mockListEnabled.mockResolvedValue([makeIntegration('slack')]);
+      const fetchMock = vi.fn().mockResolvedValue({ ok: true, status: 200 });
+      global.fetch = fetchMock;
+
+      await service.sendToIntegrations(makeSummaryData() as any);
+
+      const [url, options] = fetchMock.mock.calls[0];
+      expect(url).toBe('https://hooks.example.com/webhook/secret');
+      const body = JSON.parse(options.body as string);
+      expect(body).toHaveProperty('blocks');
+      expect(mockLogCreate).toHaveBeenCalledWith(expect.objectContaining({ status: 'success' }));
+    });
+
+    it('dispatches to discord integration successfully', async () => {
+      mockListEnabled.mockResolvedValue([makeIntegration('discord')]);
+      const fetchMock = vi.fn().mockResolvedValue({ ok: true, status: 204 });
+      global.fetch = fetchMock;
+
+      await service.sendToIntegrations(makeSummaryData() as any);
+
+      const [, options] = fetchMock.mock.calls[0];
+      const body = JSON.parse(options.body as string);
+      expect(body).toHaveProperty('embeds');
+    });
+
+    it('records failure when HTTP returns non-OK', async () => {
+      mockListEnabled.mockResolvedValue([makeIntegration('webhook')]);
+      global.fetch = vi.fn().mockResolvedValue({ ok: false, status: 503 });
+
+      await service.sendToIntegrations(makeSummaryData() as any);
+
+      expect(mockLogCreate).toHaveBeenCalledWith(
+        expect.objectContaining({ status: 'failure', httpStatus: 503 }),
+      );
+    });
+
+    it('records failure when fetch throws network error', async () => {
+      mockListEnabled.mockResolvedValue([makeIntegration('webhook')]);
+      global.fetch = vi.fn().mockRejectedValue(new Error('Network unreachable'));
+
+      await service.sendToIntegrations(makeSummaryData() as any);
+
+      expect(mockLogCreate).toHaveBeenCalledWith(
+        expect.objectContaining({ status: 'failure', errorMessage: expect.stringContaining('Network unreachable') }),
+      );
+    });
+
+    it('records failure when getDecryptedWebhookUrl throws', async () => {
+      mockListEnabled.mockResolvedValue([makeIntegration('webhook')]);
+      mockGetDecryptedWebhookUrl.mockRejectedValue(new Error('Key not found'));
+
+      await service.sendToIntegrations(makeSummaryData() as any);
+
+      expect(mockLogCreate).toHaveBeenCalledWith(
+        expect.objectContaining({ status: 'failure', errorMessage: expect.stringContaining('Key not found') }),
+      );
+    });
+
+    it('continues processing other integrations when one fails', async () => {
+      mockListEnabled.mockResolvedValue([makeIntegration('slack'), makeIntegration('webhook')]);
+      global.fetch = vi.fn()
+        .mockRejectedValueOnce(new Error('Slack down'))
+        .mockResolvedValueOnce({ ok: true, status: 200 });
+
+      await service.sendToIntegrations(makeSummaryData() as any);
+
+      expect(mockLogCreate).toHaveBeenCalledTimes(2);
+    });
+
+    it('does not throw when log DAO creation fails', async () => {
+      mockListEnabled.mockResolvedValue([makeIntegration('webhook')]);
+      global.fetch = vi.fn().mockResolvedValue({ ok: true, status: 200 });
+      mockLogCreate.mockRejectedValue(new Error('DB error'));
+
+      await expect(service.sendToIntegrations(makeSummaryData() as any)).resolves.toBeUndefined();
+    });
+
+    it('builds slack payload with key details and actions', async () => {
+      mockListEnabled.mockResolvedValue([makeIntegration('slack')]);
+      const fetchMock = vi.fn().mockResolvedValue({ ok: true, status: 200 });
+      global.fetch = fetchMock;
+
+      await service.sendToIntegrations(makeSummaryData() as any);
+
+      const body = JSON.parse(fetchMock.mock.calls[0][1].body as string);
+      const blockTypes = (body.blocks as Array<{ type: string }>).map((b) => b.type);
+      expect(blockTypes).toContain('header');
+      expect(blockTypes).toContain('section');
+      expect(blockTypes).toContain('context');
+    });
+
+    it('builds webhook payload with structured data', async () => {
+      mockListEnabled.mockResolvedValue([makeIntegration('webhook')]);
+      const fetchMock = vi.fn().mockResolvedValue({ ok: true, status: 200 });
+      global.fetch = fetchMock;
+
+      await service.sendToIntegrations(makeSummaryData() as any);
+
+      const body = JSON.parse(fetchMock.mock.calls[0][1].body as string);
+      expect(body.event).toBe('email.processed');
+      expect(body.email.subject).toBe('Order Confirmed');
+      expect(body.summary.gist).toBe('Your order has been confirmed.');
+      expect(body.actions).toHaveLength(1);
+    });
+
+    it('truncates emailSubject to 255 chars when creating log', async () => {
+      mockListEnabled.mockResolvedValue([makeIntegration('webhook')]);
+      global.fetch = vi.fn().mockResolvedValue({ ok: true, status: 200 });
+      const longSubject = 'A'.repeat(300);
+
+      await service.sendToIntegrations(makeSummaryData({ emailSubject: longSubject }) as any);
+
+      expect(mockLogCreate).toHaveBeenCalledWith(
+        expect.objectContaining({ emailSubject: 'A'.repeat(255) }),
+      );
+    });
+  });
+
+  describe('sendTestNotification', () => {
+    it('dispatches test notification successfully', async () => {
+      global.fetch = vi.fn().mockResolvedValue({ ok: true, status: 200 });
+      const integration = makeIntegration('webhook');
+
+      await service.sendTestNotification(integration as any);
+
+      expect(global.fetch).toHaveBeenCalled();
+    });
+
+    it('throws when integration returns non-OK response', async () => {
+      global.fetch = vi.fn().mockResolvedValue({ ok: false, status: 401 });
+
+      await expect(service.sendTestNotification(makeIntegration('webhook') as any)).rejects.toThrow('HTTP 401');
+    });
+
+    it('throws when fetch throws', async () => {
+      global.fetch = vi.fn().mockRejectedValue(new Error('Connection refused'));
+
+      await expect(service.sendTestNotification(makeIntegration('slack') as any)).rejects.toThrow('Connection refused');
+    });
+  });
+});

--- a/test/services/ProcessingService.test.ts
+++ b/test/services/ProcessingService.test.ts
@@ -1,0 +1,220 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const {
+  mockListTaskRunsForUser,
+  mockListCalendarEventsForUser,
+  mockListProcessedMessagesForUser,
+  mockGetByIdForUser,
+  mockGetAccessToken,
+  mockSyncForApplication,
+  mockSyncPackageActions,
+  mockSyncFlightActions,
+} = vi.hoisted(() => ({
+  mockListTaskRunsForUser: vi.fn().mockResolvedValue({ runs: [], nextCursor: undefined }),
+  mockListCalendarEventsForUser: vi.fn().mockResolvedValue({ events: [], nextCursor: undefined }),
+  mockListProcessedMessagesForUser: vi.fn().mockResolvedValue({ messages: [], nextCursor: undefined }),
+  mockGetByIdForUser: vi.fn(),
+  mockGetAccessToken: vi.fn().mockResolvedValue('access-token'),
+  mockSyncForApplication: vi.fn().mockResolvedValue(undefined),
+  mockSyncPackageActions: vi.fn().mockResolvedValue(undefined),
+  mockSyncFlightActions: vi.fn().mockResolvedValue(undefined),
+}));
+
+vi.mock('@mail-otter/backend-data/dao', () => ({
+  BackgroundTaskRunDAO: vi.fn(function () {
+    return { listForUser: mockListTaskRunsForUser };
+  }),
+  SyncedCalendarEventDAO: vi.fn(function () {
+    return { listForUser: mockListCalendarEventsForUser };
+  }),
+  ProcessedMessageDAO: vi.fn(function () {
+    return { listForUser: mockListProcessedMessagesForUser };
+  }),
+  ConnectedApplicationDAO: vi.fn(function () {
+    return { getByIdForUser: mockGetByIdForUser };
+  }),
+}));
+
+vi.mock('@mail-otter/backend-services/oauth2', () => ({
+  OAuth2AccessTokenService: vi.fn(function () {
+    return { getAccessToken: mockGetAccessToken };
+  }),
+}));
+
+vi.mock('../../packages/backend-services/src/digest', () => ({
+  CalendarEventSyncUtil: vi.fn(function () {
+    return { syncForApplication: mockSyncForApplication };
+  }),
+  ActionStatusSyncUtil: vi.fn(function () {
+    return {
+      syncPackageActions: mockSyncPackageActions,
+      syncFlightActions: mockSyncFlightActions,
+    };
+  }),
+}));
+
+vi.mock('@mail-otter/backend-runtime/config', () => ({
+  ConfigurationManager: {
+    digest: {
+      getPackageTrackingApiKey: vi.fn(() => 'pkg-api-key'),
+      getFlightTrackingApiKey: vi.fn(() => 'flt-api-key'),
+    },
+  },
+}));
+
+import { ProcessingService } from '@mail-otter/backend-services/processing';
+import { BadRequestError } from '@mail-otter/backend-errors';
+
+function makeEnv() {
+  return {
+    DB: {} as D1Database,
+    AES_ENCRYPTION_KEY_SECRET: { get: vi.fn().mockResolvedValue('master-key') } as unknown as SecretsStoreSecret,
+    ACTION_ENCRYPTION_KEY_SECRET: { get: vi.fn().mockResolvedValue('action-key') } as unknown as SecretsStoreSecret,
+    OAUTH2_TOKEN_CACHE: {} as KVNamespace,
+    OAUTH2_TOKEN_REFRESHERS: {} as DurableObjectNamespace,
+  };
+}
+
+function makeApplication(overrides?: Record<string, unknown>) {
+  return {
+    applicationId: 'app-1',
+    userEmail: 'user@example.com',
+    providerId: 'google-gmail',
+    providerEmail: 'user@gmail.com',
+    timeZone: 'UTC',
+    ...overrides,
+  };
+}
+
+describe('ProcessingService', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  describe('listTaskRuns', () => {
+    it('delegates to BackgroundTaskRunDAO.listForUser', async () => {
+      const result = await ProcessingService.listTaskRuns(
+        'user@example.com',
+        { taskType: 'calendar_sync', applicationId: 'app-1', status: undefined, cursor: undefined, latestPerType: undefined },
+        { DB: {} as D1Database },
+      );
+
+      expect(mockListTaskRunsForUser).toHaveBeenCalledWith('user@example.com', expect.objectContaining({
+        taskType: 'calendar_sync',
+        applicationId: 'app-1',
+      }));
+      expect(result.runs).toHaveLength(0);
+    });
+
+    it('sets latestPerType: true when no taskType provided', async () => {
+      await ProcessingService.listTaskRuns(
+        'user@example.com',
+        { taskType: undefined, applicationId: undefined, status: undefined, cursor: undefined, latestPerType: undefined },
+        { DB: {} as D1Database },
+      );
+
+      expect(mockListTaskRunsForUser).toHaveBeenCalledWith('user@example.com', expect.objectContaining({
+        latestPerType: true,
+      }));
+    });
+
+    it('sets latestPerType: false when taskType is specified', async () => {
+      await ProcessingService.listTaskRuns(
+        'user@example.com',
+        { taskType: 'calendar_sync', applicationId: undefined, status: undefined, cursor: undefined, latestPerType: undefined },
+        { DB: {} as D1Database },
+      );
+
+      expect(mockListTaskRunsForUser).toHaveBeenCalledWith('user@example.com', expect.objectContaining({
+        latestPerType: false,
+      }));
+    });
+  });
+
+  describe('listCalendarEvents', () => {
+    it('delegates to SyncedCalendarEventDAO.listForUser', async () => {
+      const result = await ProcessingService.listCalendarEvents(
+        'user@example.com',
+        { applicationId: 'app-1', cursor: undefined },
+        { DB: {} as D1Database },
+      );
+
+      expect(mockListCalendarEventsForUser).toHaveBeenCalledWith('user@example.com', {
+        applicationId: 'app-1',
+        cursor: undefined,
+      });
+      expect(result.events).toHaveLength(0);
+    });
+  });
+
+  describe('listProcessedMessages', () => {
+    it('delegates to ProcessedMessageDAO.listForUser', async () => {
+      const result = await ProcessingService.listProcessedMessages(
+        'user@example.com',
+        { applicationId: 'app-1', status: 'processed', cursor: undefined },
+        { DB: {} as D1Database },
+      );
+
+      expect(mockListProcessedMessagesForUser).toHaveBeenCalledWith('user@example.com', {
+        applicationId: 'app-1',
+        status: 'processed',
+        cursor: undefined,
+      });
+      expect(result.messages).toHaveLength(0);
+    });
+  });
+
+  describe('triggerTask', () => {
+    it('throws BadRequestError for unsupported task type', async () => {
+      await expect(
+        ProcessingService.triggerTask('user@example.com', 'invalid_task', 'app-1', makeEnv() as any),
+      ).rejects.toThrow(BadRequestError);
+    });
+
+    it('throws BadRequestError when application not found', async () => {
+      mockGetByIdForUser.mockResolvedValue(null);
+
+      await expect(
+        ProcessingService.triggerTask('user@example.com', 'calendar_sync', 'app-1', makeEnv() as any),
+      ).rejects.toThrow(BadRequestError);
+    });
+
+    it('triggers calendar_sync task successfully', async () => {
+      mockGetByIdForUser.mockResolvedValue(makeApplication());
+
+      await ProcessingService.triggerTask('user@example.com', 'calendar_sync', 'app-1', makeEnv() as any);
+
+      expect(mockGetAccessToken).toHaveBeenCalled();
+      expect(mockSyncForApplication).toHaveBeenCalled();
+    });
+
+    it('triggers action_status_sync with package and flight APIs', async () => {
+      mockGetByIdForUser.mockResolvedValue(makeApplication());
+
+      await ProcessingService.triggerTask('user@example.com', 'action_status_sync', 'app-1', makeEnv() as any);
+
+      expect(mockSyncPackageActions).toHaveBeenCalledWith('app-1', 'pkg-api-key');
+      expect(mockSyncFlightActions).toHaveBeenCalledWith('app-1', 'flt-api-key');
+    });
+
+    it('skips package sync when no API key configured', async () => {
+      const { ConfigurationManager } = await import('@mail-otter/backend-runtime/config');
+      vi.mocked(ConfigurationManager.digest.getPackageTrackingApiKey).mockReturnValueOnce('');
+      mockGetByIdForUser.mockResolvedValue(makeApplication());
+
+      await ProcessingService.triggerTask('user@example.com', 'action_status_sync', 'app-1', makeEnv() as any);
+
+      expect(mockSyncPackageActions).not.toHaveBeenCalled();
+    });
+
+    it('skips flight sync when no API key configured', async () => {
+      const { ConfigurationManager } = await import('@mail-otter/backend-runtime/config');
+      vi.mocked(ConfigurationManager.digest.getFlightTrackingApiKey).mockReturnValueOnce('');
+      mockGetByIdForUser.mockResolvedValue(makeApplication());
+
+      await ProcessingService.triggerTask('user@example.com', 'action_status_sync', 'app-1', makeEnv() as any);
+
+      expect(mockSyncFlightActions).not.toHaveBeenCalled();
+    });
+  });
+});


### PR DESCRIPTION
Add 10 new test files covering previously zero-or-near-zero coverage areas:

- **DAOs**: ApplicationIntegrationDAO (create/list/update/delete/count/masking), BackgroundTaskRunDAO (startRun/succeedRun/failRun/skipRun/listForUser with cursor+filters+latestPerType/pruneOldRuns), SyncedCalendarEventDAO (upsertEvents/listEventsForRange/listForUser/pruneOldEvents)

- **Services**: IntegrationService (sendToIntegrations for slack/discord/webhook, failure handling, log DAO resilience, sendTestNotification), ProcessingService (listTaskRuns/listCalendarEvents/listProcessedMessages/triggerTask), DigestConfigService (getConfig defaults, saveConfig normalization, markSent, isDueToSend), DigestEmailUtil (buildSubject, hasContent per section, buildHtml all six sections), DigestService (sendDigest enabled/disabled/no-content/gmail/outlook, sendDigestForced), CalendarEventSyncUtil (gmail/outlook/unsupported provider, edge cases), ActionStatusSyncUtil (package sync with Aftership, flight sync, error resilience)

Overall coverage: 57.6%→65.0% statements, 46.2%→54.5% branches, 65.4%→72.9% functions, 59.0%→66.5% lines. All 900 tests pass.