### PR TITLE
Replace Bare DELETE LIMIT With IN-Subselect In Prune Queries

### DIFF
--- a/packages/backend-data/src/dao/ApplicationContextDAO.ts
+++ b/packages/backend-data/src/dao/ApplicationContextDAO.ts
@@ -454,8 +454,11 @@ class ApplicationContextDAO extends BaseDAO {
           .prepare(
             `
               DELETE FROM application_context_documents
-              WHERE status = ? AND deleted_at IS NOT NULL AND deleted_at < ?
-              LIMIT ?
+              WHERE context_document_id IN (
+                SELECT context_document_id FROM application_context_documents
+                WHERE status = ? AND deleted_at IS NOT NULL AND deleted_at < ?
+                LIMIT ?
+              )
             `,
           )
           .bind(APPLICATION_CONTEXT_DOCUMENT_STATUS_DELETED, deletedBefore, limit)
@@ -472,8 +475,11 @@ class ApplicationContextDAO extends BaseDAO {
           .prepare(
             `
               DELETE FROM application_context_documents
-              WHERE status = ? AND updated_at < ?
-              LIMIT ?
+              WHERE context_document_id IN (
+                SELECT context_document_id FROM application_context_documents
+                WHERE status = ? AND updated_at < ?
+                LIMIT ?
+              )
             `,
           )
           .bind(APPLICATION_CONTEXT_DOCUMENT_STATUS_ERROR, errorBefore, limit)

--- a/packages/backend-data/src/dao/ContextAuditLogDAO.ts
+++ b/packages/backend-data/src/dao/ContextAuditLogDAO.ts
@@ -110,8 +110,11 @@ class ContextAuditLogDAO extends BaseDAO {
           .prepare(
             `
               DELETE FROM context_audit_logs
-              WHERE created_at < ?
-              LIMIT ?
+              WHERE id IN (
+                SELECT id FROM context_audit_logs
+                WHERE created_at < ?
+                LIMIT ?
+              )
             `,
           )
           .bind(olderThan, limit)

--- a/packages/backend-data/src/dao/ContextDeletionRunDAO.ts
+++ b/packages/backend-data/src/dao/ContextDeletionRunDAO.ts
@@ -88,8 +88,11 @@ class ContextDeletionRunDAO extends BaseDAO {
           .prepare(
             `
               DELETE FROM application_context_deletion_runs
-              WHERE created_at < ?
-              LIMIT ?
+              WHERE deletion_run_id IN (
+                SELECT deletion_run_id FROM application_context_deletion_runs
+                WHERE created_at < ?
+                LIMIT ?
+              )
             `,
           )
           .bind(olderThan, limit)

--- a/packages/backend-data/src/dao/EmailActionDAO.ts
+++ b/packages/backend-data/src/dao/EmailActionDAO.ts
@@ -413,8 +413,11 @@ class EmailActionDAO extends EncryptedDAO {
           .prepare(
             `
               DELETE FROM email_summary_actions
-              WHERE updated_at < ? AND status IN (?, ?, ?, ?)
-              LIMIT ?
+              WHERE action_id IN (
+                SELECT action_id FROM email_summary_actions
+                WHERE updated_at < ? AND status IN (?, ?, ?, ?)
+                LIMIT ?
+              )
             `,
           )
           .bind(

--- a/packages/backend-data/src/dao/OAuth2AuthorizationSessionDAO.ts
+++ b/packages/backend-data/src/dao/OAuth2AuthorizationSessionDAO.ts
@@ -54,8 +54,11 @@ class OAuth2AuthorizationSessionDAO extends BaseDAO {
           .prepare(
             `
               DELETE FROM oauth2_authorization_sessions
-              WHERE expires_at < ? OR consumed_at IS NOT NULL
-              LIMIT ?
+              WHERE session_id IN (
+                SELECT session_id FROM oauth2_authorization_sessions
+                WHERE expires_at < ? OR consumed_at IS NOT NULL
+                LIMIT ?
+              )
             `,
           )
           .bind(now, limit)

--- a/packages/backend-data/src/dao/ProcessedMessageDAO.ts
+++ b/packages/backend-data/src/dao/ProcessedMessageDAO.ts
@@ -88,8 +88,11 @@ class ProcessedMessageDAO extends BaseDAO {
           .prepare(
             `
               DELETE FROM processed_messages
-              WHERE updated_at < ? AND status IN (${placeholders})
-              LIMIT ?
+              WHERE processed_message_id IN (
+                SELECT processed_message_id FROM processed_messages
+                WHERE updated_at < ? AND status IN (${placeholders})
+                LIMIT ?
+              )
             `,
           )
           .bind(olderThan, ...statuses, limit)

--- a/test/dao/ApplicationContextDAO.test.ts
+++ b/test/dao/ApplicationContextDAO.test.ts
@@ -306,6 +306,22 @@ describe('ApplicationContextDAO', () => {
       const result = await dao.deleteStaleErrorDocuments(1_778_000_000, 100);
       expect(result).toBe(2);
     });
+
+    it('scopes LIMIT inside a subselect (D1 rejects bare DELETE ... LIMIT)', async () => {
+      const db = makeDb({ run: vi.fn().mockResolvedValue({ success: true, meta: { changes: 1 } } as D1Result) });
+      dao = new ApplicationContextDAO(db);
+
+      await dao.deleteStaleDeletedDocuments(1_778_000_000, 100);
+      await dao.deleteStaleErrorDocuments(1_778_000_000, 100);
+
+      const prepareFn = db.prepare as ReturnType<typeof vi.fn>;
+      expect(prepareFn).toHaveBeenCalledTimes(2);
+      for (const call of prepareFn.mock.calls) {
+        const sql = (call as unknown[])[0] as string;
+        expect(sql).toMatch(/IN\s*\(\s*SELECT/);
+        expect(sql.slice(0, sql.indexOf('('))).not.toMatch(/LIMIT/i);
+      }
+    });
   });
 
   describe('insertAuditLog / insertAuditLogs', () => {

--- a/test/dao/ContextSplitDAOs.test.ts
+++ b/test/dao/ContextSplitDAOs.test.ts
@@ -52,6 +52,19 @@ describe('Context split DAOs', () => {
     await expect(dao.deleteOldDeletionRuns(100, 500)).resolves.toBe(2);
   });
 
+  it('prune deletes scope LIMIT inside a subselect (D1 rejects bare DELETE ... LIMIT)', async () => {
+    const auditDb = makeDb({ run: vi.fn().mockResolvedValue({ success: true, meta: { changes: 1 } }) });
+    await new ContextAuditLogDAO(auditDb).deleteOldAuditLogs(100, 500);
+    const deletionDb = makeDb({ run: vi.fn().mockResolvedValue({ success: true, meta: { changes: 1 } }) });
+    await new ContextDeletionRunDAO(deletionDb).deleteOldDeletionRuns(100, 500);
+    for (const db of [auditDb, deletionDb]) {
+      const prepareFn = db.prepare as unknown as ReturnType<typeof vi.fn>;
+      const sql = (prepareFn.mock.calls[0] as unknown[])[0] as string;
+      expect(sql).toMatch(/IN\s*\(\s*SELECT/);
+      expect(sql.slice(0, sql.indexOf('('))).not.toMatch(/LIMIT/i);
+    }
+  });
+
   it('ApplicationContextDAO delegates audit/deletion-run calls (facade)', async () => {
     const run = vi.fn().mockResolvedValue({ success: true, meta: { changes: 4 } });
     const dao = new ApplicationContextDAO(makeDb({ run }));

--- a/test/dao/EmailActionDAO.test.ts
+++ b/test/dao/EmailActionDAO.test.ts
@@ -264,6 +264,17 @@ describe('EmailActionDAO', () => {
       const result = await dao.deleteOlderThan(mockNow - 86_400 * 30, 100);
       expect(result).toBe(3);
     });
+
+    it('scopes LIMIT inside a subselect (D1 rejects bare DELETE ... LIMIT)', async () => {
+      const db = makeDb({ run: vi.fn().mockResolvedValue({ success: true, meta: { changes: 1 } } as D1Result) });
+      dao = new EmailActionDAO(db, 'key');
+
+      await dao.deleteOlderThan(mockNow - 86_400 * 30, 100);
+
+      const sql = ((db.prepare as ReturnType<typeof vi.fn>).mock.calls[0] as unknown[])[0] as string;
+      expect(sql).toMatch(/IN\s*\(\s*SELECT/);
+      expect(sql.slice(0, sql.indexOf('('))).not.toMatch(/LIMIT/i);
+    });
   });
 
   describe('recordExecution', () => {

--- a/test/dao/OAuth2SessionDAO.test.ts
+++ b/test/dao/OAuth2SessionDAO.test.ts
@@ -93,6 +93,19 @@ describe('OAuth2AuthorizationSessionDAO', () => {
 
       expect(count).toBe(0);
     });
+
+    it('scopes LIMIT inside a subselect (D1 rejects bare DELETE ... LIMIT)', async () => {
+      mockRun.mockResolvedValue({ success: true, meta: { changes: 1 } });
+      const db = createMockDb();
+      const localDao = new OAuth2AuthorizationSessionDAO(db);
+
+      await localDao.deleteExpiredSessions(100);
+
+      const prepareFn = db.prepare;
+      const sql = (prepareFn.mock.calls[0] as unknown[])[0] as string;
+      expect(sql).toMatch(/IN\s*\(\s*SELECT/);
+      expect(sql.slice(0, sql.indexOf('('))).not.toMatch(/LIMIT/i);
+    });
   });
 
   describe('consume', () => {

--- a/test/dao/ProcessedMessageDAO.test.ts
+++ b/test/dao/ProcessedMessageDAO.test.ts
@@ -242,6 +242,17 @@ describe('ProcessedMessageDAO (mock-based)', () => {
       expect(bindings[1]).toBe(PROCESSED_MESSAGE_STATUS_ERROR);
       expect(bindings[2]).toBe(50);
     });
+
+    it('scopes LIMIT inside a subselect (D1 rejects bare DELETE ... LIMIT)', async () => {
+      const { db } = makeDb();
+      const dao = new ProcessedMessageDAO(db);
+
+      await dao.deleteOlderThan(9999, [PROCESSED_MESSAGE_STATUS_ERROR], 50);
+
+      const sql = ((db.prepare as ReturnType<typeof vi.fn>).mock.calls[0] as unknown[])[0] as string;
+      expect(sql).toMatch(/IN\s*\(\s*SELECT/);
+      expect(sql.slice(0, sql.indexOf('('))).not.toMatch(/LIMIT/i);
+    });
   });
 
   describe('getLatestForApplication', () => {


### PR DESCRIPTION
D1 rejects bare DELETE ... LIMIT (SQLite requires
SQLITE_ENABLE_UPDATE_DELETE_LIMIT), which crashed
StaleContextDocumentPruningTask in deleteStaleDeletedDocuments. Rewrote all 7 prune deletes to DELETE WHERE pk IN
(SELECT pk ... LIMIT ?), matching the existing
BackgroundTaskRunDAO/SyncedCalendarEventDAO pattern. Added SQL-shape regression tests to 5 DAO suites.