### PR TITLE
Increase Auto-Merge Retry Attempts

### DIFF
--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -139,7 +139,7 @@ jobs:
         uses: ./.github/actions/retry-step
         with:
           command: gh pr merge --auto --merge "$PR_URL"
-          max_attempts: '2'
+          max_attempts: '5'
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           PR_URL: ${{ github.event.pull_request.html_url }}


### PR DESCRIPTION
Bump max_attempts from 2 to 5 for the Enable Auto-Merge step in dependabot-auto-merge job to improve reliability against transient GitHub API failures.