### PR TITLE
Shrink Dismiss Button In Metric Component

### DIFF
--- a/apps/web/src/components/shared/Metric.tsx
+++ b/apps/web/src/components/shared/Metric.tsx
@@ -25,9 +25,9 @@ export function Metric({
         <button
           onClick={onDismiss}
           title="Dismiss Error"
-          className="absolute top-2 right-2 text-[var(--color-text-muted)] hover:text-[var(--color-text-primary)] leading-none text-sm flex items-center gap-1 whitespace-nowrap"
+          className="absolute top-1 right-1 text-[var(--color-text-muted)] hover:text-[var(--color-text-primary)] leading-none text-xs flex items-center gap-0.5 whitespace-nowrap"
         >
-          Dismiss <X className="h-3.5 w-3.5" />
+          Dismiss <X className="h-2.5 w-2.5" />
         </button>
       )}
     </div>


### PR DESCRIPTION
Reduce the dismiss button size in the Metric component by using smaller font (text-xs), tighter gap (gap-0.5), compact positioning (top-1 right-1), and smaller X icon (h-2.5 w-2.5).