### PR TITLE
Preserve Content Language And Context Fields In Validation

### DIFF
--- a/packages/shared/src/schema/input.ts
+++ b/packages/shared/src/schema/input.ts
@@ -21,7 +21,11 @@ interface RequestInputSchema {
   query?: z.ZodType;
 }
 
-const CreateAppBodySchema = ConnectedAppBaseSchema;
+const CreateAppBodySchema = ConnectedAppBaseSchema.extend({
+  enabledFeatures: z.array(z.string()).optional().nullable(),
+  timeZone: z.string().max(64).optional().nullable(),
+  contentLanguage: z.string().max(32).optional().nullable(),
+});
 
 const UpdateAppBodySchema = z
   .object({
@@ -40,6 +44,7 @@ const UpdateAppBodySchema = z
       .optional()
       .nullable(),
     timeZone: z.string().max(64).optional().nullable(),
+    contentLanguage: z.string().max(32).optional().nullable(),
     autoExecuteActionTypes: z.array(z.string()).optional().nullable(),
     imapHost: z.string().max(253).optional(),
     imapPort: z.number().int().min(1).max(65_535).optional(),
@@ -70,6 +75,7 @@ const UpdateAppContextBodySchema = z.object({
   contextIndexingEnabled: z.boolean().optional(),
   ragRetrievalEnabled: z.boolean().optional(),
   maxContextDocuments: z.number().int().positive().nullable().optional(),
+  attachmentVisionEnabled: z.boolean().optional(),
 });
 
 const DeleteAppContextDocumentsBodySchema = z.object({

--- a/test/schema/RequestValidation.test.ts
+++ b/test/schema/RequestValidation.test.ts
@@ -93,6 +93,33 @@ describe('Request input schemas', () => {
     expect((result as { success: true; data: Record<string, unknown> }).data.timeZone).toBe('America/New_York');
   });
 
+  it('passes contentLanguage through PUT /user/application schema', async () => {
+    const request = new Request('https://mail.example.com/user/application', { method: 'PUT' });
+    const result = await validateRequestInput(request, {
+      applicationId: '11111111-1111-4111-8111-111111111111',
+      displayName: 'Outlook inbox',
+      providerId: 'microsoft-outlook',
+      connectionMethod: 'oauth2',
+      contentLanguage: 'de',
+    });
+    expect(result).toMatchObject({ success: true });
+    expect((result as { success: true; data: Record<string, unknown> }).data.contentLanguage).toBe('de');
+  });
+
+  it('passes contentLanguage through POST /user/application schema', async () => {
+    const request = new Request('https://mail.example.com/user/application', { method: 'POST' });
+    const result = await validateRequestInput(request, {
+      displayName: 'Outlook inbox',
+      providerId: 'microsoft-outlook',
+      connectionMethod: 'oauth2',
+      clientId: 'client-id',
+      clientSecret: 'client-secret',
+      contentLanguage: 'ja',
+    });
+    expect(result).toMatchObject({ success: true });
+    expect((result as { success: true; data: Record<string, unknown> }).data.contentLanguage).toBe('ja');
+  });
+
   it('rejects unsupported providers', async () => {
     const request = new Request('https://mail.example.com/user/application', { method: 'POST' });
 
@@ -123,6 +150,13 @@ describe('Request input schemas', () => {
     it('accepts body with only maxContextDocuments', async () => {
       const request = new Request('https://mail.example.com/user/application/context', { method: 'PUT' });
       await expect(validateRequestInput(request, { applicationId, maxContextDocuments: 10 })).resolves.toMatchObject({ success: true });
+    });
+
+    it('passes attachmentVisionEnabled through PUT /user/application/context schema', async () => {
+      const request = new Request('https://mail.example.com/user/application/context', { method: 'PUT' });
+      const result = await validateRequestInput(request, { applicationId, attachmentVisionEnabled: false });
+      expect(result).toMatchObject({ success: true });
+      expect((result as { success: true; data: Record<string, unknown> }).data.attachmentVisionEnabled).toBe(false);
     });
   });
 


### PR DESCRIPTION
Zod request schemas stripped contentLanguage on PUT/POST /user/application and attachmentVisionEnabled on PUT /user/application/context, so the API returned 200 with the old value while the DAO silently skipped the undefined field. Extend the schemas to pass these fields through to the services.

- UpdateAppBodySchema now accepts optional nullable contentLanguage
- CreateAppBodySchema extends the base with enabledFeatures, timeZone, and contentLanguage
- UpdateAppContextBodySchema now accepts optional attachmentVisionEnabled
- Regression tests cover all three passthrough paths